### PR TITLE
Copilot/fix failing tests

### DIFF
--- a/app/Services/Krypton/OrderService.php
+++ b/app/Services/Krypton/OrderService.php
@@ -193,8 +193,8 @@ class OrderService
         $contextService = app(KryptonContextService::class);
         $defaults = $contextService->getData();
 
-        // session_id is MANDATORY from Krypton - no fallback to null or defaults allowed
-        // terminal_session_id, terminal_id, revenue_id have sensible fallbacks if missing from POS context
+        // Allow session_id to remain null so CreateOrder can throw SessionNotFoundException.
+        // Other POS context values may still use sensible fallbacks when unavailable.
         $normalized = [
             'price_level_id' => $defaults['price_level_id'] ?? null,
             'tax_set_id' => $defaults['tax_set_id'] ?? null,

--- a/app/Services/Krypton/OrderService.php
+++ b/app/Services/Krypton/OrderService.php
@@ -201,7 +201,7 @@ class OrderService
             'service_type_id' => $defaults['service_type_id'] ?? 1,
             'revenue_id' => $defaults['revenue_id'] ?? 1,
             'terminal_id' => $defaults['terminal_id'] ?? 1,
-            'session_id' => $defaults['session_id'] ?? null,  // REQUIRED - null triggers SessionNotFoundException in CreateOrder
+            'session_id' => $defaults['session_id'] ?? null,  // null propagates to CreateOrder which throws SessionNotFoundException
             'terminal_session_id' => $defaults['terminal_session_id'] ?? null,
             'employee_log_id' => $defaults['employee_log_id'] ?? null,
             'cash_tray_session_id' => $defaults['cash_tray_session_id'] ?? null,

--- a/app/Services/Krypton/OrderService.php
+++ b/app/Services/Krypton/OrderService.php
@@ -201,7 +201,7 @@ class OrderService
             'service_type_id' => $defaults['service_type_id'] ?? 1,
             'revenue_id' => $defaults['revenue_id'] ?? 1,
             'terminal_id' => $defaults['terminal_id'] ?? 1,
-            'session_id' => $defaults['session_id'],  // REQUIRED - no fallback, exception thrown by KryptonContextService if missing
+            'session_id' => $defaults['session_id'] ?? null,  // REQUIRED - null triggers SessionNotFoundException in CreateOrder
             'terminal_session_id' => $defaults['terminal_session_id'] ?? null,
             'employee_log_id' => $defaults['employee_log_id'] ?? null,
             'cash_tray_session_id' => $defaults['cash_tray_session_id'] ?? null,

--- a/tests/Feature/Api/DeviceApiTest.php
+++ b/tests/Feature/Api/DeviceApiTest.php
@@ -20,6 +20,17 @@ class DeviceApiTest extends TestCase
     private function actingAsAdmin(): void
     {
         $user = User::factory()->create();
+
+        // Create device management permissions if they don't exist, then grant
+        // them to the test user so DevicePolicy checks don't throw PermissionDoesNotExist.
+        $permissions = ['view devices', 'create devices', 'update devices', 'delete devices'];
+        foreach ($permissions as $permission) {
+            \Spatie\Permission\Models\Permission::firstOrCreate(
+                ['name' => $permission, 'guard_name' => 'web']
+            );
+        }
+        $user->givePermissionTo($permissions);
+
         Sanctum::actingAs($user, [], 'sanctum');
     }
 

--- a/tests/Feature/Api/DeviceApiTest.php
+++ b/tests/Feature/Api/DeviceApiTest.php
@@ -8,6 +8,7 @@ use App\Models\Branch;
 use App\Models\Device;
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\PermissionRegistrar;
 
 class DeviceApiTest extends TestCase
 {
@@ -29,6 +30,9 @@ class DeviceApiTest extends TestCase
                 ['name' => $permission, 'guard_name' => 'web']
             );
         }
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
         $user->givePermissionTo($permissions);
 
         Sanctum::actingAs($user, [], 'sanctum');

--- a/tests/Feature/Order/TransactionRollbackTest.php
+++ b/tests/Feature/Order/TransactionRollbackTest.php
@@ -30,7 +30,8 @@ class TransactionRollbackTest extends TestCase
         ]);
 
         // Seed an active POS session so KryptonContextService can resolve a
-        // valid session_id without throwing SessionNotFoundException.
+        // valid session_id and order creation does not later fail due to
+        // missing context.
         $this->createTestSession();
     }
 

--- a/tests/Feature/Order/TransactionRollbackTest.php
+++ b/tests/Feature/Order/TransactionRollbackTest.php
@@ -28,6 +28,10 @@ class TransactionRollbackTest extends TestCase
             'receipt_name' => 'Test Item',
             'price' => 100.00,
         ]);
+
+        // Seed an active POS session so KryptonContextService can resolve a
+        // valid session_id without throwing SessionNotFoundException.
+        $this->createTestSession();
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -121,6 +121,65 @@ abstract class TestCase extends BaseTestCase
                 });
             }
 
+            // Additional POS tables required by KryptonContextService::load()
+            // so that queries inside Cache::remember don't throw "no such table"
+            // and abort the entire context load.
+
+            if (! $schema->hasTable('terminals')) {
+                $schema->create('terminals', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->string('name')->nullable();
+                });
+                // Insert a default terminal row so Terminal::where('id', 1)->first()
+                // returns a model instead of null.
+                DB::connection('pos')->table('terminals')->insert(['id' => 1, 'name' => 'Test Terminal']);
+            }
+
+            if (! $schema->hasTable('terminal_sessions')) {
+                $schema->create('terminal_sessions', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('terminal_id')->nullable();
+                    $table->integer('session_id')->nullable();
+                    $table->dateTime('date_time_opened')->nullable();
+                    $table->dateTime('date_time_closed')->nullable();
+                });
+            }
+
+            if (! $schema->hasTable('employee_logs')) {
+                $schema->create('employee_logs', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('employee_id')->nullable();
+                    $table->integer('terminal_id')->nullable();
+                    $table->dateTime('date_time_in')->nullable();
+                    $table->dateTime('date_time_out')->nullable();
+                });
+            }
+
+            if (! $schema->hasTable('cash_tray_sessions')) {
+                $schema->create('cash_tray_sessions', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('session_id')->nullable();
+                });
+            }
+
+            if (! $schema->hasTable('terminal_services')) {
+                $schema->create('terminal_services', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->integer('terminal_id')->nullable();
+                    $table->integer('revenue_id')->nullable();
+                    $table->integer('service_type_id')->nullable();
+                });
+            }
+
+            if (! $schema->hasTable('revenues')) {
+                $schema->create('revenues', function (Blueprint $table) {
+                    $table->increments('id');
+                    $table->boolean('is_active')->default(false);
+                    $table->integer('price_level_id')->nullable();
+                    $table->integer('tax_set_id')->nullable();
+                });
+            }
+
             // Some Eloquent queries use `whereHas('table')` which generates
             // subqueries referencing the `tables` table on the default DB
             // connection. To avoid cross-connection missing-table errors in


### PR DESCRIPTION
This pull request focuses on improving test reliability and error handling around POS session and permission management, particularly for the Krypton context and device API tests. The changes ensure that required database tables and permissions exist, and that tests don't fail due to missing data or permissions.

**Test database setup improvements:**

* Added creation of several POS-related tables (`terminals`, `terminal_sessions`, `employee_logs`, `cash_tray_sessions`, `terminal_services`, `revenues`) in the test environment, including seeding a default terminal row, to prevent "no such table" errors when loading Krypton context in tests.
* In `TransactionRollbackTest`, now seeds an active POS session during test setup to ensure a valid `session_id` is available, preventing `SessionNotFoundException`.

**Test permission management:**

* In `DeviceApiTest`, ensures device management permissions are created and assigned to the test user before running tests, preventing `PermissionDoesNotExist` errors from policy checks.

**Error handling improvements:**

* In `OrderService`, changed the default for `session_id` to `null` if not provided, allowing downstream code to throw a more specific `SessionNotFoundException` rather than a generic error.