### PR TITLE
feat(menus): restore Course/Group/Image filters in admin Menus DataTable

### DIFF
--- a/resources/js/components/Menus/columns.ts
+++ b/resources/js/components/Menus/columns.ts
@@ -27,6 +27,16 @@ export const columns: ColumnDef<Menu, any>[] = [
     },
   },
   {
+    accessorKey: 'course',
+    header: ({ column }) => h(DataTableColumnHeader, { column, title: 'Course' }),
+    cell: ({ row }) => h('div', {}, row.getValue('course')),
+  },
+  {
+    accessorKey: 'group',
+    header: ({ column }) => h(DataTableColumnHeader, { column, title: 'Group' }),
+    cell: ({ row }) => h('div', {}, row.getValue('group')),
+  },
+  {
     accessorKey: 'category',
     header: ({ column }) => h(DataTableColumnHeader, { column, title: 'Category' }),
     cell: ({ row }) => h('div', {}, row.getValue('category')),
@@ -43,6 +53,17 @@ export const columns: ColumnDef<Menu, any>[] = [
         ])
       }
       return h('div', { class: 'font-medium' }, '₱' + price.toFixed(2))
+    },
+  },
+  {
+    accessorKey: 'has_uploaded_image',
+    header: ({ column }) => h(DataTableColumnHeader, { column, title: 'Image' }),
+    enableSorting: false,
+    cell: ({ row }) => {
+      const uploaded = row.getValue('has_uploaded_image')
+      return h('div', { class: 'flex items-center justify-center' }, [
+        h(Badge, { variant: uploaded ? 'secondary' : 'outline', class: 'text-xs' }, uploaded ? 'Uploaded' : 'Missing')
+      ])
     },
   },
   {

--- a/resources/js/components/ui/DataTableToolbar.vue
+++ b/resources/js/components/ui/DataTableToolbar.vue
@@ -29,6 +29,12 @@ const isAvailableFiltered = computed(() => {
   if (!hasColumn('is_available')) return false
   return !!table.getColumn('is_available')?.getFilterValue()
 })
+
+const hasUploadedImageColumn = computed(() => hasColumn('has_uploaded_image'))
+const uploadedImageFilter = computed<boolean | undefined>(() => {
+  if (!hasUploadedImageColumn.value) return undefined
+  return table.getColumn('has_uploaded_image')?.getFilterValue() as boolean | undefined
+})
 </script>
 
 <template>
@@ -61,6 +67,33 @@ const isAvailableFiltered = computed(() => {
         title="Group"
         :options="groupOptions"
       />
+
+      <template v-if="hasUploadedImageColumn">
+        <Button
+          variant="outline"
+          size="sm"
+          :class="['h-8 text-xs', uploadedImageFilter === true ? 'border-solid border-primary' : 'border-dashed']"
+          @click="() => {
+            const col = table.getColumn('has_uploaded_image')
+            if (!col) return
+            col.setFilterValue(uploadedImageFilter === true ? undefined : true)
+          }"
+        >
+          Uploaded
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          :class="['h-8 text-xs', uploadedImageFilter === false ? 'border-solid border-primary' : 'border-dashed']"
+          @click="() => {
+            const col = table.getColumn('has_uploaded_image')
+            if (!col) return
+            col.setFilterValue(uploadedImageFilter === false ? undefined : false)
+          }"
+        >
+          Missing
+        </Button>
+      </template>
 
       <Button
         variant="outline"

--- a/resources/js/pages/Monitoring/Index.vue
+++ b/resources/js/pages/Monitoring/Index.vue
@@ -196,7 +196,7 @@ const resetSession = async (sessionId: number) => {
     try {
         const res = await axios.post(`/monitoring/sessions/${sessionId}/reset`);
         const message = res.data?.message ?? 'Reset dispatched.';
-        res.data?.success ? toastSuccess(message) : toastError(message);
+        if (res.data?.success) { toastSuccess(message) } else { toastError(message) }
         await refreshMetrics();
     } catch (e: any) {
         toastError(e?.response?.data?.message ?? 'Reset failed — see browser console.');
@@ -229,7 +229,7 @@ const forceEndSession = async (sessionId: number, canSafelyForceEnd: boolean, un
     try {
         const res = await axios.post(`/monitoring/sessions/${sessionId}/force-end`, { force });
         const message = res.data?.message ?? 'Force-end submitted.';
-        res.data?.success ? toastSuccess(message) : toastError(message);
+        if (res.data?.success) { toastSuccess(message) } else { toastError(message) }
         await refreshMetrics();
     } catch (e: any) {
         toastError(e?.response?.data?.message ?? 'Force-end failed — see browser console.');

--- a/resources/js/types/models.d.ts
+++ b/resources/js/types/models.d.ts
@@ -124,6 +124,7 @@ export interface Menu {
     img_path: string;
     description: string;
     index: number;
+    has_uploaded_image: boolean;
     is_taxable: boolean;
     is_available: boolean;
     is_modifier: boolean;


### PR DESCRIPTION
Registers course, group, and has_uploaded_image columns so the faceted filter toolbar binds correctly. Adds Uploaded/Missing toggle buttons for image presence. Fixes nex-case-009.

## Summary

Describe the change briefly.

## Documentation governance checks

- [ ] This PR does not introduce duplicate canonical guidance.
- [ ] This PR does not introduce a second production deployment flow.
- [ ] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [ ] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [ ] `docs/INDEX.md` was updated if canonical docs changed.
