### PR TITLE
fix: restrict DeviceOrderItems mass-assignment with explicit fillable

### DIFF
--- a/app/Models/DeviceOrderItems.php
+++ b/app/Models/DeviceOrderItems.php
@@ -14,7 +14,27 @@ class DeviceOrderItems extends Model
 {
     use SoftDeletes, HasFactory;
     protected $table = 'device_order_items';
-    protected $guarded = [];
+    protected $fillable = [
+        'order_id',
+        'ordered_menu_id',
+        'menu_id',
+        'quantity',
+        'price',
+        'subtotal',
+        'tax',
+        'discount',
+        'total',
+        'notes',
+        'seat_number',
+        'index',
+        'is_refill',
+        'is_printed',
+        'printed_at',
+        'printed_by_print_event_id',
+        'print_type',
+        'status',
+        'client_submission_id',
+    ];
 
     protected $casts = [
         'price' => 'decimal:4',


### PR DESCRIPTION
## Summary

- Replaces `$guarded = []` on `DeviceOrderItems` with an explicit `$fillable` list
- Only the fields actively written by server-side service code are included (`order_id`, `menu_id`, `quantity`, `price`, `subtotal`, `tax`, `discount`, `total`, `notes`, `seat_number`, `index`, `is_refill`, `is_printed`, `printed_at`, `printed_by_print_event_id`, `print_type`, `status`, `client_submission_id`)
- Sensitive audit columns (`id`, `created_at`, `updated_at`, `deleted_at`) are now protected from any unintended bulk-assignment

## Context

`DeviceOrderItems` is the only local (non-Krypton-mirror) writable model that had `$guarded = []`. The Krypton models with empty guards (`Order`, `Menu`, `Table`, etc.) are read-only POS mirrors and are unaffected.

The single `DeviceOrderItems::create()` call site (`app/Actions/Order/CreateOrderedMenu.php:123`) uses fully server-computed values — prices come from the POS response, not from user input — so there was no active exploitation path. This change closes the gap defensively for future code paths.

## Test plan

- [x] All 429 tests pass (`php artisan test`)
- [x] `PrintTicketService` tests that update `printed_by_print_event_id` and `print_type` still pass
- [ ] Verify `DeviceOrderItems::create()` in `CreateOrderedMenu` works end-to-end on a live order submission

https://claude.ai/code/session_01Cm9X1Ndfddes6NDVkGyic8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm9X1Ndfddes6NDVkGyic8)_