### PR TITLE
Staging

### DIFF
--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -47,6 +47,7 @@ class OrderBroadcastPayload
                 'price' => $it->price,
                 'subtotal' => $it->subtotal,
                 'is_refill' => (bool) ($it->is_refill ?? false),
+                'notes' => $it->notes ?? null,
                 'type' => $it->type ?? null,
             ])->values()->all(),
             'serviceRequests' => $order->serviceRequests ?? [],

--- a/app/Http/Controllers/Api/V1/OrderApiController.php
+++ b/app/Http/Controllers/Api/V1/OrderApiController.php
@@ -398,14 +398,19 @@ class OrderApiController extends Controller
                                     );
                                     // Reload to pick up printEvent relation
                                     $deviceOrder->refresh();
-                                    PrintRefill::dispatch($deviceOrder, $posItems);
 
-                                    // Broadcast the complete updated order to admin.orders
-                                    // so the Refill Monitor receives all items immediately.
+                                    // Queue broadcasts until the print-event transaction commits,
+                                    // so listeners never observe uncommitted state.
                                     $freshOrder = $deviceOrder->fresh(['items.menu', 'device.table', 'table', 'serviceRequests']);
-                                    if ($freshOrder) {
-                                        OrderStatusUpdated::dispatch($freshOrder);
-                                    }
+                                    DB::afterCommit(function () use ($deviceOrder, $posItems, $freshOrder) {
+                                        PrintRefill::dispatch($deviceOrder, $posItems);
+
+                                        // Broadcast the complete updated order to admin.orders
+                                        // so the Refill Monitor receives all items immediately.
+                                        if ($freshOrder) {
+                                            OrderStatusUpdated::dispatch($freshOrder);
+                                        }
+                                    });
                                 });
                             } catch (\Throwable $e) {
                                 report($e);

--- a/app/Http/Controllers/Api/V1/OrderApiController.php
+++ b/app/Http/Controllers/Api/V1/OrderApiController.php
@@ -435,12 +435,13 @@ class OrderApiController extends Controller
                 }
             }
 
-            $freshOrder = DeviceOrder::with(['items.menu', 'table'])->find($deviceOrder->id);
+            // Fetch fresh order with relationships to return via DeviceOrderResource
+            $freshOrder = DeviceOrder::with(['items.menu', 'table', 'device'])->find($deviceOrder->id);
 
             $responseBody = [
                 'success' => true,
                 'created' => $created,
-                'order' => $freshOrder ? $freshOrder->toArray() : null,
+                'order' => $freshOrder ? DeviceOrderResource::make($freshOrder) : null,
             ];
 
             if ($responseCacheKey) {

--- a/app/Http/Controllers/Api/V1/OrderApiController.php
+++ b/app/Http/Controllers/Api/V1/OrderApiController.php
@@ -360,7 +360,7 @@ class OrderApiController extends Controller
                     'subtotal' => $subtotal,
                     'tax' => $tax,
                     'total' => $total,
-                    'notes' => $pos->note ?? 'Refill',
+                    'notes' => isset($pos->note) && trim((string) $pos->note) !== '' ? $pos->note : 'Refill',
                     'seat_number' => $pos->seat_number ?? 1,
                     'index' => $pos->index ?? 1,
                     'is_refill' => true,

--- a/app/Http/Controllers/Api/V1/OrderApiController.php
+++ b/app/Http/Controllers/Api/V1/OrderApiController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Actions\Order\CreateOrderedMenu;
 use App\Events\Order\OrderPrinted;
+use App\Events\Order\OrderStatusUpdated;
 use App\Events\PrintOrder;
 use App\Events\PrintRefill;
 use App\Http\Controllers\Controller;
@@ -359,10 +360,10 @@ class OrderApiController extends Controller
                     'subtotal' => $subtotal,
                     'tax' => $tax,
                     'total' => $total,
-                    'notes' => $pos->note ?? null,
+                    'notes' => $pos->note ?? 'Refill',
                     'seat_number' => $pos->seat_number ?? 1,
                     'index' => $pos->index ?? 1,
-                    // Note: is_refill column removed - table doesn't have it
+                    'is_refill' => true,
                 ];
             }
 
@@ -398,6 +399,13 @@ class OrderApiController extends Controller
                                     // Reload to pick up printEvent relation
                                     $deviceOrder->refresh();
                                     PrintRefill::dispatch($deviceOrder, $posItems);
+
+                                    // Broadcast the complete updated order to admin.orders
+                                    // so the Refill Monitor receives all items immediately.
+                                    $freshOrder = $deviceOrder->fresh(['items.menu', 'device.table', 'table', 'serviceRequests']);
+                                    if ($freshOrder) {
+                                        OrderStatusUpdated::dispatch($freshOrder);
+                                    }
                                 });
                             } catch (\Throwable $e) {
                                 report($e);
@@ -427,7 +435,13 @@ class OrderApiController extends Controller
                 }
             }
 
-            $responseBody = ['success' => true, 'created' => $created];
+            $freshOrder = DeviceOrder::with(['items.menu', 'table'])->find($deviceOrder->id);
+
+            $responseBody = [
+                'success' => true,
+                'created' => $created,
+                'order' => $freshOrder ? $freshOrder->toArray() : null,
+            ];
 
             if ($responseCacheKey) {
                 Cache::put($responseCacheKey, [


### PR DESCRIPTION
This pull request enhances the refill order workflow by ensuring that order updates are broadcast to listeners in real time and that API responses return the latest order state. It also improves the handling of notes and refill flags in order items.

**Refill Order Workflow Improvements:**

* After processing a refill, the system now broadcasts the complete, updated order to the `admin.orders` channel using the `OrderStatusUpdated` event. This ensures that the Refill Monitor and other listeners immediately receive all updated items.
* The API response for a refill order now includes the latest state of the order, with related menu and table data, making it easier for clients to update their UI with fresh information.

**Order Item Data Enhancements:**

* When creating refill order items, the `notes` field defaults to `'Refill'` if no note is provided, and the `is_refill` flag is explicitly set to `true`.
* The order broadcast payload now always includes the `notes` property for each item, defaulting to `null` if not set.

**Other Changes:**

* The `OrderStatusUpdated` event is now imported in the `OrderApiController`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order broadcasts now include per-item notes.
  * Refill orders are marked as refills and mirror item details (notes, seat, index) for consistency.
  * Refill API responses now return enriched order details and trigger real-time order status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->