### PR TITLE
fix(pos): use Krypton MySQL NOW() for date_time_opened to fix table timer drift

### DIFF
--- a/app/Actions/Order/CreateOrder.php
+++ b/app/Actions/Order/CreateOrder.php
@@ -52,7 +52,6 @@ class CreateOrder
 
             // terminal_session_id can be null if not available from POS context
             $terminalSessionId = $attr['terminal_session_id'] ?? null;
-            $dateTimeOpened = now(); // Current date and time
             $dateTimeClosed = null; // Order is open initially
             $revenueId = $attr['revenue_id'] ?? 1; // Default revenue center
             $terminalId = $attr['terminal_id'] ?? 1; // Current POS terminal ID
@@ -72,10 +71,15 @@ class CreateOrder
             $terminalServiceId = $attr['terminal_service_id'];
             $isOnlineOrder = $attr['is_online_order']; // Default to false, can be set based on request
 
+            // date_time_opened is intentionally omitted here and replaced with NOW()
+            // inline in the stored procedure call below. Using PHP now() would anchor
+            // the timestamp to the Pi's system clock; if the Pi and the Krypton MySQL
+            // Windows machine have a clock difference, the POS table timer immediately
+            // shows a non-zero elapsed time on order creation.
             $params = [
                 $sessionId,
                 $terminalSessionId,
-                $dateTimeOpened,
+                // date_time_opened → NOW() inline in query (see placeholder below)
                 $dateTimeClosed,
                 $revenueId,
                 $terminalId,
@@ -115,8 +119,10 @@ class CreateOrder
                 ]);
             }
 
-            $placeholdersArray = array_fill(0, count($params), '?');
-            $placeholders = implode(', ', $placeholdersArray);
+            // Build placeholders: first 2 as bound params, then NOW() for date_time_opened,
+            // then the remaining 17 params. Total = 20 SP arguments.
+            $remainingCount = count($params) - 2;
+            $placeholders = '?, ?, NOW(), ' . implode(', ', array_fill(0, $remainingCount, '?'));
             // Call the procedure
             $order = Order::fromQuery('CALL create_order('.$placeholders.')', $params)->first();
 


### PR DESCRIPTION
## Problem

After a tablet order is submitted, the Krypton POS table turns green (correct) but the table timer immediately shows ~55 minutes elapsed instead of starting at 0.

## Root Cause

`CreateOrder.php` was passing PHP's `now()` as the `date_time_opened` parameter to the `create_order` stored procedure:

```php
$dateTimeOpened = now(); // Current date and time
```

`now()` uses the **Pi's system clock** (Asia/Manila). The Krypton POS computes the table timer as:

```
elapsed = Krypton_MySQL_NOW() - date_time_opened
```

If the Pi's clock is behind the Krypton MySQL Windows machine's clock (e.g., by ~55 minutes due to NTP drift or misconfiguration), `date_time_opened` is stored as a time that's already 55 minutes in the past from the POS's perspective — so the timer shows 55 minutes immediately on order creation.

## Fix

Replace the PHP `now()` binding with an inline `NOW()` SQL expression so `date_time_opened` is always set by the **Krypton MySQL server's own clock**:

```php
// Before (Pi clock, may drift vs Windows MySQL)
$placeholders = implode(', ', array_fill(0, count($params), '?'));

// After (Krypton MySQL server clock)
$remainingCount = count($params) - 2;
$placeholders = '?, ?, NOW(), ' . implode(', ', array_fill(0, $remainingCount, '?'));
```

`date_time_opened` is now always the same source of truth as what Krypton's `NOW()` returns when computing the elapsed timer — so it always starts at 0 regardless of any clock difference between Pi and Windows.

The fix covers both flows:
- Tablet order flow (`OrderService` → `CreateOrder`)
- Admin order flow (`PosOrderService` → `CreateOrder`)

## Additional Recommendation

Also verify the Pi's NTP sync is healthy:

```bash
timedatectl status
# Should show: NTP service: active, System clock synchronized: yes
```

Other timestamps (e.g., `device_orders.created_at`, print event times) still use the Pi's clock, so a large Pi clock drift may affect other monitoring displays too.

## Test Plan

- [ ] Submit a tablet order → Krypton POS table turns green → timer starts at **0 min**
- [ ] Admin creates order via POS panel → timer starts at **0 min**
- [ ] Existing unit tests pass (`php artisan test`)
- [ ] No regression in order creation flow (print, broadcast, etc.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm9X1Ndfddes6NDVkGyic8)_