### PR TITLE
docs: add conflict-free Raspberry Pi deployment runbook

### DIFF
--- a/docs/deployment/access-and-integration-rules.md
+++ b/docs/deployment/access-and-integration-rules.md
@@ -1,0 +1,217 @@
+# Woosoo Deployment Access and Integration Rules
+
+This document defines the production access rules for the on-premise Raspberry Pi deployment.
+
+---
+
+## Canonical Hostname
+
+All client devices should use the local hostname:
+
+```txt
+woosoo.local
+```
+
+The Raspberry Pi resolves this name locally through `dnsmasq`:
+
+```txt
+woosoo.local → Raspberry Pi static LAN IP
+```
+
+Example:
+
+```txt
+woosoo.local → 192.168.100.10
+```
+
+Client devices should not be configured to use the raw Pi IP as the normal application URL.
+
+---
+
+## Client Access Map
+
+The current `compose.yaml` and `docker/nginx/default.conf` expose:
+
+```txt
+Admin panel:        https://woosoo.local
+Laravel API:        https://woosoo.local/api
+Reverb/WebSocket:   wss://woosoo.local/app
+Tablet ordering:    https://woosoo.local:4443
+Print bridge API:   https://woosoo.local
+```
+
+The long-term preferred tablet URL may become `https://woosoo.local/tablet`, but the current staging Docker/Nginx configuration serves the tablet PWA on port `4443`.
+
+---
+
+## Tablet Ordering PWA Rule
+
+Ordering tablets access the Nuxt tablet ordering PWA through:
+
+```txt
+https://woosoo.local:4443
+```
+
+The tablet PWA should call the backend API through:
+
+```txt
+https://woosoo.local/api
+```
+
+The tablet PWA should connect to realtime events through:
+
+```txt
+wss://woosoo.local/app
+```
+
+Ordering tablets must not talk directly to:
+
+```txt
+POS database
+POS API
+Bluetooth printer
+print bridge tablet
+MySQL/MariaDB
+Redis
+internal Reverb port
+```
+
+---
+
+## Admin Panel Rule
+
+The Laravel admin panel remains on:
+
+```txt
+https://woosoo.local
+```
+
+Laravel routes such as admin dashboards, API docs, settings pages, and backend management pages remain owned by `woosoo-nexus`.
+
+---
+
+## Print Bridge Rule
+
+The Bluetooth thermal printer is not connected to the Raspberry Pi.
+
+The printer is paired only with the print bridge tablet / relay device.
+
+```txt
+woosoo-nexus on Raspberry Pi
+  https://woosoo.local
+        ↑
+        │ API / WebSocket
+        │
+Print Bridge Tablet / Relay Device
+  woosoo-print-bridge app
+        ↓
+        │ Bluetooth
+        ↓
+Bluetooth Thermal Printer
+```
+
+The print bridge tablet should:
+
+1. Connect to `https://woosoo.local`.
+2. Authenticate or register as a device.
+3. Listen for print events through Reverb/WebSocket.
+4. Fallback-fetch unprinted orders through the backend API if WebSocket events are missed.
+5. Format the receipt locally.
+6. Send the receipt data to the Bluetooth thermal printer.
+7. Call the backend to mark the order as printed.
+8. Send heartbeat/status to the backend.
+
+The backend manages order data and print state.
+
+The print bridge tablet manages Bluetooth pairing, printer connection, receipt formatting, and actual printing.
+
+---
+
+## Print Flow
+
+```txt
+Ordering Tablet
+  → https://woosoo.local:4443
+  → creates order
+
+Raspberry Pi / woosoo-nexus
+  → saves order
+  → broadcasts print event
+
+Print Bridge Tablet
+  → receives or fetches order from https://woosoo.local
+  → prints via Bluetooth thermal printer
+  → marks order printed
+```
+
+Fallback flow:
+
+```txt
+If WebSocket is missed or disconnected:
+  print bridge calls backend unprinted-orders endpoint
+  print bridge prints pending orders
+  print bridge confirms printed status
+```
+
+---
+
+## POS Integration Rule
+
+Only `woosoo-nexus` should communicate with the POS / third-party application.
+
+```txt
+Tablet PWA        → woosoo-nexus only
+Print bridge      → woosoo-nexus only
+woosoo-nexus      → POS database/API
+```
+
+Client devices must not talk directly to the POS system.
+
+---
+
+## DNS Rule for Tablets
+
+Because router access may not be available, tablets should keep DHCP for their IP address but manually use the Pi as DNS.
+
+Example tablet Wi-Fi settings:
+
+```txt
+IP assignment: DHCP
+DNS 1:         192.168.100.10
+DNS 2:         blank or 192.168.100.10
+```
+
+Never set public DNS such as `8.8.8.8` as tablet DNS 2. Some devices may use DNS 2 instead of the Pi and fail to resolve `woosoo.local`.
+
+---
+
+## Forbidden Shortcuts
+
+Do not introduce these shortcuts:
+
+```txt
+Tablet → POS directly
+Tablet → printer directly
+Tablet → MySQL directly
+Print bridge → POS directly
+Printer → Raspberry Pi Bluetooth directly
+Client devices → raw Docker service ports except documented tablet PWA port 4443
+Client devices → Raspberry Pi IP as the normal app URL
+```
+
+All application traffic should pass through `https://woosoo.local` unless explicitly documented otherwise.
+
+---
+
+## Operational Summary
+
+```txt
+Tablets use:        https://woosoo.local:4443
+Admin uses:         https://woosoo.local
+Print bridge uses:  https://woosoo.local
+Printer uses:       Bluetooth from print bridge tablet
+POS is accessed by: woosoo-nexus only
+DNS is served by:   Raspberry Pi dnsmasq
+Production storage: M.2/NVMe SSD
+Deployment method:  Docker Compose via compose.yaml
+```

--- a/docs/deployment/examples/woosoo.env.example
+++ b/docs/deployment/examples/woosoo.env.example
@@ -1,0 +1,53 @@
+# ==================================================
+# Woosoo Local Deployment Config
+# Copy to: /etc/woosoo/woosoo.env
+# Edit this file, then run:
+#   sudo bash scripts/deployment/apply-woosoo-config.sh
+#
+# The apply script uses require_var for the REQUIRED values below.
+# ==================================================
+
+# REQUIRED
+WOOSOO_HOST="woosoo.local"
+WOOSOO_SERVER_IP="192.168.100.10"
+WOOSOO_GATEWAY="192.168.100.1"
+WOOSOO_CIDR="24"
+WOOSOO_NEXUS_PATH="/opt/woosoo/woosoo-nexus"
+WOOSOO_SCHEME="https"
+
+# OPTIONAL (has defaults or deployment-specific values)
+WOOSOO_DNS_FORWARDERS="1.1.1.1 8.8.8.8"
+WOOSOO_NM_CONNECTION=""
+WOOSOO_DOCKER_COMPOSE="docker compose -f compose.yaml"
+WOOSOO_TIMEZONE="Asia/Manila"
+
+WOOSOO_POS_HOST="192.168.100.20"
+WOOSOO_POS_PORT="3308"
+WOOSOO_POS_DATABASE="krypton_woosoo"
+WOOSOO_POS_USERNAME="krypton_readonly"
+WOOSOO_POS_PASSWORD=""
+
+WOOSOO_DB_DATABASE="woosoo"
+WOOSOO_DB_USERNAME="woosoo"
+WOOSOO_DB_PASSWORD="change_this_password"
+WOOSOO_DB_ROOT_PASSWORD="change_this_root_password"
+
+WOOSOO_REVERB_APP_ID="woosoo"
+WOOSOO_REVERB_APP_KEY="change_this_reverb_key"
+WOOSOO_REVERB_APP_SECRET="change_this_reverb_secret"
+
+WOOSOO_ALIASES="api.woosoo.local tablet.woosoo.local"
+
+WOOSOO_APP_SERVICE="app"
+WOOSOO_NGINX_SERVICE="nginx"
+WOOSOO_REVERB_SERVICE="reverb"
+WOOSOO_QUEUE_SERVICE="queue"
+WOOSOO_SCHEDULER_SERVICE="scheduler"
+WOOSOO_MYSQL_SERVICE="mysql"
+
+WOOSOO_BACKUP_DIR="/opt/woosoo/backups"
+WOOSOO_BACKUP_RETENTION_DAYS="14"
+WOOSOO_APPLY_STATIC_IP="true"
+WOOSOO_RESTART_DOCKER="true"
+# Set to true only when applying static IP changes over SSH and you accept the disconnect risk.
+FORCE_APPLY_STATIC_IP="false"

--- a/docs/deployment/on-premise-raspberry-pi.md
+++ b/docs/deployment/on-premise-raspberry-pi.md
@@ -1,0 +1,363 @@
+# Woosoo On-Premise Raspberry Pi Deployment Runbook
+
+This runbook deploys `woosoo-nexus` on a Raspberry Pi 5 for local restaurant use.
+
+Current staging Docker layout:
+
+```txt
+Admin/API/Reverb: https://woosoo.local
+Tablet PWA:       https://woosoo.local:4443
+Print bridge:     https://woosoo.local
+```
+
+The tablet PWA is currently served by the `tablet-pwa` service in `compose.yaml` and proxied by Nginx on port `4443`.
+
+---
+
+## Architecture
+
+```mermaid
+graph TD
+    T[Ordering Tablets] -->|https://woosoo.local:4443| N[Nginx on Raspberry Pi]
+    A[Admin Browser] -->|https://woosoo.local| N
+    PB[Print Bridge Tablet] -->|https://woosoo.local API/WSS| N
+    PB -->|Bluetooth| PR[Bluetooth Thermal Printer]
+    N --> APP[Laravel app]
+    N --> RV[Reverb]
+    APP --> DB[(MySQL)]
+    APP --> RD[(Redis)]
+    APP --> POS[Third-party POS/Krypton]
+```
+
+---
+
+## Hardware
+
+Required:
+
+```txt
+Raspberry Pi 5
+M.2/NVMe SSD
+Active cooling
+Reliable USB-C power supply
+Ethernet connection
+Android ordering tablets
+Android print bridge tablet
+Bluetooth thermal printer
+```
+
+Recommended:
+
+```txt
+UPS
+Dedicated Wi-Fi AP for tablets
+Spare SSD image or backup Pi
+```
+
+---
+
+## Network Model Without Router Access
+
+The router still provides DHCP to tablets, but tablets manually use the Pi as DNS.
+
+Example:
+
+```txt
+Router/gateway:       192.168.100.1
+Raspberry Pi server:  192.168.100.10
+POS host:             192.168.100.20
+Tablet DNS 1:         192.168.100.10
+Tablet DNS 2:         blank or 192.168.100.10
+```
+
+Never set public DNS such as `8.8.8.8` as tablet DNS 2. Some devices may bypass the Pi and fail to resolve `woosoo.local`.
+
+---
+
+## Installation Order
+
+1. Flash Raspberry Pi OS 64-bit to the M.2 SSD.
+2. Boot the Pi from the SSD.
+3. Enable SSH if needed.
+4. Update the OS.
+5. Install Docker.
+6. Clone `woosoo-nexus`.
+7. Copy and edit `/etc/woosoo/woosoo.env`.
+8. Generate TLS certs in `docker/certs`.
+9. Run `scripts/deployment/apply-woosoo-config.sh`.
+10. Start the Docker stack using `compose.yaml`.
+11. Run first-install Laravel commands and migrations.
+12. Configure tablet DNS.
+13. Test admin, tablet PWA, Reverb, print bridge, and backups.
+14. Reboot and run the health check.
+
+---
+
+## Base OS Setup
+
+```bash
+sudo apt update
+sudo apt full-upgrade -y
+sudo reboot
+```
+
+After reboot:
+
+```bash
+sudo apt install -y git curl ca-certificates dnsutils nano unzip
+sudo timedatectl set-timezone Asia/Manila
+```
+
+---
+
+## Install Docker
+
+```bash
+curl -fsSL https://get.docker.com | sh
+sudo usermod -aG docker $USER
+sudo systemctl enable docker
+sudo systemctl start docker
+```
+
+Log out and back in, then verify:
+
+```bash
+docker --version
+docker compose version
+```
+
+---
+
+## Clone Repository
+
+```bash
+sudo mkdir -p /opt/woosoo
+sudo chown -R $USER:$USER /opt/woosoo
+cd /opt/woosoo
+
+git clone https://github.com/tech-artificer/woosoo-nexus.git
+cd woosoo-nexus
+```
+
+The staging branch already includes:
+
+```txt
+compose.yaml
+Dockerfile
+docker/nginx/default.conf
+docker/certs/README.md
+docker/certs/generate-dev-certs.sh
+```
+
+---
+
+## Configure One File
+
+```bash
+sudo mkdir -p /etc/woosoo
+sudo cp docs/deployment/examples/woosoo.env.example /etc/woosoo/woosoo.env
+sudo nano /etc/woosoo/woosoo.env
+```
+
+Important values:
+
+```bash
+WOOSOO_HOST="woosoo.local"
+WOOSOO_SERVER_IP="192.168.100.10"
+WOOSOO_GATEWAY="192.168.100.1"
+WOOSOO_POS_HOST="192.168.100.20"
+WOOSOO_DOCKER_COMPOSE="docker compose -f compose.yaml"
+```
+
+---
+
+## TLS Certificates
+
+The current Nginx config expects these files inside the container:
+
+```txt
+/etc/nginx/certs/fullchain.pem
+/etc/nginx/certs/privkey.pem
+```
+
+`compose.yaml` mounts the host directory:
+
+```yaml
+./docker/certs:/etc/nginx/certs:ro
+```
+
+So the host files must be:
+
+```txt
+docker/certs/fullchain.pem
+docker/certs/privkey.pem
+```
+
+For development/self-signed certs, use the existing helper in `docker/certs`:
+
+```bash
+cd docker/certs
+chmod +x generate-dev-certs.sh
+./generate-dev-certs.sh 192.168.100.10
+cd ../..
+```
+
+Install/trust the generated certificate authority or certificate on each tablet as needed.
+
+---
+
+## Apply Host Configuration
+
+Run from the repo root:
+
+```bash
+sudo bash scripts/deployment/apply-woosoo-config.sh
+```
+
+This configures:
+
+```txt
+static Pi IP through NetworkManager
+dnsmasq local DNS
+/etc/hosts fallback
+Laravel .env values
+certificate directory check
+Docker stack startup/cache refresh
+```
+
+When running over SSH, the script refuses to change the active network IP unless `FORCE_APPLY_STATIC_IP=true` is set.
+
+---
+
+## First Install Laravel Commands
+
+```bash
+docker compose -f compose.yaml up -d --build
+docker compose -f compose.yaml exec app composer install --no-dev --optimize-autoloader
+```
+
+Only run this on first install:
+
+```bash
+docker compose -f compose.yaml exec app php artisan key:generate
+```
+
+Do not run `key:generate` again on an existing production database unless intentionally rotating `APP_KEY`.
+
+Then run:
+
+```bash
+docker compose -f compose.yaml exec app php artisan migrate --force
+docker compose -f compose.yaml exec app php artisan storage:link || true
+docker compose -f compose.yaml exec app php artisan config:cache
+docker compose -f compose.yaml exec app php artisan route:cache
+docker compose -f compose.yaml exec app php artisan view:cache
+```
+
+---
+
+## Tablet Setup
+
+For each ordering tablet:
+
+```txt
+Wi-Fi IP assignment: DHCP
+DNS 1:               Raspberry Pi IP, e.g. 192.168.100.10
+DNS 2:               blank or same Pi IP
+Tablet URL:          https://woosoo.local:4443
+```
+
+---
+
+## Print Bridge Setup
+
+The print bridge tablet pairs to the Bluetooth printer and talks to the backend through:
+
+```txt
+https://woosoo.local
+```
+
+The Bluetooth printer should not be paired directly to the Raspberry Pi.
+
+---
+
+## Health Check
+
+```bash
+sudo bash scripts/deployment/woosoo-health.sh
+```
+
+Checks include:
+
+```txt
+expected Pi IP
+dnsmasq
+woosoo.local resolution
+ports 53/80/443/4443
+admin HTTPS
+tablet PWA HTTPS
+Reverb proxy route
+Docker containers
+disk/memory/temperature
+```
+
+---
+
+## Backup
+
+Manual backup:
+
+```bash
+sudo bash scripts/deployment/woosoo-backup.sh
+```
+
+Cron example:
+
+```cron
+0 3 * * * /bin/bash /opt/woosoo/woosoo-nexus/scripts/deployment/woosoo-backup.sh >> /var/log/woosoo-backup.log 2>&1
+```
+
+Default retention is controlled by:
+
+```bash
+WOOSOO_BACKUP_RETENTION_DAYS="14"
+```
+
+---
+
+## Reboot Survival Test
+
+```bash
+sudo reboot
+```
+
+After reboot:
+
+```bash
+sudo bash scripts/deployment/woosoo-health.sh
+```
+
+Pass criteria:
+
+```txt
+Pi has expected IP
+dnsmasq active
+woosoo.local resolves
+Docker containers running
+https://woosoo.local responds
+https://woosoo.local:4443 responds
+Reverb route does not return 502
+Disk has free space
+Temperature is sane
+```
+
+---
+
+## Access Summary
+
+```txt
+Admin/API:     https://woosoo.local
+Tablet PWA:    https://woosoo.local:4443
+Print bridge:  https://woosoo.local
+Reverb/WSS:    wss://woosoo.local/app
+```

--- a/docs/deployment/on-premise-raspberry-pi.md
+++ b/docs/deployment/on-premise-raspberry-pi.md
@@ -81,15 +81,17 @@ Never set public DNS such as `8.8.8.8` as tablet DNS 2. Some devices may bypass 
 3. Enable SSH if needed.
 4. Update the OS.
 5. Install Docker.
-6. Clone `woosoo-nexus`.
-7. Copy and edit `/etc/woosoo/woosoo.env`.
-8. Generate TLS certs in `docker/certs`.
-9. Run `scripts/deployment/apply-woosoo-config.sh`.
-10. Start the Docker stack using `compose.yaml`.
-11. Run first-install Laravel commands and migrations.
-12. Configure tablet DNS.
-13. Test admin, tablet PWA, Reverb, print bridge, and backups.
-14. Reboot and run the health check.
+6. Clone `woosoo-nexus` and check out `staging`.
+7. Make deployment scripts executable.
+8. Copy and edit `/etc/woosoo/woosoo.env`.
+9. Secure `/etc/woosoo/woosoo.env` permissions.
+10. Generate TLS certs in `docker/certs`.
+11. Run `scripts/deployment/apply-woosoo-config.sh`.
+12. Start the Docker stack using `compose.yaml`.
+13. Run first-install Laravel commands and migrations.
+14. Configure tablet DNS.
+15. Test admin, tablet PWA, Reverb, print bridge, and backups.
+16. Reboot and run the health check.
 
 ---
 
@@ -137,6 +139,15 @@ cd /opt/woosoo
 
 git clone https://github.com/tech-artificer/woosoo-nexus.git
 cd woosoo-nexus
+git checkout staging
+```
+
+Make the deployment scripts executable:
+
+```bash
+chmod +x scripts/deployment/apply-woosoo-config.sh
+chmod +x scripts/deployment/woosoo-backup.sh
+chmod +x scripts/deployment/woosoo-health.sh
 ```
 
 The staging branch already includes:
@@ -157,6 +168,8 @@ docker/certs/generate-dev-certs.sh
 sudo mkdir -p /etc/woosoo
 sudo cp docs/deployment/examples/woosoo.env.example /etc/woosoo/woosoo.env
 sudo nano /etc/woosoo/woosoo.env
+sudo chown root:root /etc/woosoo/woosoo.env
+sudo chmod 600 /etc/woosoo/woosoo.env
 ```
 
 Important values:
@@ -226,6 +239,10 @@ Docker stack startup/cache refresh
 ```
 
 When running over SSH, the script refuses to change the active network IP unless `FORCE_APPLY_STATIC_IP=true` is set.
+
+On first-time Pi builds, Docker image pulls/builds can take several minutes. If the script warns that the app service is not ready yet, let Docker finish and rerun the script.
+
+The script warns if `APP_KEY` is missing. Before first production use, run `php artisan key:generate` as shown below.
 
 ---
 
@@ -322,6 +339,14 @@ Default retention is controlled by:
 ```bash
 WOOSOO_BACKUP_RETENTION_DAYS="14"
 ```
+
+The backup script uses a lock file to prevent overlapping backups.
+
+---
+
+## Reverb Exposure
+
+`REVERB_HOST=0.0.0.0` binds Reverb inside the Docker network. The Reverb service is not published directly to the host in `compose.yaml`; Nginx proxies WebSocket traffic through `https://woosoo.local/app`.
 
 ---
 

--- a/scripts/deployment/apply-woosoo-config.sh
+++ b/scripts/deployment/apply-woosoo-config.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/woosoo/woosoo.env"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Run as root: sudo bash scripts/deployment/apply-woosoo-config.sh"
+  exit 1
+fi
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing config file: $CONFIG_FILE"
+  echo "Copy docs/deployment/examples/woosoo.env.example to $CONFIG_FILE first."
+  exit 1
+fi
+
+set -a
+source "$CONFIG_FILE"
+set +a
+
+require_var() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "Missing required config: $name"
+    exit 1
+  fi
+}
+
+require_var WOOSOO_HOST
+require_var WOOSOO_SERVER_IP
+require_var WOOSOO_GATEWAY
+require_var WOOSOO_CIDR
+require_var WOOSOO_NEXUS_PATH
+require_var WOOSOO_SCHEME
+
+WOOSOO_APPLY_STATIC_IP="${WOOSOO_APPLY_STATIC_IP:-true}"
+WOOSOO_RESTART_DOCKER="${WOOSOO_RESTART_DOCKER:-true}"
+WOOSOO_DOCKER_COMPOSE="${WOOSOO_DOCKER_COMPOSE:-docker compose -f compose.yaml}"
+WOOSOO_APP_SERVICE="${WOOSOO_APP_SERVICE:-app}"
+WOOSOO_NGINX_SERVICE="${WOOSOO_NGINX_SERVICE:-nginx}"
+WOOSOO_REVERB_SERVICE="${WOOSOO_REVERB_SERVICE:-reverb}"
+WOOSOO_QUEUE_SERVICE="${WOOSOO_QUEUE_SERVICE:-queue}"
+WOOSOO_SCHEDULER_SERVICE="${WOOSOO_SCHEDULER_SERVICE:-scheduler}"
+WOOSOO_BACKUP_DIR="${WOOSOO_BACKUP_DIR:-/opt/woosoo/backups}"
+WOOSOO_DNS_FORWARDERS="${WOOSOO_DNS_FORWARDERS:-1.1.1.1 8.8.8.8}"
+FORCE_APPLY_STATIC_IP="${FORCE_APPLY_STATIC_IP:-false}"
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+safe_backup_file() {
+  local file="$1"
+  if [[ -f "$file" ]]; then
+    mkdir -p "$WOOSOO_BACKUP_DIR/config"
+    cp "$file" "$WOOSOO_BACKUP_DIR/config/$(basename "$file").$(date +%F_%H%M%S).bak"
+  fi
+}
+
+quote_env_value() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
+}
+
+set_env() {
+  local key="$1"
+  local value="$2"
+  local file=".env"
+  local rendered sed_value
+
+  rendered="$(quote_env_value "$value")"
+  sed_value="${rendered//\\/\\\\}"
+  sed_value="${sed_value//&/\\&}"
+  sed_value="${sed_value//|/\\|}"
+
+  if grep -qE "^${key}=" "$file"; then
+    sed -i "s|^${key}=.*|${key}=${sed_value}|g" "$file"
+  else
+    echo "${key}=${rendered}" >> "$file"
+  fi
+}
+
+install_packages_if_missing() {
+  local packages=(dnsmasq dnsutils curl iproute2 ca-certificates)
+  local missing=()
+  for package in "${packages[@]}"; do
+    if ! dpkg -s "$package" >/dev/null 2>&1; then
+      missing+=("$package")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    apt-get update
+    apt-get install -y --no-install-recommends "${missing[@]}"
+  else
+    echo "OK: required OS packages already installed"
+  fi
+}
+
+get_connection_device() {
+  local connection="$1"
+  nmcli -t -f NAME,DEVICE connection show --active | awk -F: -v name="$connection" '$1==name {print $2; exit}'
+}
+
+get_device_ipv4() {
+  local device="$1"
+  ip -4 -o addr show dev "$device" | awk '{print $4}' | cut -d/ -f1 | head -n1
+}
+
+assert_static_ip_change_safe() {
+  local connection="$1"
+  local device current_ip
+
+  if [[ -z "${SSH_CONNECTION:-}${SSH_CLIENT:-}" ]]; then
+    return 0
+  fi
+
+  device="$(get_connection_device "$connection" || true)"
+  current_ip=""
+  if [[ -n "$device" ]]; then
+    current_ip="$(get_device_ipv4 "$device" || true)"
+  fi
+
+  if [[ "$current_ip" == "$WOOSOO_SERVER_IP" ]]; then
+    return 0
+  fi
+
+  if [[ "$FORCE_APPLY_STATIC_IP" == "true" ]]; then
+    echo "WARNING: SSH session detected, but FORCE_APPLY_STATIC_IP=true."
+    echo "Proceeding with nmcli connection modify and nmcli connection up for WOOSOO_NM_CONNECTION=$connection to WOOSOO_SERVER_IP=$WOOSOO_SERVER_IP."
+    return 0
+  fi
+
+  echo "ERROR: SSH session detected. Refusing to change active network settings remotely."
+  echo "WOOSOO_NM_CONNECTION=$connection"
+  echo "Current interface=${device:-unknown} current IP=${current_ip:-unknown}"
+  echo "Target WOOSOO_SERVER_IP=$WOOSOO_SERVER_IP"
+  echo "The script would run: nmcli connection modify \"$connection\" ... ipv4.method manual"
+  echo "Then: nmcli connection up \"$connection\""
+  echo "Run locally on the Pi console, or rerun with FORCE_APPLY_STATIC_IP=true if you accept the risk."
+  exit 1
+}
+
+wait_for_app_service() {
+  local attempts=30
+  local delay=2
+
+  if ! $WOOSOO_DOCKER_COMPOSE ps --services | grep -qx "$WOOSOO_APP_SERVICE"; then
+    echo "WARNING: app service not found in compose: $WOOSOO_APP_SERVICE"
+    return 1
+  fi
+
+  echo "Waiting for Laravel app service to become ready..."
+  for _ in $(seq 1 "$attempts"); do
+    if $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan --version >/dev/null 2>&1; then
+      echo "OK: Laravel app service is ready"
+      return 0
+    fi
+    sleep "$delay"
+  done
+
+  echo "WARNING: Laravel app service did not become ready in time"
+  return 1
+}
+
+echo "=== Woosoo Configuration Apply ==="
+echo "Host:          $WOOSOO_HOST"
+echo "Server IP:     $WOOSOO_SERVER_IP/$WOOSOO_CIDR"
+echo "Gateway:       $WOOSOO_GATEWAY"
+echo "Nexus path:    $WOOSOO_NEXUS_PATH"
+echo "Compose:       $WOOSOO_DOCKER_COMPOSE"
+echo
+
+install_packages_if_missing
+
+if systemctl is-active --quiet systemd-resolved; then
+  echo "Disabling systemd-resolved to avoid port 53 conflict with dnsmasq..."
+  systemctl disable --now systemd-resolved || true
+  safe_backup_file "/etc/resolv.conf"
+  rm -f /etc/resolv.conf
+  first_dns="$(echo "$WOOSOO_DNS_FORWARDERS" | awk '{print $1}')"
+  echo "nameserver ${first_dns:-1.1.1.1}" > /etc/resolv.conf
+fi
+
+if [[ "$WOOSOO_APPLY_STATIC_IP" == "true" ]]; then
+  if command_exists nmcli; then
+    if [[ -z "${WOOSOO_NM_CONNECTION:-}" ]]; then
+      WOOSOO_NM_CONNECTION="$(nmcli -t -f NAME,TYPE,DEVICE connection show --active | awk -F: '$2=="ethernet" && $3!="" {print $1; exit}' || true)"
+    fi
+    if [[ -n "$WOOSOO_NM_CONNECTION" ]]; then
+      assert_static_ip_change_safe "$WOOSOO_NM_CONNECTION"
+      echo "Applying static IP to NetworkManager connection: $WOOSOO_NM_CONNECTION"
+      nmcli connection modify "$WOOSOO_NM_CONNECTION" \
+        ipv4.addresses "${WOOSOO_SERVER_IP}/${WOOSOO_CIDR}" \
+        ipv4.gateway "$WOOSOO_GATEWAY" \
+        ipv4.dns "$WOOSOO_DNS_FORWARDERS" \
+        ipv4.method manual
+      nmcli connection up "$WOOSOO_NM_CONNECTION" || true
+    else
+      echo "WARNING: Could not detect wired NetworkManager connection."
+    fi
+  else
+    echo "WARNING: nmcli not found. Static IP not applied."
+  fi
+fi
+
+sleep 2
+if ip -4 addr | grep -Fq "$WOOSOO_SERVER_IP"; then
+  echo "OK: Server IP is active: $WOOSOO_SERVER_IP"
+else
+  echo "WARNING: Server IP $WOOSOO_SERVER_IP not detected on active interfaces."
+fi
+
+DNSMASQ_CONF="/etc/dnsmasq.d/woosoo.conf"
+safe_backup_file "$DNSMASQ_CONF"
+cat > "$DNSMASQ_CONF" <<EOF
+# Generated by Woosoo deploy script.
+# Edit /etc/woosoo/woosoo.env then rerun this script.
+
+domain-needed
+bogus-priv
+address=/${WOOSOO_HOST}/${WOOSOO_SERVER_IP}
+EOF
+for alias in ${WOOSOO_ALIASES:-}; do
+  echo "address=/${alias}/${WOOSOO_SERVER_IP}" >> "$DNSMASQ_CONF"
+done
+cat >> "$DNSMASQ_CONF" <<EOF
+
+# Forward normal DNS.
+EOF
+for dns in $WOOSOO_DNS_FORWARDERS; do
+  echo "server=${dns}" >> "$DNSMASQ_CONF"
+done
+
+dnsmasq --test
+systemctl enable dnsmasq
+systemctl restart dnsmasq
+
+DNS_RESULT="$(dig "$WOOSOO_HOST" "@127.0.0.1" +short | tail -n1 || true)"
+if [[ "$DNS_RESULT" != "$WOOSOO_SERVER_IP" ]]; then
+  echo "ERROR: DNS test failed. Expected $WOOSOO_SERVER_IP, got ${DNS_RESULT:-empty}"
+  exit 1
+fi
+
+echo "OK: $WOOSOO_HOST resolves to $WOOSOO_SERVER_IP"
+
+safe_backup_file "/etc/hosts"
+sed -i '/# BEGIN WOOSOO HOSTS/,/# END WOOSOO HOSTS/d' /etc/hosts
+{
+  echo "# BEGIN WOOSOO HOSTS"
+  echo "$WOOSOO_SERVER_IP $WOOSOO_HOST ${WOOSOO_ALIASES:-}"
+  echo "# END WOOSOO HOSTS"
+} >> /etc/hosts
+
+if [[ ! -d "$WOOSOO_NEXUS_PATH" ]]; then
+  echo "ERROR: Laravel project path not found: $WOOSOO_NEXUS_PATH"
+  exit 1
+fi
+
+cd "$WOOSOO_NEXUS_PATH"
+
+if [[ ! -f artisan ]]; then
+  echo "ERROR: artisan not found in $WOOSOO_NEXUS_PATH"
+  exit 1
+fi
+
+if [[ ! -f compose.yaml && ! -f docker-compose.yml && ! -f compose.yml && ! -f docker-compose.yaml ]]; then
+  echo "ERROR: No Docker Compose file found in $WOOSOO_NEXUS_PATH"
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  if [[ -f .env.example ]]; then
+    cp .env.example .env
+  else
+    touch .env
+  fi
+fi
+
+safe_backup_file ".env"
+
+echo "Updating Laravel .env..."
+set_env "PUBLIC_SCHEME" "$WOOSOO_SCHEME"
+set_env "PUBLIC_HOST" "$WOOSOO_HOST"
+set_env "PUBLIC_HTTP_PORT" "80"
+set_env "PUBLIC_HTTPS_PORT" "443"
+set_env "APP_ENV" "production"
+set_env "APP_DEBUG" "false"
+set_env "APP_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
+set_env "APP_TIMEZONE" "${WOOSOO_TIMEZONE:-Asia/Manila}"
+set_env "DB_CONNECTION" "mysql"
+set_env "DB_HOST" "mysql"
+set_env "DB_PORT" "3306"
+set_env "DB_DATABASE" "${WOOSOO_DB_DATABASE:-woosoo}"
+set_env "DB_USERNAME" "${WOOSOO_DB_USERNAME:-woosoo}"
+set_env "DB_PASSWORD" "${WOOSOO_DB_PASSWORD:-change_this_password}"
+set_env "DB_ROOT_PASSWORD" "${WOOSOO_DB_ROOT_PASSWORD:-change_this_root_password}"
+set_env "DB_POS_HOST" "${WOOSOO_POS_HOST:-192.168.100.20}"
+set_env "DB_POS_PORT" "${WOOSOO_POS_PORT:-3308}"
+set_env "DB_POS_DATABASE" "${WOOSOO_POS_DATABASE:-krypton_woosoo}"
+set_env "DB_POS_USERNAME" "${WOOSOO_POS_USERNAME:-krypton_readonly}"
+set_env "DB_POS_PASSWORD" "${WOOSOO_POS_PASSWORD:-}"
+set_env "CACHE_DRIVER" "redis"
+set_env "QUEUE_CONNECTION" "redis"
+set_env "SESSION_DRIVER" "redis"
+set_env "REDIS_HOST" "redis"
+set_env "REDIS_PASSWORD" "null"
+set_env "REDIS_PORT" "6379"
+set_env "BROADCAST_DRIVER" "reverb"
+set_env "REVERB_APP_ID" "${WOOSOO_REVERB_APP_ID:-woosoo}"
+set_env "REVERB_APP_KEY" "${WOOSOO_REVERB_APP_KEY:-change_this_reverb_key}"
+set_env "REVERB_APP_SECRET" "${WOOSOO_REVERB_APP_SECRET:-change_this_reverb_secret}"
+set_env "REVERB_HOST" "0.0.0.0"
+set_env "REVERB_PUBLIC_HOST" "$WOOSOO_HOST"
+set_env "REVERB_PORT" "8080"
+set_env "REVERB_SCHEME" "http"
+set_env "VITE_REVERB_APP_KEY" "${WOOSOO_REVERB_APP_KEY:-change_this_reverb_key}"
+set_env "VITE_REVERB_HOST" "$WOOSOO_HOST"
+set_env "VITE_REVERB_PORT" "443"
+set_env "VITE_REVERB_SCHEME" "$WOOSOO_SCHEME"
+set_env "SESSION_DOMAIN" "$WOOSOO_HOST"
+set_env "SESSION_SECURE_COOKIE" "true"
+set_env "SESSION_SAME_SITE" "lax"
+set_env "SANCTUM_STATEFUL_DOMAINS" "${WOOSOO_HOST},${WOOSOO_HOST}:443,${WOOSOO_HOST}:80"
+set_env "CORS_ALLOWED_ORIGINS" "${WOOSOO_SCHEME}://${WOOSOO_HOST},http://${WOOSOO_HOST}"
+set_env "LOG_LEVEL" "error"
+
+CERT_DIR="$WOOSOO_NEXUS_PATH/docker/certs"
+mkdir -p "$CERT_DIR"
+if [[ ! -f "$CERT_DIR/fullchain.pem" || ! -f "$CERT_DIR/privkey.pem" ]]; then
+  echo "WARNING: TLS certificate files are missing."
+  echo "Expected host files:"
+  echo "  $CERT_DIR/fullchain.pem"
+  echo "  $CERT_DIR/privkey.pem"
+  echo "compose.yaml mounts ./docker/certs:/etc/nginx/certs:ro."
+fi
+
+if [[ "$WOOSOO_RESTART_DOCKER" == "true" ]]; then
+  if command_exists docker; then
+    $WOOSOO_DOCKER_COMPOSE up -d
+    if wait_for_app_service; then
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan config:clear || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan cache:clear || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan route:clear || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan view:clear || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan config:cache || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan route:cache || true
+      $WOOSOO_DOCKER_COMPOSE exec -T "$WOOSOO_APP_SERVICE" php artisan view:cache || true
+    fi
+    $WOOSOO_DOCKER_COMPOSE ps
+  else
+    echo "WARNING: Docker not installed. Skipping Docker operations."
+  fi
+fi
+
+echo
+echo "=== Final Checks ==="
+dig "$WOOSOO_HOST" "@127.0.0.1" +short || true
+curl -k -I --max-time 10 "${WOOSOO_SCHEME}://${WOOSOO_HOST}" || true
+df -h /
+free -h
+if command_exists vcgencmd; then vcgencmd measure_temp || true; fi
+
+echo
+echo "Done. Tablet DNS must point to: ${WOOSOO_SERVER_IP}"
+echo "Admin URL: ${WOOSOO_SCHEME}://${WOOSOO_HOST}"
+echo "Tablet PWA URL from current compose.yaml: ${WOOSOO_SCHEME}://${WOOSOO_HOST}:4443"

--- a/scripts/deployment/apply-woosoo-config.sh
+++ b/scripts/deployment/apply-woosoo-config.sh
@@ -143,7 +143,7 @@ assert_static_ip_change_safe() {
 }
 
 wait_for_app_service() {
-  local attempts=30
+  local attempts=60
   local delay=2
 
   if ! $WOOSOO_DOCKER_COMPOSE ps --services | grep -qx "$WOOSOO_APP_SERVICE"; then
@@ -160,7 +160,7 @@ wait_for_app_service() {
     sleep "$delay"
   done
 
-  echo "WARNING: Laravel app service did not become ready in time"
+  echo "WARNING: Laravel app service did not become ready in time. On first Pi builds, Docker image pull/build can take several minutes. Rerun this script after the stack finishes building."
   return 1
 }
 
@@ -179,8 +179,9 @@ if systemctl is-active --quiet systemd-resolved; then
   systemctl disable --now systemd-resolved || true
   safe_backup_file "/etc/resolv.conf"
   rm -f /etc/resolv.conf
-  first_dns="$(echo "$WOOSOO_DNS_FORWARDERS" | awk '{print $1}')"
-  echo "nameserver ${first_dns:-1.1.1.1}" > /etc/resolv.conf
+  for dns in $WOOSOO_DNS_FORWARDERS; do
+    echo "nameserver $dns" >> /etc/resolv.conf
+  done
 fi
 
 if [[ "$WOOSOO_APPLY_STATIC_IP" == "true" ]]; then
@@ -325,6 +326,10 @@ set_env "SESSION_SAME_SITE" "lax"
 set_env "SANCTUM_STATEFUL_DOMAINS" "${WOOSOO_HOST},${WOOSOO_HOST}:443,${WOOSOO_HOST}:80"
 set_env "CORS_ALLOWED_ORIGINS" "${WOOSOO_SCHEME}://${WOOSOO_HOST},http://${WOOSOO_HOST}"
 set_env "LOG_LEVEL" "error"
+
+if ! grep -qE '^APP_KEY=base64:.+' .env; then
+  echo "INFO: APP_KEY is not set. Before first production use, run: $WOOSOO_DOCKER_COMPOSE exec -T $WOOSOO_APP_SERVICE php artisan key:generate"
+fi
 
 CERT_DIR="$WOOSOO_NEXUS_PATH/docker/certs"
 mkdir -p "$CERT_DIR"

--- a/scripts/deployment/woosoo-backup.sh
+++ b/scripts/deployment/woosoo-backup.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 CONFIG_FILE="/etc/woosoo/woosoo.env"
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Run as root: sudo bash scripts/deployment/woosoo-backup.sh"
+  exit 1
+fi
+
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Missing $CONFIG_FILE"
   exit 1
@@ -20,6 +25,7 @@ MYSQL_SERVICE="${WOOSOO_MYSQL_SERVICE:-mysql}"
 DB_NAME="${WOOSOO_DB_DATABASE:-woosoo}"
 DB_USER="${WOOSOO_DB_USERNAME:-woosoo}"
 DB_PASS="${WOOSOO_DB_PASSWORD:-change_this_password}"
+LOCK_FILE="/tmp/woosoo-backup.lock"
 
 mkdir -p "$WOOSOO_BACKUP_DIR/db"
 
@@ -41,7 +47,13 @@ trap cleanup EXIT
 
 echo "Creating DB backup: $BACKUP_FILE"
 
-if $WOOSOO_DOCKER_COMPOSE exec -T "$MYSQL_SERVICE" sh -lc 'command -v mariadb-dump >/dev/null 2>&1'; then
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "ERROR: another Woosoo backup is already running"
+  exit 1
+fi
+
+if $WOOSOO_DOCKER_COMPOSE exec -T "$MYSQL_SERVICE" sh -c 'command -v mariadb-dump >/dev/null 2>&1'; then
   DUMP_CMD="mariadb-dump"
 else
   DUMP_CMD="mysqldump"

--- a/scripts/deployment/woosoo-backup.sh
+++ b/scripts/deployment/woosoo-backup.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/woosoo/woosoo.env"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing $CONFIG_FILE"
+  exit 1
+fi
+
+set -a
+source "$CONFIG_FILE"
+set +a
+
+WOOSOO_DOCKER_COMPOSE="${WOOSOO_DOCKER_COMPOSE:-docker compose -f compose.yaml}"
+WOOSOO_NEXUS_PATH="${WOOSOO_NEXUS_PATH:-/opt/woosoo/woosoo-nexus}"
+WOOSOO_BACKUP_DIR="${WOOSOO_BACKUP_DIR:-/opt/woosoo/backups}"
+WOOSOO_BACKUP_RETENTION_DAYS="${WOOSOO_BACKUP_RETENTION_DAYS:-14}"
+MYSQL_SERVICE="${WOOSOO_MYSQL_SERVICE:-mysql}"
+DB_NAME="${WOOSOO_DB_DATABASE:-woosoo}"
+DB_USER="${WOOSOO_DB_USERNAME:-woosoo}"
+DB_PASS="${WOOSOO_DB_PASSWORD:-change_this_password}"
+
+mkdir -p "$WOOSOO_BACKUP_DIR/db"
+
+if [[ ! -d "$WOOSOO_NEXUS_PATH" ]]; then
+  echo "Nexus path missing: $WOOSOO_NEXUS_PATH"
+  exit 1
+fi
+
+cd "$WOOSOO_NEXUS_PATH"
+
+BACKUP_FILE="$WOOSOO_BACKUP_DIR/db/${DB_NAME}_$(date +%F_%H%M%S).sql.gz"
+TEMP_SQL_FILE="${BACKUP_FILE%.gz}.tmp"
+TEMP_GZ_FILE="$BACKUP_FILE.tmp"
+
+cleanup() {
+  rm -f "$TEMP_SQL_FILE" "$TEMP_GZ_FILE"
+}
+trap cleanup EXIT
+
+echo "Creating DB backup: $BACKUP_FILE"
+
+if $WOOSOO_DOCKER_COMPOSE exec -T "$MYSQL_SERVICE" sh -lc 'command -v mariadb-dump >/dev/null 2>&1'; then
+  DUMP_CMD="mariadb-dump"
+else
+  DUMP_CMD="mysqldump"
+fi
+
+if ! $WOOSOO_DOCKER_COMPOSE exec -T \
+  -e MYSQL_PWD="$DB_PASS" \
+  "$MYSQL_SERVICE" \
+  "$DUMP_CMD" -u"$DB_USER" "$DB_NAME" > "$TEMP_SQL_FILE"; then
+  echo "ERROR: database dump failed; no backup written"
+  exit 1
+fi
+
+if [[ ! -s "$TEMP_SQL_FILE" ]]; then
+  echo "ERROR: database dump produced an empty file; no backup written"
+  exit 1
+fi
+
+gzip -c "$TEMP_SQL_FILE" > "$TEMP_GZ_FILE"
+mv "$TEMP_GZ_FILE" "$BACKUP_FILE"
+rm -f "$TEMP_SQL_FILE"
+
+echo "Backup complete: $BACKUP_FILE"
+
+echo "Deleting backups older than ${WOOSOO_BACKUP_RETENTION_DAYS} days..."
+find "$WOOSOO_BACKUP_DIR/db" -name "*.sql.gz" -type f -mtime +"$WOOSOO_BACKUP_RETENTION_DAYS" -delete
+
+echo "Remaining backups:"
+find "$WOOSOO_BACKUP_DIR/db" -maxdepth 1 -type f -name "*.sql.gz" -printf '%TY-%Tm-%Td %TH:%TM %s bytes %p\n' | sort || true

--- a/scripts/deployment/woosoo-health.sh
+++ b/scripts/deployment/woosoo-health.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 CONFIG_FILE="/etc/woosoo/woosoo.env"
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Run as root: sudo bash scripts/deployment/woosoo-health.sh"
+  exit 1
+fi
+
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Missing $CONFIG_FILE"
   exit 1
@@ -33,7 +38,7 @@ systemctl is-active dnsmasq || true
 
 echo
 echo "[4] Host port listeners"
-ss -lntup | awk '$5 ~ /:(53|80|443|4443)$/ || $5 ~ /:(53|80|443|4443)\s/ {print}' || true
+ss -lntup | grep -E ':(53|80|443|4443)\b' || true
 
 echo
 echo "[5] Admin HTTPS check"

--- a/scripts/deployment/woosoo-health.sh
+++ b/scripts/deployment/woosoo-health.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/woosoo/woosoo.env"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing $CONFIG_FILE"
+  exit 1
+fi
+
+set -a
+source "$CONFIG_FILE"
+set +a
+
+WOOSOO_DOCKER_COMPOSE="${WOOSOO_DOCKER_COMPOSE:-docker compose -f compose.yaml}"
+WOOSOO_NEXUS_PATH="${WOOSOO_NEXUS_PATH:-/opt/woosoo/woosoo-nexus}"
+WOOSOO_SCHEME="${WOOSOO_SCHEME:-https}"
+WOOSOO_REVERB_APP_KEY="${WOOSOO_REVERB_APP_KEY:-}"
+
+echo "=== Woosoo Health Check ==="
+echo
+
+echo "[1] Expected IP address"
+ip -4 addr | grep -F "${WOOSOO_SERVER_IP}" || echo "WARNING: Expected IP not found: ${WOOSOO_SERVER_IP}"
+
+echo
+echo "[2] DNS local resolution"
+dig "$WOOSOO_HOST" @127.0.0.1 +short || true
+
+echo
+echo "[3] dnsmasq status"
+systemctl is-active dnsmasq || true
+
+echo
+echo "[4] Host port listeners"
+ss -lntup | awk '$5 ~ /:(53|80|443|4443)$/ || $5 ~ /:(53|80|443|4443)\s/ {print}' || true
+
+echo
+echo "[5] Admin HTTPS check"
+curl -k -I --max-time 10 "${WOOSOO_SCHEME}://${WOOSOO_HOST}" || true
+
+echo
+echo "[6] Tablet PWA HTTPS check"
+curl -k -I --max-time 10 "${WOOSOO_SCHEME}://${WOOSOO_HOST}:4443" || true
+
+echo
+echo "[7] Reverb proxy route check"
+if [[ -n "$WOOSOO_REVERB_APP_KEY" ]]; then
+  curl -k -I --max-time 10 "${WOOSOO_SCHEME}://${WOOSOO_HOST}/app/${WOOSOO_REVERB_APP_KEY}" || true
+else
+  echo "WOOSOO_REVERB_APP_KEY not set; skipping Reverb proxy route check"
+fi
+
+echo
+echo "[8] Docker containers"
+if [[ -d "$WOOSOO_NEXUS_PATH" ]]; then
+  cd "$WOOSOO_NEXUS_PATH"
+  $WOOSOO_DOCKER_COMPOSE ps || true
+else
+  echo "Nexus path missing: $WOOSOO_NEXUS_PATH"
+fi
+
+echo
+echo "[9] Disk"
+df -h
+
+echo
+echo "[10] Memory"
+free -h
+
+echo
+echo "[11] Temperature"
+if command -v vcgencmd >/dev/null 2>&1; then
+  vcgencmd measure_temp || true
+else
+  echo "vcgencmd not installed"
+fi
+
+echo
+echo "[12] Recent dnsmasq logs"
+journalctl -u dnsmasq -n 30 --no-pager || true


### PR DESCRIPTION
## Summary

Replacement for #84, rebuilt from current `staging` to avoid merge conflicts/divergence.

Adds Raspberry Pi on-premise deployment docs and operational scripts that align with the existing staging Docker setup:

- existing `compose.yaml`
- existing root `Dockerfile`
- existing `docker/nginx/default.conf`
- existing `docker/certs/fullchain.pem` and `privkey.pem` convention
- existing tablet PWA service exposed at `https://woosoo.local:4443`

## Added files

```txt
docs/deployment/on-premise-raspberry-pi.md
docs/deployment/access-and-integration-rules.md
docs/deployment/examples/woosoo.env.example
scripts/deployment/apply-woosoo-config.sh
scripts/deployment/woosoo-health.sh
scripts/deployment/woosoo-backup.sh
```

## Deployment model

```txt
Admin/API:     https://woosoo.local
Tablet PWA:    https://woosoo.local:4443
Print bridge:  https://woosoo.local
Reverb/WSS:    wss://woosoo.local/app
```

## Notes

- This PR does not add duplicate Docker files.
- It uses `docker compose -f compose.yaml` by default.
- The apply script guards against SSH-based static IP changes unless `FORCE_APPLY_STATIC_IP=true` is set.
- The backup script avoids exposing the DB password in process args and writes backups atomically via temporary files.
- The health script checks DNS, admin HTTPS, tablet HTTPS, Reverb proxy, Docker containers, disk, memory, and temperature.

## Related

Supersedes #84.
