### PR TITLE
feat(nexus): broadcasting integrity check + VerifyIntegrity command

### DIFF
--- a/app/Console/Commands/VerifyIntegrityCommand.php
+++ b/app/Console/Commands/VerifyIntegrityCommand.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+
+class VerifyIntegrityCommand extends Command
+{
+    protected $signature = 'woosoo:verify-integrity';
+
+    protected $description = 'Verify Reverb configuration integrity to catch silent broadcast key/id mismatches.';
+
+    public function handle(): int
+    {
+        $checks = [];
+        $hasFail = false;
+
+        // Check 1: Required env vars non-empty
+        $check1 = $this->checkRequiredEnvVars($checks);
+        if ($check1 === 'FAIL') {
+            $hasFail = true;
+        }
+
+        // Check 2: Broadcasting driver resolution
+        $check2 = $this->checkBroadcastingDriverResolution($checks);
+        if ($check2 === 'FAIL') {
+            $hasFail = true;
+        }
+
+        // Check 3: Config consistency (reverb.apps vs broadcasting.connections.reverb)
+        $check3 = $this->checkConfigConsistency($checks);
+        if ($check3 === 'FAIL') {
+            $hasFail = true;
+        }
+
+        // Check 4: Env vs config divergence (stale cache detection)
+        $check4 = $this->checkEnvVsConfigDivergence($checks);
+        if ($check4 === 'FAIL') {
+            $hasFail = true;
+        }
+
+        // Check 5: Reverb server vs client-facing values
+        $check5 = $this->checkServerVsClientFacing($checks);
+        if ($check5 === 'FAIL') {
+            $hasFail = true;
+        }
+
+        // Check 6: APP_KEY and POS config (warning only)
+        $this->checkAppKeyAndPosConfig($checks);
+
+        // Print table
+        $this->printTable($checks);
+
+        return $hasFail ? 1 : 0;
+    }
+
+    private function checkRequiredEnvVars(&$checks): string
+    {
+        $appId = trim((string) env('REVERB_APP_ID'));
+        $appKey = trim((string) env('REVERB_APP_KEY'));
+        $appSecret = trim((string) env('REVERB_APP_SECRET'));
+
+        if ($appId === '' || $appKey === '' || $appSecret === '') {
+            $checks[] = [
+                'Check',
+                'Required env vars (REVERB_APP_ID/KEY/SECRET)',
+                'FAIL',
+                'One or more required env vars are empty',
+            ];
+            return 'FAIL';
+        }
+
+        $checks[] = [
+            'Check',
+            'Required env vars (REVERB_APP_ID/KEY/SECRET)',
+            'PASS',
+            'All required env vars present',
+        ];
+        return 'PASS';
+    }
+
+    private function checkBroadcastingDriverResolution(&$checks): string
+    {
+        $broadcastDriver = config('broadcasting.default');
+
+        if ($broadcastDriver === 'null') {
+            $checks[] = [
+                'Check',
+                'Broadcasting driver resolution',
+                'FAIL',
+                'Driver resolved to "null" — check BROADCAST_CONNECTION, REVERB_APP_KEY, PUSHER_APP_KEY',
+            ];
+            return 'FAIL';
+        }
+
+        if ($broadcastDriver !== 'reverb') {
+            // If explicitly set to something other than reverb, that's a warning-level issue
+            $checks[] = [
+                'Check',
+                'Broadcasting driver resolution',
+                'WARN',
+                "Driver is '{$broadcastDriver}' (not 'reverb')",
+            ];
+            return 'WARN';
+        }
+
+        // Check if BROADCAST_CONNECTION is unset but reverb is inferred
+        if (env('BROADCAST_CONNECTION') === null && env('REVERB_APP_KEY')) {
+            $checks[] = [
+                'Check',
+                'Broadcasting driver resolution',
+                'WARN',
+                'BROADCAST_CONNECTION unset; reverb inferred from REVERB_APP_KEY (explicit setting recommended)',
+            ];
+            return 'WARN';
+        }
+
+        $checks[] = [
+            'Check',
+            'Broadcasting driver resolution',
+            'PASS',
+            'Driver correctly resolved to reverb',
+        ];
+        return 'PASS';
+    }
+
+    private function checkConfigConsistency(&$checks): string
+    {
+        $reverbApps = config('reverb.apps.apps');
+        $broadcastingReverb = config('broadcasting.connections.reverb');
+
+        if (!is_array($reverbApps) || count($reverbApps) === 0) {
+            $checks[] = [
+                'Check',
+                'Config consistency (reverb.apps vs broadcasting)',
+                'FAIL',
+                'No apps defined in config/reverb.php apps.apps',
+            ];
+            return 'FAIL';
+        }
+
+        $reverbApp = $reverbApps[0];
+
+        $reverbKey = trim((string) ($reverbApp['key'] ?? ''));
+        $reverbSecret = trim((string) ($reverbApp['secret'] ?? ''));
+        $reverbId = trim((string) ($reverbApp['app_id'] ?? ''));
+
+        $broadcastKey = trim((string) ($broadcastingReverb['key'] ?? ''));
+        $broadcastSecret = trim((string) ($broadcastingReverb['secret'] ?? ''));
+        $broadcastId = trim((string) ($broadcastingReverb['app_id'] ?? ''));
+
+        $mismatch = [];
+        if ($reverbKey !== $broadcastKey) {
+            $mismatch[] = 'key';
+        }
+        if ($reverbSecret !== $broadcastSecret) {
+            $mismatch[] = 'secret';
+        }
+        if ($reverbId !== $broadcastId) {
+            $mismatch[] = 'app_id';
+        }
+
+        if (count($mismatch) > 0) {
+            $checks[] = [
+                'Check',
+                'Config consistency (reverb.apps vs broadcasting)',
+                'FAIL',
+                'Mismatch in: ' . implode(', ', $mismatch),
+            ];
+            return 'FAIL';
+        }
+
+        $checks[] = [
+            'Check',
+            'Config consistency (reverb.apps vs broadcasting)',
+            'PASS',
+            'Config values match',
+        ];
+        return 'PASS';
+    }
+
+    private function checkEnvVsConfigDivergence(&$checks): string
+    {
+        $envKey = trim((string) env('REVERB_APP_KEY'));
+        $envId = trim((string) env('REVERB_APP_ID'));
+        $envSecret = trim((string) env('REVERB_APP_SECRET'));
+
+        $configKey = trim((string) config('reverb.apps.apps.0.key', ''));
+        $configId = trim((string) config('reverb.apps.apps.0.app_id', ''));
+        $configSecret = trim((string) config('reverb.apps.apps.0.secret', ''));
+
+        $mismatch = [];
+        if ($envKey !== $configKey) {
+            $mismatch[] = 'REVERB_APP_KEY';
+        }
+        if ($envId !== $configId) {
+            $mismatch[] = 'REVERB_APP_ID';
+        }
+        if ($envSecret !== $configSecret) {
+            $mismatch[] = 'REVERB_APP_SECRET';
+        }
+
+        if (count($mismatch) > 0) {
+            $checks[] = [
+                'Check',
+                'Env vs config divergence (stale cache)',
+                'FAIL',
+                'Divergence detected in: ' . implode(', ', $mismatch) . '. Run "php artisan config:clear"',
+            ];
+            return 'FAIL';
+        }
+
+        $checks[] = [
+            'Check',
+            'Env vs config divergence (stale cache)',
+            'PASS',
+            'Env and config values match',
+        ];
+        return 'PASS';
+    }
+
+    private function checkServerVsClientFacing(&$checks): string
+    {
+        $serverHost = trim((string) config('reverb.servers.reverb.host', ''));
+        $serverPort = (int) config('reverb.servers.reverb.port', 8080);
+
+        $clientHost = trim((string) config('broadcasting.connections.reverb.options.host', ''));
+        $clientPort = (int) config('broadcasting.connections.reverb.options.port', 8080);
+
+        // Warn if server bind is 0.0.0.0 but client is not localhost-ish or reverb
+        if ($serverHost === '0.0.0.0' && !in_array($clientHost, ['localhost', 'reverb', '127.0.0.1'], true)) {
+            $checks[] = [
+                'Check',
+                'Reverb server vs client-facing config',
+                'WARN',
+                "Server binds 0.0.0.0:{$serverPort}, client targets {$clientHost}:{$clientPort} (verify correctness)",
+            ];
+            return 'WARN';
+        }
+
+        $checks[] = [
+            'Check',
+            'Reverb server vs client-facing config',
+            'PASS',
+            "Server {$serverHost}:{$serverPort}, client {$clientHost}:{$clientPort}",
+        ];
+        return 'PASS';
+    }
+
+    private function checkAppKeyAndPosConfig(&$checks): void
+    {
+        $appKey = trim((string) config('app.key', ''));
+        $posIp = trim((string) env('POS_IP', '192.168.1.32'));
+
+        $warnings = [];
+        if ($appKey === '' || str_starts_with($appKey, 'base64:') === false) {
+            $warnings[] = 'APP_KEY not properly set';
+        }
+        if ($posIp === '') {
+            $warnings[] = 'POS_IP not configured';
+        }
+
+        if (count($warnings) > 0) {
+            $checks[] = [
+                'Check',
+                'APP_KEY and POS config',
+                'WARN',
+                implode('; ', $warnings),
+            ];
+            return;
+        }
+
+        $checks[] = [
+            'Check',
+            'APP_KEY and POS config',
+            'PASS',
+            'Both configured',
+        ];
+    }
+
+    private function printTable(array $checks): void
+    {
+        // Headers
+        $headers = ['Check', 'Description', 'Status', 'Detail'];
+
+        // Format rows: status determines color/symbol
+        $rows = [];
+        foreach ($checks as $check) {
+            $rows[] = [
+                $check[0],
+                $check[1],
+                $check[2],
+                $check[3],
+            ];
+        }
+
+        $this->table($headers, $rows);
+    }
+}

--- a/app/Http/Controllers/Api/HealthController.php
+++ b/app/Http/Controllers/Api/HealthController.php
@@ -55,6 +55,17 @@ class HealthController
             $health['services']['queue'] = ['status' => 'unknown', 'error' => $e->getMessage()];
         }
 
+        // Check broadcasting configuration integrity
+        try {
+            $broadcastingStatus = $this->checkBroadcastingIntegrity();
+            $health['services']['broadcasting'] = $broadcastingStatus;
+            if (!$broadcastingStatus['consistent']) {
+                $health['status'] = 'degraded';
+            }
+        } catch (\Exception $e) {
+            $health['services']['broadcasting'] = ['status' => 'unknown', 'error' => $e->getMessage()];
+        }
+
         // Determine HTTP status code
         $httpStatus = match ($health['status']) {
             'ok' => 200,
@@ -63,5 +74,84 @@ class HealthController
         };
 
         return response()->json($health, $httpStatus);
+    }
+
+    /**
+     * Check Reverb configuration consistency
+     *
+     * @return array
+     */
+    private function checkBroadcastingIntegrity(): array
+    {
+        $driver = config('broadcasting.default');
+
+        if ($driver !== 'reverb') {
+            return [
+                'driver' => $driver,
+                'consistent' => false,
+            ];
+        }
+
+        $reverbApps = config('reverb.apps.apps');
+        if (!is_array($reverbApps) || count($reverbApps) === 0) {
+            return [
+                'driver' => 'reverb',
+                'consistent' => false,
+            ];
+        }
+
+        $reverbApp = $reverbApps[0];
+        $broadcastingReverb = config('broadcasting.connections.reverb');
+
+        $reverbKey = trim((string) ($reverbApp['key'] ?? ''));
+        $reverbSecret = trim((string) ($reverbApp['secret'] ?? ''));
+        $reverbId = trim((string) ($reverbApp['app_id'] ?? ''));
+
+        $broadcastKey = trim((string) ($broadcastingReverb['key'] ?? ''));
+        $broadcastSecret = trim((string) ($broadcastingReverb['secret'] ?? ''));
+        $broadcastId = trim((string) ($broadcastingReverb['app_id'] ?? ''));
+
+        $consistent = $reverbKey === $broadcastKey
+            && $reverbSecret === $broadcastSecret
+            && $reverbId === $broadcastId
+            && trim((string) env('REVERB_APP_KEY')) === $reverbKey
+            && trim((string) env('REVERB_APP_ID')) === $reverbId
+            && trim((string) env('REVERB_APP_SECRET')) === $reverbSecret;
+
+        $host = trim((string) config('broadcasting.connections.reverb.options.host', ''));
+        $port = (int) config('broadcasting.connections.reverb.options.port', 8080);
+        $scheme = trim((string) config('broadcasting.connections.reverb.options.scheme', 'https'));
+
+        // Create a fingerprint of the key (redacted)
+        $keyFingerprint = $this->createKeyFingerprint($reverbKey);
+
+        return [
+            'driver' => $driver,
+            'key_fingerprint' => $keyFingerprint,
+            'host' => $host,
+            'port' => $port,
+            'scheme' => $scheme,
+            'consistent' => $consistent,
+        ];
+    }
+
+    /**
+     * Create a redacted fingerprint of the key
+     *
+     * @param string $key
+     * @return string
+     */
+    private function createKeyFingerprint(string $key): string
+    {
+        $key = trim($key);
+        if ($key === '') {
+            return 'none';
+        }
+
+        $first4 = substr($key, 0, 4);
+        $length = strlen($key);
+        $shaPrefix = substr(hash('sha256', $key), 0, 8);
+
+        return "{$first4}...({$length}b, sha256:{$shaPrefix})";
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -229,7 +229,7 @@ Route::prefix('v1')->middleware(['auth:device'])->group(function () {
 });
 
 // Admin/device-reset endpoint (requires auth)
-Route::middleware(['requestId','auth:sanctum'])->group(function () {
+Route::middleware(['requestId', 'auth:sanctum'])->group(function () {
     Route::post('/sessions/{id}/reset', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'reset'])->name('api.sessions.reset');
 });
 
@@ -296,6 +296,35 @@ Route::get('/health', function () {
         $services['redis'] = false;
     }
 
+    // Broadcasting integrity check
+    try {
+        $driver = config('broadcasting.default');
+        $reverbApps = config('reverb.apps.apps');
+        $reverbApp = is_array($reverbApps) && count($reverbApps) > 0 ? $reverbApps[0] : null;
+        $broadcastingReverb = config('broadcasting.connections.reverb');
+
+        if ($driver !== 'reverb' || $reverbApp === null) {
+            $broadcastingStatus = ['driver' => $driver, 'consistent' => false];
+        } else {
+            $reverbKey = trim((string) ($reverbApp['key'] ?? ''));
+            $consistent = $reverbKey === trim((string) ($broadcastingReverb['key'] ?? ''))
+                && trim((string) ($reverbApp['secret'] ?? '')) === trim((string) ($broadcastingReverb['secret'] ?? ''))
+                && trim((string) ($reverbApp['app_id'] ?? '')) === trim((string) ($broadcastingReverb['app_id'] ?? ''));
+            $first4 = substr($reverbKey, 0, 4);
+            $broadcastingStatus = [
+                'driver'          => $driver,
+                'key_fingerprint' => $reverbKey !== '' ? "{$first4}...(" . strlen($reverbKey) . "b, sha256:" . substr(hash('sha256', $reverbKey), 0, 8) . ")" : 'none',
+                'host'            => trim((string) config('broadcasting.connections.reverb.options.host', '')),
+                'port'            => (int) config('broadcasting.connections.reverb.options.port', 8080),
+                'scheme'          => trim((string) config('broadcasting.connections.reverb.options.scheme', 'https')),
+                'consistent'      => $consistent,
+            ];
+        }
+        $services['broadcasting'] = $broadcastingStatus;
+    } catch (\Throwable $e) {
+        $services['broadcasting'] = ['driver' => 'unknown', 'consistent' => false];
+    }
+
     // Queue depth — size() on the default queue connection
     $queueDepth = null;
     try {
@@ -307,9 +336,11 @@ Route::get('/health', function () {
     // Determine overall status
     $coreHealthy = $services['mysql'];
     $fullyHealthy = $coreHealthy && $services['redis'];
+    $broadcastingConsistent = $services['broadcasting']['consistent'] ?? true;
+    
     $overallStatus = match (true) {
         !$coreHealthy => 'down',
-        !$fullyHealthy => 'degraded',
+        (!$fullyHealthy || !$broadcastingConsistent) => 'degraded',
         default => 'ok',
     };
 

--- a/tests/Feature/HealthBroadcastingTest.php
+++ b/tests/Feature/HealthBroadcastingTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * Plan E — /api/health broadcasting integrity block.
+ *
+ * The route in routes/api.php calls checkBroadcastingIntegrity() which
+ * compares config('reverb.apps.apps.0') against
+ * config('broadcasting.connections.reverb') and returns a non-secret
+ * block with key_fingerprint + consistent flag.
+ */
+class HealthBroadcastingTest extends TestCase
+{
+    private function setConsistentBroadcastConfig(
+        string $key = 'testkey12345',
+        string $secret = 'testsecret12345',
+        string $appId = '999001',
+        string $host = '127.0.0.1',
+        int $port = 6001,
+        string $scheme = 'http',
+    ): void {
+        Config::set('broadcasting.default', 'reverb');
+
+        Config::set('reverb.apps.apps', [[
+            'key'     => $key,
+            'secret'  => $secret,
+            'app_id'  => $appId,
+            'options' => [
+                'host'   => $host,
+                'port'   => $port,
+                'scheme' => $scheme,
+                'useTLS' => false,
+            ],
+            'allowed_origins' => ['*'],
+        ]]);
+
+        Config::set('broadcasting.connections.reverb', [
+            'driver' => 'reverb',
+            'key'    => $key,
+            'secret' => $secret,
+            'app_id' => $appId,
+            'options' => [
+                'host'   => $host,
+                'port'   => $port,
+                'scheme' => $scheme,
+                'useTLS' => false,
+            ],
+        ]);
+    }
+
+    public function test_broadcasting_block_present_when_configs_consistent(): void
+    {
+        $this->setConsistentBroadcastConfig();
+
+        $response = $this->getJson('/api/health');
+
+        $response->assertJsonPath('data.services.broadcasting.consistent', true);
+        $response->assertJsonStructure([
+            'data' => [
+                'services' => [
+                    'broadcasting' => ['driver', 'key_fingerprint', 'host', 'port', 'scheme', 'consistent'],
+                ],
+            ],
+        ]);
+    }
+
+    public function test_consistent_true_does_not_degrade_overall_status(): void
+    {
+        $this->setConsistentBroadcastConfig();
+
+        $response = $this->getJson('/api/health');
+
+        // Broadcasting alone should not push status to degraded
+        $broadcastingConsistent = $response->json('data.services.broadcasting.consistent');
+        $this->assertTrue($broadcastingConsistent);
+    }
+
+    public function test_key_fingerprint_is_redacted_not_raw(): void
+    {
+        $rawKey = 'supersecretreverbkey9999';
+        $this->setConsistentBroadcastConfig(key: $rawKey);
+
+        $response = $this->getJson('/api/health');
+
+        $responseBody = $response->getContent();
+        $fingerprint = $response->json('data.services.broadcasting.key_fingerprint');
+
+        // Fingerprint must be set
+        $this->assertNotNull($fingerprint);
+        $this->assertNotEmpty($fingerprint);
+
+        // Raw key must NOT appear verbatim in the full response body
+        $this->assertStringNotContainsString($rawKey, $responseBody);
+
+        // Fingerprint must follow redacted format: {first4}...({len}b, sha256:{8-hex})
+        $this->assertMatchesRegularExpression(
+            '/^.{1,4}\.{3}\(\d+b, sha256:[0-9a-f]{8}\)$/',
+            $fingerprint,
+        );
+    }
+
+    public function test_raw_secret_never_appears_in_response(): void
+    {
+        $rawSecret = 'uniqueTestSecretValue9876';
+        $this->setConsistentBroadcastConfig(secret: $rawSecret);
+
+        $response = $this->getJson('/api/health');
+
+        $responseBody = $response->getContent();
+        $this->assertStringNotContainsString($rawSecret, $responseBody);
+    }
+
+    public function test_inconsistent_keys_sets_consistent_false(): void
+    {
+        $this->setConsistentBroadcastConfig();
+
+        // Diverge the broadcasting connection key from the reverb app key
+        Config::set('broadcasting.connections.reverb.key', 'totally-different-key');
+
+        $response = $this->getJson('/api/health');
+
+        $response->assertJsonPath('data.services.broadcasting.consistent', false);
+    }
+
+    public function test_inconsistent_config_sets_overall_status_degraded(): void
+    {
+        $this->setConsistentBroadcastConfig();
+        Config::set('broadcasting.connections.reverb.key', 'mismatched-key');
+
+        $response = $this->getJson('/api/health');
+
+        $this->assertContains(
+            $response->json('data.status'),
+            ['degraded', 'down'],
+        );
+    }
+}

--- a/tests/Feature/VerifyIntegrityCommandTest.php
+++ b/tests/Feature/VerifyIntegrityCommandTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+/**
+ * Plan E — woosoo:verify-integrity command.
+ *
+ * The command uses both env() and config() so test cases rely on .env.testing
+ * having REVERB_APP_KEY=key / REVERB_APP_SECRET=secret / REVERB_APP_ID=290838
+ * and manipulate config() values via Config::set to exercise each check.
+ */
+class VerifyIntegrityCommandTest extends TestCase
+{
+    private function setConsistentConfig(
+        string $key = 'key',
+        string $secret = 'secret',
+        string $appId = '290838',
+    ): void {
+        Config::set('broadcasting.default', 'reverb');
+        Config::set('reverb.apps.apps', [[
+            'key'    => $key,
+            'secret' => $secret,
+            'app_id' => $appId,
+        ]]);
+        Config::set('broadcasting.connections.reverb', [
+            'key'    => $key,
+            'secret' => $secret,
+            'app_id' => $appId,
+            'options' => ['host' => '127.0.0.1', 'port' => 6001, 'scheme' => 'http'],
+        ]);
+        Config::set('reverb.apps.apps.0.key', $key);
+        Config::set('reverb.apps.apps.0.app_id', $appId);
+        Config::set('reverb.apps.apps.0.secret', $secret);
+    }
+
+    /**
+     * All checks consistent with .env.testing values → exit 0.
+     * (.env.testing: REVERB_APP_KEY=key, REVERB_APP_SECRET=secret, REVERB_APP_ID=290838)
+     */
+    public function test_all_consistent_exits_zero(): void
+    {
+        $this->setConsistentConfig();
+
+        $this->artisan('woosoo:verify-integrity')->assertExitCode(0);
+    }
+
+    /**
+     * Check #3 FAIL: reverb.apps key diverges from broadcasting.connections.reverb key.
+     */
+    public function test_reverb_apps_vs_broadcasting_key_mismatch_exits_one(): void
+    {
+        $this->setConsistentConfig();
+
+        // Diverge broadcasting connection key from reverb app key
+        Config::set('broadcasting.connections.reverb.key', 'mismatched-broadcast-key');
+
+        $this->artisan('woosoo:verify-integrity')->assertExitCode(1);
+    }
+
+    /**
+     * Check #3 FAIL: app_id mismatch.
+     */
+    public function test_reverb_apps_vs_broadcasting_app_id_mismatch_exits_one(): void
+    {
+        $this->setConsistentConfig();
+        Config::set('broadcasting.connections.reverb.app_id', '000000');
+
+        $this->artisan('woosoo:verify-integrity')->assertExitCode(1);
+    }
+
+    /**
+     * Check #4 FAIL: config key differs from env key (stale config cache simulation).
+     * env('REVERB_APP_KEY') = 'key' from .env.testing;
+     * setting config to a different value triggers FAIL.
+     */
+    public function test_env_vs_config_key_divergence_exits_one(): void
+    {
+        $this->setConsistentConfig();
+
+        // Overwrite config key so it differs from env('REVERB_APP_KEY') = 'key'
+        Config::set('reverb.apps.apps', [[
+            'key'    => 'config-cached-different-key',
+            'secret' => 'secret',
+            'app_id' => '290838',
+        ]]);
+        Config::set('broadcasting.connections.reverb.key', 'config-cached-different-key');
+
+        $this->artisan('woosoo:verify-integrity')->assertExitCode(1);
+    }
+
+    /**
+     * Check #2 FAIL: broadcasting driver resolved to null-string.
+     */
+    public function test_broadcast_driver_null_string_exits_one(): void
+    {
+        $this->setConsistentConfig();
+        Config::set('broadcasting.default', 'null');
+
+        $this->artisan('woosoo:verify-integrity')->assertExitCode(1);
+    }
+
+    /**
+     * Redaction: command output must never contain the raw secret value.
+     * Uses a unique secret to ensure the assertion is meaningful.
+     */
+    public function test_command_output_never_contains_raw_secret(): void
+    {
+        // Use a distinctive secret that won't appear as a field name
+        $rawSecret = 'xS3cR3t-UniqueTestValue-42';
+        $this->setConsistentConfig(secret: $rawSecret);
+
+        // Capture artisan output
+        $output = '';
+        $this->artisan('woosoo:verify-integrity')
+            ->expectsOutputToContain('PASS');
+
+        // Re-run capturing output explicitly via Artisan facade
+        \Illuminate\Support\Facades\Artisan::call('woosoo:verify-integrity');
+        $output = \Illuminate\Support\Facades\Artisan::output();
+
+        $this->assertStringNotContainsString($rawSecret, $output);
+    }
+}


### PR DESCRIPTION
- /api/health: adds broadcasting key/config consistency check to service map; overall status degrades when Reverb key/secret/app_id mismatch
- HealthController: private checkBroadcastingIntegrity() + createKeyFingerprint() methods (instance scope, not global functions)
- routes/api.php health closure: inline broadcasting check (no global function pollution); requestId middleware restored on session reset route
- VerifyIntegrityCommand: artisan woosoo:verify-integrity command
- SessionApiController: use imported Device alias (no FQCN)
- Tests: HealthBroadcastingTest, VerifyIntegrityCommandTest

## Summary

Describe the change briefly.

## Documentation governance checks

- [ ] This PR does not introduce duplicate canonical guidance.
- [ ] This PR does not introduce a second production deployment flow.
- [ ] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [ ] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [ ] `docs/INDEX.md` was updated if canonical docs changed.
