### PR TITLE
feat(nexus): POS payment outbox consumer, fix SessionReset scope, dev…

### DIFF
--- a/app/Console/Commands/ConsumePosPaymentStatusEvents.php
+++ b/app/Console/Commands/ConsumePosPaymentStatusEvents.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\OrderStatus;
+use App\Events\SessionReset;
+use App\Services\Pos\PosOrderStatusFinalizer;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class ConsumePosPaymentStatusEvents extends Command
+{
+    private const OrderOutboxTable = 'woosoo_order_status_outbox';
+
+    private const SessionOutboxTable = 'woosoo_session_status_outbox';
+
+    private const MaxAttempts = 5;
+
+    protected $signature = 'pos:consume-payment-status-events {--limit=100 : Maximum POS outbox rows processed per outbox per run}';
+
+    protected $description = 'Consume POS-local order payment and daily session-close outbox rows.';
+
+    public function handle(PosOrderStatusFinalizer $finalizer): int
+    {
+        $limit = max(1, (int) $this->option('limit'));
+        $processedOrders = 0;
+        $failedOrders = 0;
+        $processedSessions = 0;
+        $failedSessions = 0;
+
+        [$processedOrders, $failedOrders] = $this->consumeOrderRows($finalizer, $limit);
+        [$processedSessions, $failedSessions] = $this->consumeSessionRows($limit);
+
+        $failed = $failedOrders + $failedSessions;
+
+        Log::info('[POS Outbox] Status events consumed', [
+            'processed_orders' => $processedOrders,
+            'failed_orders' => $failedOrders,
+            'processed_sessions' => $processedSessions,
+            'failed_sessions' => $failedSessions,
+            'limit' => $limit,
+        ]);
+
+        $this->info(
+            "POS outbox consumed: orders={$processedOrders}, sessions={$processedSessions}, failed={$failed}, limit={$limit}"
+        );
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function consumeOrderRows(PosOrderStatusFinalizer $finalizer, int $limit): array
+    {
+        try {
+            $rows = DB::connection('pos')
+                ->table(self::OrderOutboxTable)
+                ->whereNull('processed_at')
+                ->whereNull('failed_at')
+                ->where('attempts', '<', self::MaxAttempts)
+                ->orderBy('id')
+                ->limit($limit)
+                ->get();
+        } catch (\Throwable $e) {
+            Log::warning('[POS Outbox] Unable to read payment status outbox', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->warn("Unable to read POS payment status outbox: {$e->getMessage()}");
+
+            return [0, 1];
+        }
+
+        $processed = 0;
+        $failed = 0;
+
+        foreach ($rows as $row) {
+            try {
+                $targetStatus = OrderStatus::from((string) $row->target_status);
+
+                if (! in_array($targetStatus, [OrderStatus::COMPLETED, OrderStatus::VOIDED], true)) {
+                    throw new \InvalidArgumentException("Unsupported target_status [{$row->target_status}].");
+                }
+
+                $finalizer->finalizeByPosOrderId(
+                    (int) $row->pos_order_id,
+                    $targetStatus,
+                    'system:pos-outbox'
+                );
+
+                DB::connection('pos')
+                    ->table(self::OrderOutboxTable)
+                    ->where('id', (int) $row->id)
+                    ->update([
+                        'processed_at' => now(),
+                        'last_error' => null,
+                        'updated_at' => now(),
+                    ]);
+
+                $processed++;
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->recordFailure(self::OrderOutboxTable, $row, $e, [
+                    'pos_order_id' => $row->pos_order_id ?? null,
+                ]);
+            }
+        }
+
+        return [$processed, $failed];
+    }
+
+    private function consumeSessionRows(int $limit): array
+    {
+        try {
+            $rows = DB::connection('pos')
+                ->table(self::SessionOutboxTable)
+                ->whereNull('processed_at')
+                ->whereNull('failed_at')
+                ->where('attempts', '<', self::MaxAttempts)
+                ->orderBy('id')
+                ->limit($limit)
+                ->get();
+        } catch (\Throwable $e) {
+            Log::warning('[POS Outbox] Unable to read session status outbox', [
+                'error' => $e->getMessage(),
+            ]);
+            $this->warn("Unable to read POS session status outbox: {$e->getMessage()}");
+
+            return [0, 1];
+        }
+
+        $processed = 0;
+        $failed = 0;
+
+        foreach ($rows as $row) {
+            try {
+                if ((string) $row->event_type !== 'closed') {
+                    throw new \InvalidArgumentException("Unsupported event_type [{$row->event_type}].");
+                }
+
+                $sessionId = (int) $row->pos_session_id;
+                $version = (int) Cache::increment("session:{$sessionId}:version");
+
+                SessionReset::dispatch($sessionId, $version);
+
+                DB::connection('pos')
+                    ->table(self::SessionOutboxTable)
+                    ->where('id', (int) $row->id)
+                    ->update([
+                        'processed_at' => now(),
+                        'last_error' => null,
+                        'updated_at' => now(),
+                    ]);
+
+                $processed++;
+            } catch (\Throwable $e) {
+                $failed++;
+                $this->recordFailure(self::SessionOutboxTable, $row, $e, [
+                    'pos_session_id' => $row->pos_session_id ?? null,
+                ]);
+            }
+        }
+
+        return [$processed, $failed];
+    }
+
+    private function recordFailure(string $table, object $row, \Throwable $e, array $context): void
+    {
+        $attempts = (int) ($row->attempts ?? 0) + 1;
+        $updates = [
+            'attempts' => $attempts,
+            'last_error' => $e->getMessage(),
+            'updated_at' => now(),
+        ];
+
+        if ($attempts >= self::MaxAttempts) {
+            $updates['failed_at'] = now();
+        }
+
+        DB::connection('pos')
+            ->table($table)
+            ->where('id', (int) $row->id)
+            ->update($updates);
+
+        Log::warning('[POS Outbox] Event failed', [
+            'table' => $table,
+            'outbox_id' => $row->id ?? null,
+            'attempts' => $attempts,
+            'failed' => $attempts >= self::MaxAttempts,
+            'error' => $e->getMessage(),
+        ] + $context);
+    }
+}

--- a/app/Console/Commands/SetupPosOrderPaymentTrigger.php
+++ b/app/Console/Commands/SetupPosOrderPaymentTrigger.php
@@ -3,59 +3,36 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class SetupPosOrderPaymentTrigger extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
+    private const OrderOutboxTable = 'woosoo_order_status_outbox';
+
+    private const SessionOutboxTable = 'woosoo_session_status_outbox';
+
     protected $signature = 'pos:setup-payment-trigger';
 
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
-    protected $description = 'Creates a trigger on orders table in the POS database to update device_orders';
+    protected $description = 'Creates a POS-local payment status outbox and trigger for Nexus reconciliation.';
 
-    /**
-     * Execute the console command.
-     */
     public function handle(): int
     {
-        // POS DB connection (trigger will be created here)
         $connection = DB::connection('pos');
+        $this->createOrderOutboxTable();
+        $this->createSessionOutboxTable();
 
-        // MySQL trigger body can only access tables on the same MySQL server instance.
-        // When app DB and POS DB are on different hosts/ports (e.g., Docker + external POS),
-        // cross-server table updates are impossible from a trigger.
-        if (! $this->isSameMysqlEndpoint()) {
-            $connection->unprepared('DROP TRIGGER IF EXISTS after_payment_update');
+        $connection->unprepared('DROP TRIGGER IF EXISTS after_payment_update');
+        $connection->unprepared('DROP TRIGGER IF EXISTS after_session_close_update');
 
-            $this->error('Cannot create after_payment_update trigger: POS and app databases are on different MySQL endpoints.');
-            $this->line('MySQL triggers cannot update tables on another server/port.');
-            $this->newLine();
-            $this->line('POS endpoint: ' . $this->describeConnectionEndpoint('pos'));
-            $this->line('APP endpoint: ' . $this->describeConnectionEndpoint('mysql'));
-            $this->newLine();
-            $this->line('Action required: use an application-level sync flow for payment status reconciliation.');
-            $this->line('This project now provides: php artisan pos:sync-payment-statuses');
+        if ($connection->getDriverName() !== 'mysql') {
+            $this->info('POS outbox tables created. Trigger creation skipped for non-MySQL POS connection.');
 
-            return self::FAILURE;
+            return self::SUCCESS;
         }
 
-        // App DB (where device_orders lives)
-        $appDb = DB::connection('mysql')->getDatabaseName();
-        $appDbEscaped = str_replace('`', '', $appDb);
-        $fqDeviceOrdersTable = "`{$appDbEscaped}`.`device_orders`";
-
-        // Drop any existing trigger and create a new one that updates device_orders directly
-        $connection->unprepared("DROP TRIGGER IF EXISTS after_payment_update");
-
-        $triggerSql = <<<SQL
+        $orderTriggerSql = <<<'SQL'
         CREATE TRIGGER after_payment_update
         AFTER UPDATE ON `orders`
         FOR EACH ROW
@@ -65,61 +42,127 @@ class SetupPosOrderPaymentTrigger extends Command
               OR NEW.is_voided = 1
               OR (OLD.is_open = 1 AND NEW.is_open = 0)) THEN
 
-            -- Determine the new status for device_orders
-            SET @new_status = CASE 
+            INSERT INTO `woosoo_order_status_outbox` (
+                `pos_order_id`,
+                `target_status`,
+                `is_voided`,
+                `is_open`,
+                `date_time_closed`,
+                `created_at`,
+                `updated_at`
+            ) VALUES (
+                CAST(NEW.id AS UNSIGNED),
+                CASE
                 WHEN NEW.is_voided = 1 THEN 'voided'
                 ELSE 'completed'
-            END;
-
-            -- Directly update device_orders table (cross-database)
-            UPDATE {$fqDeviceOrdersTable}
-            SET 
-                status = @new_status,
-                updated_at = NOW()
-            WHERE order_id = NEW.id;
+                END,
+                NEW.is_voided,
+                NEW.is_open,
+                NEW.date_time_closed,
+                NOW(),
+                NOW()
+            )
+            ON DUPLICATE KEY UPDATE
+                `target_status` = IF(`processed_at` IS NULL, VALUES(`target_status`), `target_status`),
+                `is_voided` = VALUES(`is_voided`),
+                `is_open` = VALUES(`is_open`),
+                `date_time_closed` = VALUES(`date_time_closed`),
+                `last_error` = IF(`processed_at` IS NULL, NULL, `last_error`),
+                `failed_at` = IF(`processed_at` IS NULL, NULL, `failed_at`),
+                `updated_at` = NOW();
 
           END IF;
         END;
         SQL;
 
-        $connection->unprepared($triggerSql);
+        $sessionTriggerSql = <<<'SQL'
+        CREATE TRIGGER after_session_close_update
+        AFTER UPDATE ON `sessions`
+        FOR EACH ROW
+        BEGIN
+          -- Daily POS cashier-session close is restaurant-wide; keep it separate from per-order completion.
+          IF (OLD.date_time_closed IS NULL AND NEW.date_time_closed IS NOT NULL) THEN
 
-        $this->info('Trigger "after_payment_update" created successfully.');
-        $this->info('The trigger will now directly update device_orders status when orders are paid/voided.');
+            INSERT INTO `woosoo_session_status_outbox` (
+                `pos_session_id`,
+                `event_type`,
+                `date_time_closed`,
+                `created_at`,
+                `updated_at`
+            ) VALUES (
+                CAST(NEW.id AS UNSIGNED),
+                'closed',
+                NEW.date_time_closed,
+                NOW(),
+                NOW()
+            )
+            ON DUPLICATE KEY UPDATE
+                `event_type` = IF(`processed_at` IS NULL, VALUES(`event_type`), `event_type`),
+                `date_time_closed` = VALUES(`date_time_closed`),
+                `last_error` = IF(`processed_at` IS NULL, NULL, `last_error`),
+                `failed_at` = IF(`processed_at` IS NULL, NULL, `failed_at`),
+                `updated_at` = NOW();
+
+          END IF;
+        END;
+        SQL;
+
+        $connection->unprepared($orderTriggerSql);
+        $connection->unprepared($sessionTriggerSql);
+
+        $this->info('POS order payment and session-close outbox tables/triggers created successfully.');
+        $this->info('Nexus will consume the POS-local outbox via php artisan pos:consume-payment-status-events.');
 
         return self::SUCCESS;
     }
 
-    private function isSameMysqlEndpoint(): bool
+    private function createOrderOutboxTable(): void
     {
-        $pos = config('database.connections.pos', []);
-        $app = config('database.connections.mysql', []);
+        $schema = Schema::connection('pos');
 
-        $keys = ['host', 'port', 'unix_socket'];
-
-        foreach ($keys as $key) {
-            $left = (string) ($pos[$key] ?? '');
-            $right = (string) ($app[$key] ?? '');
-
-            if ($left !== $right) {
-                return false;
-            }
+        if ($schema->hasTable(self::OrderOutboxTable)) {
+            return;
         }
 
-        return true;
+        $schema->create(self::OrderOutboxTable, function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('pos_order_id');
+            $table->string('target_status', 32);
+            $table->boolean('is_voided')->nullable();
+            $table->boolean('is_open')->nullable();
+            $table->dateTime('date_time_closed')->nullable();
+            $table->unsignedInteger('attempts')->default(0);
+            $table->text('last_error')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('pos_order_id', 'woosoo_outbox_pos_order_unique');
+            $table->index(['processed_at', 'failed_at', 'attempts'], 'woosoo_outbox_consume_idx');
+        });
     }
 
-    private function describeConnectionEndpoint(string $connection): string
+    private function createSessionOutboxTable(): void
     {
-        $config = config("database.connections.{$connection}", []);
-        $host = (string) ($config['host'] ?? '');
-        $port = (string) ($config['port'] ?? '');
-        $socket = (string) ($config['unix_socket'] ?? '');
+        $schema = Schema::connection('pos');
 
-        if ($socket !== '') {
-            return sprintf('%s (socket: %s)', $connection, $socket);
+        if ($schema->hasTable(self::SessionOutboxTable)) {
+            return;
         }
 
-        return sprintf('%s (%s:%s)', $connection, $host !== '' ? $host : 'unknown-host', $port !== '' ? $port : 'unknown-port');
+        $schema->create(self::SessionOutboxTable, function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('pos_session_id');
+            $table->string('event_type', 32);
+            $table->dateTime('date_time_closed')->nullable();
+            $table->unsignedInteger('attempts')->default(0);
+            $table->text('last_error')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('pos_session_id', 'woosoo_outbox_pos_session_unique');
+            $table->index(['processed_at', 'failed_at', 'attempts'], 'woosoo_session_outbox_consume_idx');
+        });
     }
 }

--- a/app/Console/Commands/SyncPosOrderPaymentStatus.php
+++ b/app/Console/Commands/SyncPosOrderPaymentStatus.php
@@ -2,14 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Enums\OrderStatus;
-use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderStatusUpdated;
-use App\Events\Order\OrderVoided;
-use App\Events\Order\PaymentCompleted;
-use App\Events\SessionReset;
-use App\Models\DeviceOrder;
-use App\Services\AuditLogService;
+use App\Services\Pos\PosOrderStatusFinalizer;
 use Illuminate\Console\Command;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
@@ -21,22 +14,16 @@ class SyncPosOrderPaymentStatus extends Command
 
     protected $description = 'Synchronize paid/voided POS orders into local device_orders for split-database deployments.';
 
-    public function handle(): int
+    public function handle(PosOrderStatusFinalizer $finalizer): int
     {
         $chunkSize = max(1, (int) $this->option('chunk'));
         $totalChecked = 0;
         $totalUpdated = 0;
 
-        $openStatuses = [
-            OrderStatus::PENDING->value,
-            OrderStatus::CONFIRMED->value,
-            OrderStatus::IN_PROGRESS->value,
-            OrderStatus::READY->value,
-            OrderStatus::SERVED->value,
-        ];
+        $openStatuses = PosOrderStatusFinalizer::OPEN_STATUSES;
 
         /** @var ConnectionInterface $local */
-        $local = DB::connection('mysql');
+        $local = DB::connection();
         /** @var ConnectionInterface $pos */
         $pos = DB::connection('pos');
 
@@ -63,7 +50,7 @@ class SyncPosOrderPaymentStatus extends Command
             ->whereNotNull('order_id')
             ->whereIn('status', $openStatuses)
             ->orderBy('id')
-            ->chunkById($chunkSize, function ($rows) use (&$totalChecked, &$totalUpdated, $pos, $local): void {
+            ->chunkById($chunkSize, function ($rows) use (&$totalChecked, &$totalUpdated, $pos, $finalizer): void {
                 $totalChecked += $rows->count();
 
                 $posOrderIds = $rows
@@ -99,59 +86,18 @@ class SyncPosOrderPaymentStatus extends Command
                         continue;
                     }
 
-                    $nextStatus = ((int) ($posOrder->is_voided ?? 0) === 1)
-                        ? OrderStatus::VOIDED
-                        : OrderStatus::COMPLETED;
+                    $nextStatus = PosOrderStatusFinalizer::terminalStatusFromPosOrder($posOrder);
 
-                    if ((string) $row->status === $nextStatus->value) {
+                    if (! $nextStatus || (string) $row->status === $nextStatus->value) {
                         continue;
                     }
 
-                    $updated = $local
-                        ->table('device_orders')
-                        ->where('id', (int) $row->id)
-                        ->update([
-                            'status' => $nextStatus->value,
-                            'updated_at' => now(),
-                        ]);
-
-                    if ($updated === 0) {
-                        continue;
-                    }
-
-                    $totalUpdated++;
-
-                    AuditLogService::orderStatusChanged(
-                        null,
+                    if ($finalizer->finalizeDeviceOrderId(
                         (int) $row->id,
-                        (string) $row->status,
-                        $nextStatus->value,
-                        null,
-                        'system'
-                    );
-
-                    $deviceOrder = DeviceOrder::query()->find((int) $row->id);
-                    if (! $deviceOrder) {
-                        continue;
-                    }
-
-                    // This update path bypasses Eloquent mutators/observers intentionally,
-                    // so we manually emit the real-time events expected by tablet/admin clients.
-                    OrderStatusUpdated::dispatch($deviceOrder);
-
-                    if ($nextStatus === OrderStatus::COMPLETED) {
-                        OrderCompleted::dispatch($deviceOrder);
-                        PaymentCompleted::dispatch($deviceOrder);
-                    }
-
-                    if ($nextStatus === OrderStatus::VOIDED) {
-                        OrderVoided::dispatch($deviceOrder);
-                    }
-
-                    // Broadcast session.reset on the session channel so the tablet
-                    // ends the session immediately without relying on order-ID matching.
-                    if ($deviceOrder->session_id) {
-                        SessionReset::dispatch((int) $deviceOrder->session_id);
+                        $nextStatus,
+                        'system:pos-sync'
+                    )) {
+                        $totalUpdated++;
                     }
                 }
             }, 'id');

--- a/app/Console/Commands/SyncPosOrderPaymentStatus.php
+++ b/app/Console/Commands/SyncPosOrderPaymentStatus.php
@@ -36,12 +36,12 @@ class SyncPosOrderPaymentStatus extends Command
         try {
             $pos->getPdo();
         } catch (\Throwable $e) {
-            Log::info('[pos:sync-payment-statuses] POS DB unreachable — skipping this tick', [
+            Log::warning('[pos:sync-payment-statuses] POS DB unreachable — skipping this tick', [
                 'error' => $e->getMessage(),
             ]);
-            $this->info('POS DB unreachable. Skipping sync.');
+            $this->warn('POS DB unreachable. Skipping sync.');
 
-            return self::SUCCESS;
+            return self::FAILURE;
         }
 
         $local

--- a/app/Http/Middleware/UpdateDeviceLastSeen.php
+++ b/app/Http/Middleware/UpdateDeviceLastSeen.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Device;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateDeviceLastSeen
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($request->is('api/printer/heartbeat')) {
+            return $response;
+        }
+
+        $device = $request->user();
+        if (! $device instanceof Device) {
+            return $response;
+        }
+
+        $ttl = max(1, (int) config('devices.last_seen_write_throttle_seconds', 30));
+        $seenRecently = $device->last_seen_at?->gt(now()->subSeconds($ttl)) ?? false;
+
+        if ($seenRecently) {
+            return $response;
+        }
+
+        try {
+            $device->forceFill(['last_seen_at' => now()])->save();
+        } catch (\Throwable $e) {
+            Log::warning('[DeviceLastSeen] Failed to update device last_seen_at', [
+                'device_id' => $device->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $response;
+    }
+}

--- a/app/Services/Pos/PosOrderStatusFinalizer.php
+++ b/app/Services/Pos/PosOrderStatusFinalizer.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Services\Pos;
+
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderStatusUpdated;
+use App\Events\Order\OrderVoided;
+use App\Events\Order\PaymentCompleted;
+use App\Models\DeviceOrder;
+use App\Services\AuditLogService;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class PosOrderStatusFinalizer
+{
+    public const OPEN_STATUSES = [
+        OrderStatus::PENDING->value,
+        OrderStatus::CONFIRMED->value,
+        OrderStatus::IN_PROGRESS->value,
+        OrderStatus::READY->value,
+        OrderStatus::SERVED->value,
+    ];
+
+    public function finalizeByPosOrderId(
+        int $posOrderId,
+        OrderStatus $targetStatus,
+        string $actorType = 'system'
+    ): bool {
+        return DB::transaction(function () use ($posOrderId, $targetStatus, $actorType): bool {
+            return $this->finalizeMatchingOrder(
+                DB::table('device_orders')
+                    ->select(['id', 'status'])
+                    ->where('order_id', $posOrderId)
+                    ->orderBy('id'),
+                $targetStatus,
+                $actorType
+            );
+        });
+    }
+
+    public function finalizeDeviceOrderId(
+        int $deviceOrderId,
+        OrderStatus $targetStatus,
+        string $actorType = 'system'
+    ): bool {
+        return DB::transaction(function () use ($deviceOrderId, $targetStatus, $actorType): bool {
+            return $this->finalizeMatchingOrder(
+                DB::table('device_orders')
+                    ->select(['id', 'status'])
+                    ->where('id', $deviceOrderId),
+                $targetStatus,
+                $actorType
+            );
+        });
+    }
+
+    public static function terminalStatusFromPosOrder(object $posOrder): ?OrderStatus
+    {
+        if ((int) ($posOrder->is_voided ?? 0) === 1) {
+            return OrderStatus::VOIDED;
+        }
+
+        if ((int) ($posOrder->is_open ?? 1) === 0 || $posOrder->date_time_closed !== null) {
+            return OrderStatus::COMPLETED;
+        }
+
+        return null;
+    }
+
+    private function dispatchTerminalEvents(DeviceOrder $deviceOrder, OrderStatus $targetStatus): void
+    {
+        OrderStatusUpdated::dispatch($deviceOrder);
+
+        if ($targetStatus === OrderStatus::COMPLETED) {
+            OrderCompleted::dispatch($deviceOrder);
+            PaymentCompleted::dispatch($deviceOrder);
+        }
+
+        if ($targetStatus === OrderStatus::VOIDED) {
+            OrderVoided::dispatch($deviceOrder);
+        }
+    }
+
+    private function finalizeMatchingOrder(Builder $query, OrderStatus $targetStatus, string $actorType): bool
+    {
+        $row = $query
+            ->whereIn('status', self::OPEN_STATUSES)
+            ->first();
+
+        if (! $row) {
+            return false;
+        }
+
+        $updated = DB::table('device_orders')
+            ->where('id', (int) $row->id)
+            ->where('status', (string) $row->status)
+            ->whereIn('status', self::OPEN_STATUSES)
+            ->update([
+                'status' => $targetStatus->value,
+                'updated_at' => now(),
+            ]);
+
+        if ($updated === 0) {
+            return false;
+        }
+
+        AuditLogService::orderStatusChanged(
+            null,
+            (int) $row->id,
+            (string) $row->status,
+            $targetStatus->value,
+            null,
+            $actorType
+        );
+
+        $deviceOrder = DeviceOrder::query()->find((int) $row->id);
+        if (! $deviceOrder) {
+            throw new \RuntimeException("DeviceOrder {$row->id} disappeared after status update.");
+        }
+
+        $this->dispatchTerminalEvents($deviceOrder, $targetStatus);
+
+        return true;
+    }
+}

--- a/config/devices.php
+++ b/config/devices.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'last_seen_write_throttle_seconds' => env('DEVICE_LAST_SEEN_WRITE_THROTTLE_SECONDS', 30),
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,42 +1,33 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Queue;
-use Laravel\Sanctum\PersonalAccessToken;
-
-use App\Http\Controllers\Api\V1\{
-    DeviceApiController,
-    DeviceOrderApiController,
-    BrowseMenuApiController,
-    TableServiceApiController,
-    Menu\MenuBundleController,
-    ServiceRequestApiController,
-    PrintController,
-    OrderApiController
-};
-
-use App\Http\Controllers\Api\V1\OrderController;
-
-use App\Http\Controllers\Api\V1\Auth\{
-    AuthApiController,
-    DeviceAuthApiController,
-};
-
-use App\Http\Controllers\Api\V2\TabletApiController;
-use App\Http\Controllers\Api\V2\DeviceApiController as DeviceV2ApiController;
-use App\Http\Controllers\Api\DeploymentInfoController;
-
-use App\Http\Controllers\Api\V1\Krypton\{
-    TerminalSessionApiController,
-};
-
+use App\Events\PrintOrder;
 use App\Helpers\BroadcastConfig;
+use App\Http\Controllers\Api\DeploymentInfoController;
+use App\Http\Controllers\Api\V1\Auth\AuthApiController;
+use App\Http\Controllers\Api\V1\Auth\DeviceAuthApiController;
+use App\Http\Controllers\Api\V1\BrowseMenuApiController;
+use App\Http\Controllers\Api\V1\DeviceApiController;
+use App\Http\Controllers\Api\V1\DeviceOrderApiController;
+use App\Http\Controllers\Api\V1\Menu\MenuBundleController;
+use App\Http\Controllers\Api\V1\OrderApiController;
+use App\Http\Controllers\Api\V1\OrderController;
+use App\Http\Controllers\Api\V1\ServiceRequestApiController;
+use App\Http\Controllers\Api\V1\SessionApiController;
+use App\Http\Controllers\Api\V1\TableServiceApiController;
+use App\Http\Controllers\Api\V2\DeviceApiController as DeviceV2ApiController;
+use App\Http\Controllers\Api\V2\TabletApiController;
+use App\Http\Middleware\RequestId;
+use App\Http\Middleware\UpdateDeviceLastSeen;
+use App\Http\Responses\ApiResponse;
 use App\Models\Device;
 use App\Models\DeviceOrder;
-use App\Events\PrintOrder;
+use App\Models\Krypton\Menu;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Route;
+use Laravel\Sanctum\PersonalAccessToken;
 
 Route::options('{any}', function () {
     return response()->noContent();
@@ -85,7 +76,7 @@ Route::get('/device/ip', function (Request $request) {
     return response()->json([
         'ip' => $resolvedIp,
         'request_ip' => $requestIp,
-        'user_agent' => $request->userAgent()
+        'user_agent' => $request->userAgent(),
     ]);
 });
 
@@ -94,7 +85,7 @@ Route::get('/device/ip', function (Request $request) {
 Route::get('/config', function () {
     return response()->json([
         'broadcasting' => BroadcastConfig::clientPayload(),
-        'app_version'  => config('app.version', env('APP_VERSION', '1.0.0')),
+        'app_version' => config('app.version', env('APP_VERSION', '1.0.0')),
     ])->header('Cache-Control', 'public, max-age=300');
 })->name('api.config');
 
@@ -103,8 +94,9 @@ Route::get('/deployment-info', DeploymentInfoController::class)->name('api.deplo
 // NOTE: `device/table` moved into auth:device group below (use GET or POST).
 
 Route::middleware([
-    \App\Http\Middleware\RequestId::class,
+    RequestId::class,
     'auth:device',
+    UpdateDeviceLastSeen::class,
 ])->get('/order/{orderId}/dispatch', function (Request $request, int $orderId) {
     $order = DeviceOrder::where(['order_id' => $orderId])->first();
     PrintOrder::dispatch($order);
@@ -115,7 +107,7 @@ Route::middleware([
 
 // Print endpoint is device-only; moved under auth:device group below.
 
-Route::middleware([\App\Http\Middleware\RequestId::class, 'guest'])->group(function () {
+Route::middleware([RequestId::class, 'guest'])->group(function () {
     // Rate limit: 120 requests per minute for guest endpoints (generous for transition)
     Route::middleware('throttle:120,1')->group(function () {
         Route::post('/token/create', [AuthApiController::class, 'createToken'])->name('api.user.token.create');
@@ -130,279 +122,279 @@ Route::middleware([\App\Http\Middleware\RequestId::class, 'guest'])->group(funct
     Route::middleware('throttle:10,1')->post('/devices/register', [DeviceAuthApiController::class, 'register'])->name('api.devices.register');
 });
 
-Route::middleware([\App\Http\Middleware\RequestId::class, 'api'])->group(function () {
+Route::middleware([RequestId::class, 'api'])->group(function () {
     // Menu endpoints: 300 requests per minute (generous for busy tablets)
     Route::middleware('throttle:300,1')->group(function () {
         Route::get('/menus', [BrowseMenuApiController::class, 'getMenus'])->name('api.menus');
-    Route::get('/menus/with-modifiers', [BrowseMenuApiController::class, 'getMenusWithModifiers'])->name('api.menus.with.modifiers');
-    Route::get('/menus/modifier-groups', [BrowseMenuApiController::class, 'getAllModifierGroups'])->name('api.menus.modifier-groups');
-    Route::get('/menus/modifiers', [BrowseMenuApiController::class, 'getMenuModifiers'])->name('api.menus.modifiers');
-    Route::get('/menus/modifier-groups/{id}/modifiers', [BrowseMenuApiController::class, 'getMenuModifiersByGroup'])->name('api.menus.modifiers.by.group');
-    Route::get('/menus/course', [BrowseMenuApiController::class, 'getMenusByCourse'])->name('api.menus.by.course');
-    Route::get('/menus/group', [BrowseMenuApiController::class, 'getMenusByGroup'])->name('api.menus.by.group');
-    Route::get('/menus/group-raw', [BrowseMenuApiController::class, 'getMenusByGroupRaw'])->name('api.menus.group.raw');
-    Route::get('/menus/modifiers-by-group', [BrowseMenuApiController::class, 'getModifiersGroupedByGroup'])->name('api.menus.modifiers.by.grouped');
-    Route::get('/menus/package-modifiers', [BrowseMenuApiController::class, 'getPackageModifiers'])->name('api.menus.package.modifiers');
-    Route::get('/menus/category', [BrowseMenuApiController::class, 'getMenusByCategory'])->name('api.menus.by.category');
-    Route::get('/menus/bundle', MenuBundleController::class);
-});
-
-Route::middleware([\App\Http\Middleware\RequestId::class, 'auth:device'])->group(function () {
-    Route::get('/token/verify', function(Request $request) {
-        $tokenString = $request->bearerToken();
-
-        if (! $tokenString) {
-            return response()->json([
-                'valid' => false,
-                'message' => 'No bearer token provided.',
-            ], 400);
-        }
-
-        $token = PersonalAccessToken::findToken($tokenString);
-        
-        if (! $token || ! $token->tokenable) {
-            return response()->json([
-                'valid' => false,
-                'message' => 'Invalid or revoked token.',
-            ], 401);
-        }
-
-        if ($token->expires_at && $token->expires_at->isPast()) {
-            return response()->json([
-                'valid' => false,
-                'message' => 'Token expired.',
-            ], 401);
-        }
-
-        return response()->json([
-            'valid' => true,
-            'device' => $token->tokenable->only(['id', 'name']),
-            'created_at' => $token->created_at,
-            'expires_at' => $token->expires_at ?? null,
-        ]);
+        Route::get('/menus/with-modifiers', [BrowseMenuApiController::class, 'getMenusWithModifiers'])->name('api.menus.with.modifiers');
+        Route::get('/menus/modifier-groups', [BrowseMenuApiController::class, 'getAllModifierGroups'])->name('api.menus.modifier-groups');
+        Route::get('/menus/modifiers', [BrowseMenuApiController::class, 'getMenuModifiers'])->name('api.menus.modifiers');
+        Route::get('/menus/modifier-groups/{id}/modifiers', [BrowseMenuApiController::class, 'getMenuModifiersByGroup'])->name('api.menus.modifiers.by.group');
+        Route::get('/menus/course', [BrowseMenuApiController::class, 'getMenusByCourse'])->name('api.menus.by.course');
+        Route::get('/menus/group', [BrowseMenuApiController::class, 'getMenusByGroup'])->name('api.menus.by.group');
+        Route::get('/menus/group-raw', [BrowseMenuApiController::class, 'getMenusByGroupRaw'])->name('api.menus.group.raw');
+        Route::get('/menus/modifiers-by-group', [BrowseMenuApiController::class, 'getModifiersGroupedByGroup'])->name('api.menus.modifiers.by.grouped');
+        Route::get('/menus/package-modifiers', [BrowseMenuApiController::class, 'getPackageModifiers'])->name('api.menus.package.modifiers');
+        Route::get('/menus/category', [BrowseMenuApiController::class, 'getMenusByCategory'])->name('api.menus.by.category');
+        Route::get('/menus/bundle', MenuBundleController::class);
     });
 
-    Route::resource('/devices', DeviceApiController::class)->names('api.devices');
-    // allow both GET and POST for backward compatibility, and require auth:device
-    Route::match(['get','post'], 'device/table', [DeviceApiController::class, 'getTableByIp'])
-        ->name('device.table');
-    Route::post('/devices/refresh', [DeviceAuthApiController::class, 'refresh'])->name('api.devices.refresh');
-    Route::post('/devices/logout', [DeviceAuthApiController::class, 'logout'])->name('api.devices.logout');
-    // P0 fix 2026-04-07: throttle order creation to prevent double-tap duplicates (10 req/min per device)
-    Route::post('/devices/create-order', DeviceOrderApiController::class)->middleware('throttle.device:10,1')->name('api.devices.create.order');
+    Route::middleware([RequestId::class, 'auth:device', UpdateDeviceLastSeen::class])->group(function () {
+        Route::get('/token/verify', function (Request $request) {
+            $tokenString = $request->bearerToken();
 
-    Route::get('/tables/services', [TableServiceApiController::class, 'index'])->name('api.tables.services');
-    Route::post('/service/request', [ServiceRequestApiController::class, 'store'])->name('api.service.request');
+            if (! $tokenString) {
+                return response()->json([
+                    'valid' => false,
+                    'message' => 'No bearer token provided.',
+                ], 400);
+            }
 
-    Route::get('/device-order/{order}', [OrderApiController::class, 'show']);
-    Route::get('/device-orders', [OrderApiController::class, 'index']);
-    // Fetch a device order by its external order id (order_id)
-    Route::get('/device-order/by-order-id/{orderId}', [OrderApiController::class, 'showByExternalId']);
+            $token = PersonalAccessToken::findToken($tokenString);
 
-    // Refill endpoint (device-authenticated) and alias for print-refill
-    Route::post('/order/{orderId}/refill', [OrderApiController::class, 'refill'])->name('api.order.refill');
-    Route::post('/order/{orderId}/print-refill', [OrderApiController::class, 'refill'])->name('api.order.print-refill');
-    
-    // Session endpoints for devices
-    Route::get('/sessions/current', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'current'])->name('api.sessions.current');
-    Route::post('/sessions/join', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'current'])->name('api.sessions.join');
-    Route::get('/devices/latest-session', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'latestSession'])->name('api.devices.latest-session');
-    
-    // Order print endpoints for devices
-    Route::post('/order/{orderId}/printed', [OrderApiController::class, 'markPrinted'])->name('api.order.printed');
-    Route::get('/order/{orderId}/print', [OrderApiController::class, 'print'])->name('api.order.print');
-});
+            if (! $token || ! $token->tokenable) {
+                return response()->json([
+                    'valid' => false,
+                    'message' => 'Invalid or revoked token.',
+                ], 401);
+            }
 
-// Printer API routes are feature-gated and device-token authenticated.
-// The route file keeps the print-events feature flag ahead of auth so disabled
-// environments return 503 before evaluating relay credentials.
-Route::middleware([\App\Http\Middleware\RequestId::class])->group(function () {
-    require __DIR__ . '/api_printer_routes.php';
-});
+            if ($token->expires_at && $token->expires_at->isPast()) {
+                return response()->json([
+                    'valid' => false,
+                    'message' => 'Token expired.',
+                ], 401);
+            }
 
-// Device API v1 (device-only endpoints)
-Route::prefix('v1')->middleware(['auth:device'])->group(function () {
-    Route::get('/orders', [OrderController::class, 'index']);
-    Route::get('/orders/{order}', [OrderController::class, 'show']);
-    Route::patch('/orders/{order}/status', [OrderController::class, 'updateStatus']);
-    Route::post('/orders/status/bulk', [OrderController::class, 'bulkStatus']);
-});
-
-// Admin/device-reset endpoints (requires sanctum auth)
-Route::middleware(['requestId', 'auth:sanctum'])->group(function () {
-    Route::post('/sessions/{id}/reset', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'reset'])->name('api.sessions.reset');
-    Route::post('/sessions/{sessionId}/force-end', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'forceEnd'])->name('api.sessions.force-end');
-});
-
-// Device API v2 — tablet-ordering-pwa endpoints
-Route::prefix('v2')->middleware([\App\Http\Middleware\RequestId::class, 'auth:device'])->group(function () {
-    Route::get('/tablet/packages', [TabletApiController::class, 'packages'])->name('api.v2.tablet.packages');
-    Route::get('/tablet/packages/{id}', [TabletApiController::class, 'packageDetails'])->name('api.v2.tablet.package.details');
-    Route::get('/tablet/meat-categories', [TabletApiController::class, 'meatCategories'])->name('api.v2.tablet.meat-categories');
-    Route::get('/tablet/categories', [TabletApiController::class, 'categories'])->name('api.v2.tablet.categories');
-    Route::get('/tablet/categories/{slug}/menus', [TabletApiController::class, 'categoryMenus'])->name('api.v2.tablet.category.menus');
-});
-
-// Device management API v2 — admin/sanctum endpoints
-Route::prefix('v2')->middleware([\App\Http\Middleware\RequestId::class, 'auth:sanctum'])->group(function () {
-    Route::get('/devices', [DeviceV2ApiController::class, 'index'])->name('api.v2.devices.index');
-    Route::post('/devices', [DeviceV2ApiController::class, 'store'])->name('api.v2.devices.store');
-    Route::get('/devices/metadata', [DeviceV2ApiController::class, 'metadata'])->name('api.v2.devices.metadata');
-    Route::get('/devices/statistics', [DeviceV2ApiController::class, 'statistics'])->name('api.v2.devices.statistics');
-    Route::get('/devices/by-status', [DeviceV2ApiController::class, 'byStatus'])->name('api.v2.devices.by-status');
-    Route::get('/devices/{device}', [DeviceV2ApiController::class, 'show'])->name('api.v2.devices.show');
-    Route::get('/devices/{device}/health', [DeviceV2ApiController::class, 'health'])->name('api.v2.devices.health');
-    Route::get('/devices/{device}/heartbeats', [DeviceV2ApiController::class, 'heartbeats'])->name('api.v2.devices.heartbeats');
-    Route::post('/devices/{device}/status', [DeviceV2ApiController::class, 'toggleStatus'])->name('api.v2.devices.status');
-    Route::post('/devices/{device}/security-code', [DeviceV2ApiController::class, 'regenerateSecurityCode'])->name('api.v2.devices.security-code');
-    Route::patch('/devices/{device}/rotate-security-code', [DeviceV2ApiController::class, 'rotateSecurityCode'])->name('api.v2.devices.rotate-security-code');
-});
-
-// Session alias — PWA calls /api/session/latest; actual route is /api/sessions/current
-Route::middleware([\App\Http\Middleware\RequestId::class, 'auth:device'])->group(function () {
-    Route::get('/session/latest', [\App\Http\Controllers\Api\V1\SessionApiController::class, 'current'])->name('api.session.latest');
-});
-
-// Health endpoint — app DB, Redis, queue depth, version, uptime
-Route::get('/health', function () {
-    $startTime = defined('LARAVEL_START') ? LARAVEL_START : microtime(true);
-
-    $services = [
-        'mysql'  => false,
-        'pos'    => false,
-        'redis'  => false,
-    ];
-
-    // MySQL (app DB)
-    try {
-        DB::connection()->getPdo();
-        $services['mysql'] = true;
-    } catch (\Throwable $e) {
-        // keep false
-    }
-
-    // POS DB
-    try {
-        DB::connection('pos')->getPdo();
-        $services['pos'] = true;
-    } catch (\Throwable $e) {
-        // keep false
-    }
-
-    // Redis — requires CACHE_DRIVER=redis in production
-    try {
-        Cache::store('redis')->set('__health_ping', 1, 5);
-        $services['redis'] = (bool) Cache::store('redis')->get('__health_ping');
-    } catch (\Throwable $e) {
-        $services['redis'] = false;
-    }
-
-    // Broadcasting integrity check
-    try {
-        $driver = config('broadcasting.default');
-        $reverbApps = config('reverb.apps.apps');
-        $reverbApp = is_array($reverbApps) && count($reverbApps) > 0 ? $reverbApps[0] : null;
-        $broadcastingReverb = config('broadcasting.connections.reverb');
-
-        if ($driver !== 'reverb' || $reverbApp === null) {
-            $broadcastingStatus = ['driver' => $driver, 'consistent' => false];
-        } else {
-            $reverbKey = trim((string) ($reverbApp['key'] ?? ''));
-            $consistent = $reverbKey === trim((string) ($broadcastingReverb['key'] ?? ''))
-                && trim((string) ($reverbApp['secret'] ?? '')) === trim((string) ($broadcastingReverb['secret'] ?? ''))
-                && trim((string) ($reverbApp['app_id'] ?? '')) === trim((string) ($broadcastingReverb['app_id'] ?? ''));
-            $first4 = substr($reverbKey, 0, 4);
-            $broadcastingStatus = [
-                'driver'          => $driver,
-                'key_fingerprint' => $reverbKey !== '' ? "{$first4}...(" . strlen($reverbKey) . "b, sha256:" . substr(hash('sha256', $reverbKey), 0, 8) . ")" : 'none',
-                'host'            => trim((string) config('broadcasting.connections.reverb.options.host', '')),
-                'port'            => (int) config('broadcasting.connections.reverb.options.port', 8080),
-                'scheme'          => trim((string) config('broadcasting.connections.reverb.options.scheme', 'https')),
-                'consistent'      => $consistent,
-            ];
-        }
-        $services['broadcasting'] = $broadcastingStatus;
-    } catch (\Throwable $e) {
-        $services['broadcasting'] = ['driver' => 'unknown', 'consistent' => false];
-    }
-
-    // Queue depth — size() on the default queue connection
-    $queueDepth = null;
-    try {
-        $queueDepth = Queue::size();
-    } catch (\Throwable $e) {
-        // Queue driver may not support size() (e.g. sync driver)
-    }
-
-    // Determine overall status
-    $coreHealthy = $services['mysql'];
-    $fullyHealthy = $coreHealthy && $services['redis'];
-    $broadcastingConsistent = $services['broadcasting']['consistent'] ?? true;
-    
-    $overallStatus = match (true) {
-        !$coreHealthy => 'down',
-        (!$fullyHealthy || !$broadcastingConsistent) => 'degraded',
-        default => 'ok',
-    };
-
-    $statusCode = match ($overallStatus) {
-        'down'     => 503,
-        'degraded' => 207,
-        default    => 200,
-    };
-
-    $payload = [
-        'status'         => $overallStatus,
-        'services'       => $services,
-        'queue_depth'    => $queueDepth,
-        'version'        => config('app.version', env('APP_VERSION', '1.0.0')),
-        'environment'    => app()->environment(),
-        'uptime_seconds' => (int) round(microtime(true) - $startTime, 3),
-    ];
-
-    return response()->json([
-        'success' => $overallStatus !== 'down',
-        'data'    => $payload,
-        'message' => 'Health check',
-    ], $statusCode);
-});
-
-// Debug endpoint: returns raw POS stored-proc rows and local Menu rows for a course
-Route::get('/debug/pos/menus/course', function (Request $request) {
-    if (! (app()->environment('local') || config('app.debug'))) {
-        return \App\Http\Responses\ApiResponse::error('Debug endpoint disabled', null, 403);
-    }
-
-    $course = $request->query('course');
-
-    if (! $course) {
-        return \App\Http\Responses\ApiResponse::error('Missing ?course= query param', null, 400);
-    }
-
-    try {
-        $rows = DB::connection('pos')->select('CALL get_menus_by_course(?)', [$course]);
-    } catch (\Throwable $e) {
-        return \App\Http\Responses\ApiResponse::error('Stored procedure call failed: ' . $e->getMessage(), null, 500);
-    }
-
-    $ids = collect($rows)->pluck('id')->unique()->values()->all();
-
-    $menus = [];
-    if (! empty($ids)) {
-        $menus = \App\Models\Krypton\Menu::whereIn('id', $ids)->get()->map(function ($m) {
-            return [
-                'id' => $m->id,
-                'name' => $m->name ?? null,
-                'is_available' => $m->is_available ?? null,
-            ];
+            return response()->json([
+                'valid' => true,
+                'device' => $token->tokenable->only(['id', 'name']),
+                'created_at' => $token->created_at,
+                'expires_at' => $token->expires_at ?? null,
+            ]);
         });
-    }
 
-    return \App\Http\Responses\ApiResponse::success([
-        'course' => $course,
-        'stored_proc_rows' => $rows,
-        'menu_rows' => $menus,
-    ]);
+        Route::resource('/devices', DeviceApiController::class)->names('api.devices');
+        // allow both GET and POST for backward compatibility, and require auth:device
+        Route::match(['get', 'post'], 'device/table', [DeviceApiController::class, 'getTableByIp'])
+            ->name('device.table');
+        Route::post('/devices/refresh', [DeviceAuthApiController::class, 'refresh'])->name('api.devices.refresh');
+        Route::post('/devices/logout', [DeviceAuthApiController::class, 'logout'])->name('api.devices.logout');
+        // P0 fix 2026-04-07: throttle order creation to prevent double-tap duplicates (10 req/min per device)
+        Route::post('/devices/create-order', DeviceOrderApiController::class)->middleware('throttle.device:10,1')->name('api.devices.create.order');
 
-});
+        Route::get('/tables/services', [TableServiceApiController::class, 'index'])->name('api.tables.services');
+        Route::post('/service/request', [ServiceRequestApiController::class, 'store'])->name('api.service.request');
+
+        Route::get('/device-order/{order}', [OrderApiController::class, 'show']);
+        Route::get('/device-orders', [OrderApiController::class, 'index']);
+        // Fetch a device order by its external order id (order_id)
+        Route::get('/device-order/by-order-id/{orderId}', [OrderApiController::class, 'showByExternalId']);
+
+        // Refill endpoint (device-authenticated) and alias for print-refill
+        Route::post('/order/{orderId}/refill', [OrderApiController::class, 'refill'])->name('api.order.refill');
+        Route::post('/order/{orderId}/print-refill', [OrderApiController::class, 'refill'])->name('api.order.print-refill');
+
+        // Session endpoints for devices
+        Route::get('/sessions/current', [SessionApiController::class, 'current'])->name('api.sessions.current');
+        Route::post('/sessions/join', [SessionApiController::class, 'current'])->name('api.sessions.join');
+        Route::get('/devices/latest-session', [SessionApiController::class, 'latestSession'])->name('api.devices.latest-session');
+
+        // Order print endpoints for devices
+        Route::post('/order/{orderId}/printed', [OrderApiController::class, 'markPrinted'])->name('api.order.printed');
+        Route::get('/order/{orderId}/print', [OrderApiController::class, 'print'])->name('api.order.print');
+    });
+
+    // Printer API routes are feature-gated and device-token authenticated.
+    // The route file keeps the print-events feature flag ahead of auth so disabled
+    // environments return 503 before evaluating relay credentials.
+    Route::middleware([RequestId::class])->group(function () {
+        require __DIR__.'/api_printer_routes.php';
+    });
+
+    // Device API v1 (device-only endpoints)
+    Route::prefix('v1')->middleware(['auth:device', UpdateDeviceLastSeen::class])->group(function () {
+        Route::get('/orders', [OrderController::class, 'index']);
+        Route::get('/orders/{order}', [OrderController::class, 'show']);
+        Route::patch('/orders/{order}/status', [OrderController::class, 'updateStatus']);
+        Route::post('/orders/status/bulk', [OrderController::class, 'bulkStatus']);
+    });
+
+    // Admin/device-reset endpoints (requires sanctum auth)
+    Route::middleware(['requestId', 'auth:sanctum'])->group(function () {
+        Route::post('/sessions/{id}/reset', [SessionApiController::class, 'reset'])->name('api.sessions.reset');
+        Route::post('/sessions/{sessionId}/force-end', [SessionApiController::class, 'forceEnd'])->name('api.sessions.force-end');
+    });
+
+    // Device API v2 — tablet-ordering-pwa endpoints
+    Route::prefix('v2')->middleware([RequestId::class, 'auth:device', UpdateDeviceLastSeen::class])->group(function () {
+        Route::get('/tablet/packages', [TabletApiController::class, 'packages'])->name('api.v2.tablet.packages');
+        Route::get('/tablet/packages/{id}', [TabletApiController::class, 'packageDetails'])->name('api.v2.tablet.package.details');
+        Route::get('/tablet/meat-categories', [TabletApiController::class, 'meatCategories'])->name('api.v2.tablet.meat-categories');
+        Route::get('/tablet/categories', [TabletApiController::class, 'categories'])->name('api.v2.tablet.categories');
+        Route::get('/tablet/categories/{slug}/menus', [TabletApiController::class, 'categoryMenus'])->name('api.v2.tablet.category.menus');
+    });
+
+    // Device management API v2 — admin/sanctum endpoints
+    Route::prefix('v2')->middleware([RequestId::class, 'auth:sanctum'])->group(function () {
+        Route::get('/devices', [DeviceV2ApiController::class, 'index'])->name('api.v2.devices.index');
+        Route::post('/devices', [DeviceV2ApiController::class, 'store'])->name('api.v2.devices.store');
+        Route::get('/devices/metadata', [DeviceV2ApiController::class, 'metadata'])->name('api.v2.devices.metadata');
+        Route::get('/devices/statistics', [DeviceV2ApiController::class, 'statistics'])->name('api.v2.devices.statistics');
+        Route::get('/devices/by-status', [DeviceV2ApiController::class, 'byStatus'])->name('api.v2.devices.by-status');
+        Route::get('/devices/{device}', [DeviceV2ApiController::class, 'show'])->name('api.v2.devices.show');
+        Route::get('/devices/{device}/health', [DeviceV2ApiController::class, 'health'])->name('api.v2.devices.health');
+        Route::get('/devices/{device}/heartbeats', [DeviceV2ApiController::class, 'heartbeats'])->name('api.v2.devices.heartbeats');
+        Route::post('/devices/{device}/status', [DeviceV2ApiController::class, 'toggleStatus'])->name('api.v2.devices.status');
+        Route::post('/devices/{device}/security-code', [DeviceV2ApiController::class, 'regenerateSecurityCode'])->name('api.v2.devices.security-code');
+        Route::patch('/devices/{device}/rotate-security-code', [DeviceV2ApiController::class, 'rotateSecurityCode'])->name('api.v2.devices.rotate-security-code');
+    });
+
+    // Session alias — PWA calls /api/session/latest; actual route is /api/sessions/current
+    Route::middleware([RequestId::class, 'auth:device', UpdateDeviceLastSeen::class])->group(function () {
+        Route::get('/session/latest', [SessionApiController::class, 'current'])->name('api.session.latest');
+    });
+
+    // Health endpoint — app DB, Redis, queue depth, version, uptime
+    Route::get('/health', function () {
+        $startTime = defined('LARAVEL_START') ? LARAVEL_START : microtime(true);
+
+        $services = [
+            'mysql' => false,
+            'pos' => false,
+            'redis' => false,
+        ];
+
+        // MySQL (app DB)
+        try {
+            DB::connection()->getPdo();
+            $services['mysql'] = true;
+        } catch (Throwable $e) {
+            // keep false
+        }
+
+        // POS DB
+        try {
+            DB::connection('pos')->getPdo();
+            $services['pos'] = true;
+        } catch (Throwable $e) {
+            // keep false
+        }
+
+        // Redis — requires CACHE_DRIVER=redis in production
+        try {
+            Cache::store('redis')->set('__health_ping', 1, 5);
+            $services['redis'] = (bool) Cache::store('redis')->get('__health_ping');
+        } catch (Throwable $e) {
+            $services['redis'] = false;
+        }
+
+        // Broadcasting integrity check
+        try {
+            $driver = config('broadcasting.default');
+            $reverbApps = config('reverb.apps.apps');
+            $reverbApp = is_array($reverbApps) && count($reverbApps) > 0 ? $reverbApps[0] : null;
+            $broadcastingReverb = config('broadcasting.connections.reverb');
+
+            if ($driver !== 'reverb' || $reverbApp === null) {
+                $broadcastingStatus = ['driver' => $driver, 'consistent' => false];
+            } else {
+                $reverbKey = trim((string) ($reverbApp['key'] ?? ''));
+                $consistent = $reverbKey === trim((string) ($broadcastingReverb['key'] ?? ''))
+                    && trim((string) ($reverbApp['secret'] ?? '')) === trim((string) ($broadcastingReverb['secret'] ?? ''))
+                    && trim((string) ($reverbApp['app_id'] ?? '')) === trim((string) ($broadcastingReverb['app_id'] ?? ''));
+                $first4 = substr($reverbKey, 0, 4);
+                $broadcastingStatus = [
+                    'driver' => $driver,
+                    'key_fingerprint' => $reverbKey !== '' ? "{$first4}...(".strlen($reverbKey).'b, sha256:'.substr(hash('sha256', $reverbKey), 0, 8).')' : 'none',
+                    'host' => trim((string) config('broadcasting.connections.reverb.options.host', '')),
+                    'port' => (int) config('broadcasting.connections.reverb.options.port', 8080),
+                    'scheme' => trim((string) config('broadcasting.connections.reverb.options.scheme', 'https')),
+                    'consistent' => $consistent,
+                ];
+            }
+            $services['broadcasting'] = $broadcastingStatus;
+        } catch (Throwable $e) {
+            $services['broadcasting'] = ['driver' => 'unknown', 'consistent' => false];
+        }
+
+        // Queue depth — size() on the default queue connection
+        $queueDepth = null;
+        try {
+            $queueDepth = Queue::size();
+        } catch (Throwable $e) {
+            // Queue driver may not support size() (e.g. sync driver)
+        }
+
+        // Determine overall status
+        $coreHealthy = $services['mysql'];
+        $fullyHealthy = $coreHealthy && $services['redis'];
+        $broadcastingConsistent = $services['broadcasting']['consistent'] ?? true;
+
+        $overallStatus = match (true) {
+            ! $coreHealthy => 'down',
+            (! $fullyHealthy || ! $broadcastingConsistent) => 'degraded',
+            default => 'ok',
+        };
+
+        $statusCode = match ($overallStatus) {
+            'down' => 503,
+            'degraded' => 207,
+            default => 200,
+        };
+
+        $payload = [
+            'status' => $overallStatus,
+            'services' => $services,
+            'queue_depth' => $queueDepth,
+            'version' => config('app.version', env('APP_VERSION', '1.0.0')),
+            'environment' => app()->environment(),
+            'uptime_seconds' => (int) round(microtime(true) - $startTime, 3),
+        ];
+
+        return response()->json([
+            'success' => $overallStatus !== 'down',
+            'data' => $payload,
+            'message' => 'Health check',
+        ], $statusCode);
+    });
+
+    // Debug endpoint: returns raw POS stored-proc rows and local Menu rows for a course
+    Route::get('/debug/pos/menus/course', function (Request $request) {
+        if (! (app()->environment('local') || config('app.debug'))) {
+            return ApiResponse::error('Debug endpoint disabled', null, 403);
+        }
+
+        $course = $request->query('course');
+
+        if (! $course) {
+            return ApiResponse::error('Missing ?course= query param', null, 400);
+        }
+
+        try {
+            $rows = DB::connection('pos')->select('CALL get_menus_by_course(?)', [$course]);
+        } catch (Throwable $e) {
+            return ApiResponse::error('Stored procedure call failed: '.$e->getMessage(), null, 500);
+        }
+
+        $ids = collect($rows)->pluck('id')->unique()->values()->all();
+
+        $menus = [];
+        if (! empty($ids)) {
+            $menus = Menu::whereIn('id', $ids)->get()->map(function ($m) {
+                return [
+                    'id' => $m->id,
+                    'name' => $m->name ?? null,
+                    'is_available' => $m->is_available ?? null,
+                ];
+            });
+        }
+
+        return ApiResponse::success([
+            'course' => $course,
+            'stored_proc_rows' => $rows,
+            'menu_rows' => $menus,
+        ]);
+
+    });
 });

--- a/routes/api_printer_routes.php
+++ b/routes/api_printer_routes.php
@@ -1,7 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\PrinterApiController;
+use App\Http\Middleware\UpdateDeviceLastSeen;
+use Illuminate\Support\Facades\Route;
 
 /**
  * PrintEvent API routes
@@ -15,7 +16,7 @@ use App\Http\Controllers\Api\V1\PrinterApiController;
  * Enable these routes only for future printer expansion work by setting
  * NEXUS_PRINT_EVENTS_ENABLED=true in your .env file.
  */
-Route::middleware(['print_events.enabled', 'auth:device'])->group(function () {
+Route::middleware(['print_events.enabled', 'auth:device', UpdateDeviceLastSeen::class])->group(function () {
     // Printer API endpoints (device-authenticated for branch isolation)
     // These endpoints are for printer relay devices that authenticate via device tokens
     Route::get('/printer/unprinted-events', [PrinterApiController::class, 'getUnprintedEvents']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -24,6 +24,11 @@ Schedule::command('pulse:check')->everyMinute()->withoutOverlapping()->runInBack
 
 // Split-DB safe payment status reconciliation (POS -> local device_orders).
 // Replaces dependency on cross-server MySQL trigger updates.
+Schedule::command('pos:consume-payment-status-events')
+    ->everyFiveSeconds()
+    ->withoutOverlapping(3)
+    ->runInBackground();
+
 Schedule::command('pos:sync-payment-statuses')
     ->everyMinute()
     ->withoutOverlapping();

--- a/tests/Feature/Console/PosPaymentOutboxConsumerTest.php
+++ b/tests/Feature/Console/PosPaymentOutboxConsumerTest.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderStatusUpdated;
+use App\Events\Order\OrderVoided;
+use App\Events\Order\PaymentCompleted;
+use App\Events\SessionReset;
+use App\Models\DeviceOrder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class PosPaymentOutboxConsumerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createPosPaymentOutboxTable();
+        $this->createPosSessionOutboxTable();
+    }
+
+    public function test_consumer_completes_confirmed_local_order_dispatches_realtime_events_and_marks_row_processed(): void
+    {
+        Event::fake([
+            OrderStatusUpdated::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+
+        $order = $this->confirmedOrder([
+            'order_id' => 900101,
+            'session_id' => 4242,
+        ]);
+        $outboxId = $this->insertOutboxRow($order, OrderStatus::COMPLETED->value);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(0);
+
+        $this->assertSame(OrderStatus::COMPLETED, $order->refresh()->status);
+        $this->assertOutboxProcessed($outboxId);
+
+        Event::assertDispatched(OrderStatusUpdated::class, fn ($event): bool => $event->order->id === $order->id);
+        Event::assertDispatched(OrderCompleted::class, fn ($event): bool => $event->deviceOrder->id === $order->id);
+        Event::assertDispatched(PaymentCompleted::class, fn ($event): bool => $event->deviceOrder->id === $order->id);
+        Event::assertNotDispatched(SessionReset::class);
+    }
+
+    public function test_consumer_voids_confirmed_local_order_for_voided_target_status(): void
+    {
+        Event::fake([
+            OrderStatusUpdated::class,
+            OrderVoided::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+
+        $order = $this->confirmedOrder([
+            'order_id' => 900102,
+            'session_id' => 5252,
+        ]);
+        $outboxId = $this->insertOutboxRow($order, OrderStatus::VOIDED->value);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(0);
+
+        $this->assertSame(OrderStatus::VOIDED, $order->refresh()->status);
+        $this->assertOutboxProcessed($outboxId);
+
+        Event::assertDispatched(OrderStatusUpdated::class, fn ($event): bool => $event->order->id === $order->id);
+        Event::assertDispatched(OrderVoided::class, fn ($event): bool => $event->deviceOrder->id === $order->id);
+        Event::assertNotDispatched(SessionReset::class);
+        Event::assertNotDispatched(OrderCompleted::class);
+        Event::assertNotDispatched(PaymentCompleted::class);
+    }
+
+    public function test_consumer_does_not_dispatch_session_reset_when_one_order_in_shared_pos_session_completes(): void
+    {
+        Event::fake([
+            OrderStatusUpdated::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+
+        $firstOrder = $this->confirmedOrder([
+            'order_id' => 900201,
+            'session_id' => 4242,
+        ]);
+        $secondOrder = $this->confirmedOrder([
+            'order_id' => 900202,
+            'session_id' => 4242,
+        ]);
+        $thirdOrder = $this->confirmedOrder([
+            'order_id' => 900203,
+            'session_id' => 4242,
+        ]);
+
+        $this->insertOutboxRow($secondOrder, OrderStatus::COMPLETED->value);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(0);
+
+        $this->assertSame(OrderStatus::CONFIRMED, $firstOrder->refresh()->status);
+        $this->assertSame(OrderStatus::COMPLETED, $secondOrder->refresh()->status);
+        $this->assertSame(OrderStatus::CONFIRMED, $thirdOrder->refresh()->status);
+
+        Event::assertDispatched(OrderCompleted::class, fn ($event): bool => $event->deviceOrder->id === $secondOrder->id);
+        Event::assertNotDispatched(SessionReset::class);
+    }
+
+    public function test_consumer_dispatches_session_reset_for_pos_session_close_outbox_row(): void
+    {
+        Event::fake([
+            OrderStatusUpdated::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            OrderVoided::class,
+            SessionReset::class,
+        ]);
+
+        $outboxId = $this->insertSessionOutboxRow(4242);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(0);
+
+        $this->assertSessionOutboxProcessed($outboxId);
+
+        Event::assertDispatched(SessionReset::class, fn (SessionReset $event): bool => $event->sessionId === 4242);
+        Event::assertNotDispatched(OrderStatusUpdated::class);
+        Event::assertNotDispatched(OrderCompleted::class);
+        Event::assertNotDispatched(PaymentCompleted::class);
+        Event::assertNotDispatched(OrderVoided::class);
+    }
+
+    public function test_consumer_does_not_overwrite_already_terminal_local_order(): void
+    {
+        Event::fake([
+            OrderStatusUpdated::class,
+            OrderVoided::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+
+        $order = DeviceOrder::factory()->completed()->create([
+            'order_id' => 900103,
+            'session_id' => 6262,
+        ]);
+        $this->insertOutboxRow($order, OrderStatus::VOIDED->value);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(0);
+
+        $this->assertSame(OrderStatus::COMPLETED, $order->refresh()->status);
+        Event::assertNotDispatched(OrderStatusUpdated::class);
+        Event::assertNotDispatched(OrderVoided::class);
+        Event::assertNotDispatched(SessionReset::class);
+    }
+
+    public function test_failed_finalization_keeps_row_retryable_and_increments_attempts(): void
+    {
+        Event::fakeExcept([
+            OrderStatusUpdated::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+        Event::listen(OrderStatusUpdated::class, static function (): void {
+            throw new \RuntimeException('synthetic broadcast failure');
+        });
+
+        $order = $this->confirmedOrder([
+            'order_id' => 900104,
+            'session_id' => 7272,
+        ]);
+        $outboxId = $this->insertOutboxRow($order, OrderStatus::COMPLETED->value);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(1);
+
+        $outbox = DB::connection('pos')
+            ->table('woosoo_order_status_outbox')
+            ->where('id', $outboxId)
+            ->first();
+
+        $this->assertSame(OrderStatus::CONFIRMED, $order->refresh()->status);
+        $this->assertNull($outbox->processed_at);
+        $this->assertNull($outbox->failed_at);
+        $this->assertSame(1, (int) $outbox->attempts);
+        $this->assertStringContainsString('synthetic broadcast failure', (string) $outbox->last_error);
+    }
+
+    public function test_failed_finalization_dead_letters_row_after_fifth_attempt(): void
+    {
+        Event::fakeExcept([
+            OrderStatusUpdated::class,
+            OrderCompleted::class,
+            PaymentCompleted::class,
+            SessionReset::class,
+        ]);
+        Event::listen(OrderStatusUpdated::class, static function (): void {
+            throw new \RuntimeException('synthetic permanent broadcast failure');
+        });
+
+        $order = $this->confirmedOrder([
+            'order_id' => 900105,
+            'session_id' => 8282,
+        ]);
+        $outboxId = $this->insertOutboxRow($order, OrderStatus::COMPLETED->value, attempts: 4);
+
+        $this->artisan('pos:consume-payment-status-events')->assertExitCode(1);
+
+        $outbox = DB::connection('pos')
+            ->table('woosoo_order_status_outbox')
+            ->where('id', $outboxId)
+            ->first();
+
+        $this->assertSame(OrderStatus::CONFIRMED, $order->refresh()->status);
+        $this->assertNull($outbox->processed_at);
+        $this->assertSame(5, (int) $outbox->attempts);
+        $this->assertNotNull($outbox->failed_at);
+        $this->assertStringContainsString('synthetic permanent broadcast failure', (string) $outbox->last_error);
+    }
+
+    private function confirmedOrder(array $attributes = []): DeviceOrder
+    {
+        return DeviceOrder::factory()->confirmed()->create($attributes);
+    }
+
+    private function createPosPaymentOutboxTable(): void
+    {
+        $schema = Schema::connection('pos');
+
+        $schema->dropIfExists('woosoo_order_status_outbox');
+        $schema->create('woosoo_order_status_outbox', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedBigInteger('pos_order_id');
+            $table->string('target_status');
+            $table->unsignedInteger('attempts')->default(0);
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->text('last_error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function createPosSessionOutboxTable(): void
+    {
+        $schema = Schema::connection('pos');
+
+        $schema->dropIfExists('woosoo_session_status_outbox');
+        $schema->create('woosoo_session_status_outbox', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedBigInteger('pos_session_id');
+            $table->string('event_type');
+            $table->timestamp('date_time_closed')->nullable();
+            $table->unsignedInteger('attempts')->default(0);
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->text('last_error')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    private function insertOutboxRow(DeviceOrder $order, string $targetStatus, int $attempts = 0): int
+    {
+        return (int) DB::connection('pos')->table('woosoo_order_status_outbox')->insertGetId([
+            'pos_order_id' => $order->order_id,
+            'target_status' => $targetStatus,
+            'attempts' => $attempts,
+            'processed_at' => null,
+            'failed_at' => null,
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertSessionOutboxRow(int $sessionId, int $attempts = 0): int
+    {
+        return (int) DB::connection('pos')->table('woosoo_session_status_outbox')->insertGetId([
+            'pos_session_id' => $sessionId,
+            'event_type' => 'closed',
+            'date_time_closed' => now(),
+            'attempts' => $attempts,
+            'processed_at' => null,
+            'failed_at' => null,
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function assertOutboxProcessed(int $outboxId): void
+    {
+        $outbox = DB::connection('pos')
+            ->table('woosoo_order_status_outbox')
+            ->where('id', $outboxId)
+            ->first();
+
+        $this->assertNotNull($outbox->processed_at);
+        $this->assertNull($outbox->failed_at);
+        $this->assertNull($outbox->last_error);
+    }
+
+    private function assertSessionOutboxProcessed(int $outboxId): void
+    {
+        $outbox = DB::connection('pos')
+            ->table('woosoo_session_status_outbox')
+            ->where('id', $outboxId)
+            ->first();
+
+        $this->assertNotNull($outbox->processed_at);
+        $this->assertNull($outbox->failed_at);
+        $this->assertNull($outbox->last_error);
+    }
+}

--- a/tests/Feature/Console/PosPaymentOutboxSetupTest.php
+++ b/tests/Feature/Console/PosPaymentOutboxSetupTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class PosPaymentOutboxSetupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_setup_command_creates_pos_local_outbox_without_requiring_same_mysql_endpoint(): void
+    {
+        config([
+            'database.connections.pos.host' => '192.168.1.32',
+            'database.connections.pos.port' => '3306',
+            'database.connections.mysql.host' => 'mysql',
+            'database.connections.mysql.port' => '3306',
+        ]);
+
+        Schema::connection('pos')->dropIfExists('woosoo_order_status_outbox');
+        Schema::connection('pos')->dropIfExists('woosoo_session_status_outbox');
+
+        $this->artisan('pos:setup-payment-trigger')
+            ->assertExitCode(0);
+
+        $this->assertTrue(Schema::connection('pos')->hasTable('woosoo_order_status_outbox'));
+        $this->assertTrue(Schema::connection('pos')->hasTable('woosoo_session_status_outbox'));
+    }
+}

--- a/tests/Feature/Middleware/UpdateDeviceLastSeenTest.php
+++ b/tests/Feature/Middleware/UpdateDeviceLastSeenTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Middleware;
+
+use App\Models\Device;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class UpdateDeviceLastSeenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_authenticated_tablet_api_request_updates_device_last_seen_at(): void
+    {
+        Cache::flush();
+
+        $device = Device::factory()->create([
+            'is_active' => true,
+            'last_seen_at' => Carbon::parse('2026-05-20 10:00:00'),
+        ]);
+        $token = $device->createToken('tablet')->plainTextToken;
+        $seenAt = Carbon::parse('2026-05-21 12:00:00');
+
+        Carbon::setTestNow($seenAt);
+
+        $this->withToken($token, 'Bearer')
+            ->getJson('/api/v2/tablet/categories')
+            ->assertOk();
+
+        $this->assertSame(
+            $seenAt->toDateTimeString(),
+            $device->refresh()->last_seen_at?->toDateTimeString()
+        );
+    }
+
+    public function test_last_seen_write_is_throttled_per_device(): void
+    {
+        config(['devices.last_seen_write_throttle_seconds' => 30]);
+        Cache::flush();
+
+        $device = Device::factory()->create([
+            'is_active' => true,
+            'last_seen_at' => Carbon::parse('2026-05-20 10:00:00'),
+        ]);
+        $token = $device->createToken('tablet')->plainTextToken;
+        $firstSeenAt = Carbon::parse('2026-05-21 12:00:00');
+        $secondSeenAt = Carbon::parse('2026-05-21 12:00:10');
+
+        Carbon::setTestNow($firstSeenAt);
+        $this->withToken($token, 'Bearer')
+            ->getJson('/api/v2/tablet/categories')
+            ->assertOk();
+
+        Carbon::setTestNow($secondSeenAt);
+        $this->withToken($token, 'Bearer')
+            ->getJson('/api/v2/tablet/categories')
+            ->assertOk();
+
+        $this->assertSame(
+            $firstSeenAt->toDateTimeString(),
+            $device->refresh()->last_seen_at?->toDateTimeString()
+        );
+    }
+}


### PR DESCRIPTION
…ice last-seen middleware

Replace the cross-database MySQL trigger (broken when POS and Nexus run on
  separate DB endpoints) with POS-local outbox tables consumed by Nexus every 5s.

  - New `pos:consume-payment-status-events` command reads both
    `woosoo_order_status_outbox` (order close/void) and
    `woosoo_session_status_outbox` (daily session close). Rows retry up to 5
    times; dead-lettered via `failed_at` for monitoring.
  - `PosOrderStatusFinalizer` performs raw DB CAS terminal transitions and
    dispatches per-order events. It never dispatches `SessionReset`.
  - `SessionReset` is now reserved for actual POS daily session close only —
    ending the blast that reset all tablets whenever any single table paid.
  - `SyncPosOrderPaymentStatus` (1-min safety-net) now delegates to the same
    finalizer so event behaviour is consistent.
  - New `UpdateDeviceLastSeen` middleware refreshes `devices.last_seen_at` on
    authenticated device/tablet requests (throttled via
    `DEVICE_LAST_SEEN_WRITE_THROTTLE_SECONDS`, default 30s). Skips heartbeat.

  Deployment: run `php artisan pos:setup-payment-trigger` on the Pi after deploy
  to install POS-local outbox tables and triggers. Monitor `failed_at IS NOT NULL`
  rows in both outbox tables.
