### PR TITLE
docs: improve operations manual, fix INDEX refs, clean up deprecated printer manual

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,36 +4,42 @@ This is the authoritative navigation root for active documentation.
 
 ## Deployment
 
-- `docs/deployment/production-docker.md` — canonical production deployment flow
-- `docs/deployment/tablet-update-contract.md` — tablet deployment boundary contract
+- [`docs/deployment/production-docker.md`](deployment/production-docker.md) — canonical production Docker deployment flow
+- [`docs/deployment/restaurant-operations-handover-manual.md`](deployment/restaurant-operations-handover-manual.md) — restaurant setup, daily operations, and handover guide
+- [`docs/deployment/tablet-update-contract.md`](deployment/tablet-update-contract.md) — tablet deployment boundary contract
 
 ## Architecture
 
-- `docs/architecture/ARCHITECTURE.md` — platform architecture and runtime topology
+- [`docs/architecture/ARCHITECTURE.md`](architecture/ARCHITECTURE.md) — platform architecture and runtime topology
 
 ## Operations
 
-- `docs/operations/scripts-reference.md` — script usage and operational script scope
+- [`docs/operations/scripts-reference.md`](operations/scripts-reference.md) — operational script entrypoints and execution context
 
 ## Standards
 
-- `docs/standards/documentation-governance.md` — documentation authority and lifecycle rules
-- `docs/standards/documentation-pr-checklist.md` — merge gate for documentation changes
-- `docs/standards/access-and-integration-rules.md` — access/integration rules
+- [`docs/standards/documentation-governance.md`](standards/documentation-governance.md) — documentation authority and lifecycle rules
+- [`docs/standards/documentation-pr-checklist.md`](standards/documentation-pr-checklist.md) — merge gate for documentation changes
+- [`docs/standards/access-and-integration-rules.md`](standards/access-and-integration-rules.md) — access and integration rules
 
-## API and contracts
+## API and Contracts
 
-- `docs/API_MAP.md`
-- `docs/print-events-contract.md`
-- `docs/print-events-contract-plan.md`
-- `docs/api/*`
+- [`docs/API_MAP.md`](API_MAP.md) — full API surface map
+- [`docs/print-events-contract.md`](print-events-contract.md) — print event contract (current)
+- [`docs/print-events-contract-plan.md`](print-events-contract-plan.md) — print event contract evolution plan
+- [`docs/printer_readme.md`](printer_readme.md) — printer app integration guide (device auth, endpoints, WebSocket)
+- [`docs/api/`](api/) — per-endpoint API documentation
 
-## Product guides
+## In-App Guides
 
-- `resources/docs/guides/admin/*`
-- `resources/docs/guides/tablet/*`
-- `resources/docs/guides/relay/*`
+In-app user guides are served from `resources/docs/guides/` and displayed within the
+Woosoo Nexus admin panel under **Manual**. They are organised by audience:
+
+- `resources/docs/guides/admin/` — admin panel guides *(guides pending)*
+- `resources/docs/guides/tablet/` — tablet PWA guides *(guides pending)*
+- `resources/docs/guides/relay/` — print relay guides *(guides pending)*
 
 ## Archive
 
-- `docs/archive/` — historical, migration, audit, and deprecated material (non-canonical)
+- [`docs/archive/`](archive/) — historical, migration, audit, and deprecated material (non-canonical)
+- [`docs/printer_manual.md`](printer_manual.md) — **archived** temporary printer workaround (superseded by `printer_readme.md`)

--- a/docs/deployment/restaurant-operations-handover-manual.md
+++ b/docs/deployment/restaurant-operations-handover-manual.md
@@ -1,33 +1,39 @@
 ---
 status: canonical
-last_reviewed: 2026-05-22
+last_reviewed: 2026-05-26
 scope: ecosystem
 ---
 
-# Woosoo Restaurant Operations And Handover Manual
+# Woosoo Restaurant Operations and Handover Manual
 
-This is the maintainable source for the DOCX handover manual. The final deliverable is `docs/deployment/woosoo-restaurant-operations-handover-manual.docx`.
+This is the maintainable source for the restaurant handover manual. The final deliverable is `docs/deployment/woosoo-restaurant-operations-handover-manual.docx`.
+
+---
 
 ## Restaurant Network Values
 
 | Item | Value |
 |---|---|
-| Woosoo server/Pi public host | `192.168.1.31` |
+| Woosoo server / Pi public host | `192.168.1.31` |
 | Krypton Woosoo PC / POS host | `192.168.1.32` |
 | Krypton subnet mask | `255.255.255.0` |
 | Krypton gateway | `192.168.1.1` |
 | POS database | `krypton_woosoo` |
 | POS database port | `2121` |
 
-Only restaurant network values are included. Do not use older sample values from non-restaurant examples for production handover.
+Only restaurant network values are listed here. Do not use older sample values (e.g. `192.168.100.7`) for any production handover.
+
+---
 
 ## Business Requirements
 
-- The restaurant ordering system must run on the local LAN.
+- The restaurant ordering system runs on the local LAN; internet connectivity is not required for order flow.
 - Woosoo Nexus owns business truth: pricing, packages, POS/Krypton writes, sessions, orders, realtime events, and print events.
-- The Tablet Ordering PWA sends customer intent only.
+- The Tablet Ordering PWA sends customer intent only — it does not hold authoritative state.
 - The Print Bridge confirms the last-mile print result through heartbeat and acknowledgement flows.
 - Operators must be able to deploy, redeploy, check logs, troubleshoot, roll back, and prove handover readiness without reading source code.
+
+---
 
 ## App Responsibilities
 
@@ -35,13 +41,17 @@ Only restaurant network values are included. Do not use older sample values from
 |---|---|---|
 | Woosoo Nexus | Laravel admin/API, POS integration, sessions, orders, Reverb, print events | Admin panel, device management, order monitoring, configuration checks |
 | Tablet Ordering PWA | Customer-facing tablet app | Register device, start session, select package/menu, submit order/refills/service requests |
-| Woosoo Print Bridge | Android printer relay | Keep printer online, receive print events, ACK/failed lifecycle |
+| Woosoo Print Bridge | Android printer relay app | Keep printer online, receive print events, ACK/failed lifecycle |
 | Krypton Woosoo PC | POS database host | Static IPv4 setup, POS database availability |
 | Platform Docker Stack | Runtime orchestration | Compose services, deployment scripts, certificates, logs |
+
+---
 
 ## How To Navigate The Apps
 
 ### Woosoo Nexus Admin
+
+Open a browser on any LAN device and navigate to `https://192.168.1.31`. Log in with your admin credentials.
 
 After login, use the left sidebar. Admin users see three groups:
 
@@ -51,29 +61,144 @@ After login, use the left sidebar. Admin users see three groups:
 | Analytics | Reports, Daily Sales, Hourly Sales, Guest Count, Menu Items, Order Status, Print Audit, Discount & Tax | End-of-day checks, sales analysis, print audit, guest and menu reporting |
 | Configuration | Branches, Access Control, Accessibility, Event Logs, Reverb Service, Monitoring | System setup, role/permission control, audit logs, realtime health, queue/database checks |
 
-Use **Dashboard** for the live overview, **Orders** for live orders and order history,
-**Devices** for tablet and relay setup, **Monitoring** for queue/database/Reverb health,
-and **Manual** for the in-app guide library. For POS-specific table/order inspection,
-use **POS** from the Main group.
+**Key pages for daily use:**
+- **Dashboard** — live overview of current sessions, orders, and active devices
+- **Orders** — live order list and full order history with status
+- **Devices** — register new tablets and print relay apps, copy device tokens, see last heartbeat
+- **Monitoring** — queue/database/Reverb health at a glance
+- **Manual** — in-app guide library (if configured)
 
 ### Tablet Ordering PWA
 
-The customer-facing tablet path is:
+The customer-facing tablet path follows this sequence:
 
 1. Open the welcome screen at `/`.
-2. If the tablet is not registered, open **Settings** from the gear icon, enter or create the PIN, and complete registration.
+2. If the tablet is not registered, tap the gear icon to open **Settings**, enter or create the PIN, then complete the device registration (see _Tablet Setup and Registration_ below).
 3. Tap **Begin the Feast**.
 4. Select guest count on `/order/start`.
 5. Choose a dining package on `/order/packageSelection`.
 6. Browse meats, sides, desserts, and drinks on `/menu`.
 7. Open the order summary and continue to `/order/review`.
-8. Submit the order; the app sends `POST /api/devices/create-order`.
+8. Submit the order — the app sends a request to the server.
 9. The tablet moves to `/order/in-session` for submitted items, refills, service requests, and session status.
-10. When the session ends, the tablet shows `/order/session-ended` and returns to the welcome screen for the next table.
+10. When the session ends, the tablet shows `/order/session-ended` for a few seconds then returns to the welcome screen for the next table.
 
-Staff-only tablet maintenance is under `/settings`. The emergency same-origin reset route is
-`/sw-reset`; use it only for dedicated-origin recovery when normal settings maintenance cannot
-refresh the active tablet app.
+**Staff-only maintenance** is under `/settings`. The emergency reset route is `/sw-reset` — use it only when normal settings maintenance cannot refresh a stuck tablet.
+
+### Woosoo Print Bridge (Android)
+
+The Print Bridge is an Android app that runs on a phone or tablet connected to the Bluetooth or USB printer.
+
+- Open the app and verify the **Server URL** is set to `https://192.168.1.31`.
+- Verify the **Device Token** matches the token issued in Nexus Admin → Devices.
+- The app shows a **heartbeat status indicator** — green means it is communicating with the server.
+- When an order is placed, the Bridge receives a WebSocket event and sends a print job to the connected printer.
+- Confirm each new print by checking the **Print Log** tab inside the app.
+
+---
+
+## Tablet Setup and Registration
+
+Complete these steps once for each physical tablet before handing it over for service.
+
+### Step 1 — Install the certificate (first tablet only, per network)
+
+1. On the Pi server, locate `docker/certs/fullchain.pem`.
+2. Transfer the certificate file to the tablet (email, USB, or network share).
+3. On the Android tablet: go to **Settings → Security → Install from storage**, select the `.pem` file, and install it as a **CA certificate** (not a Wi-Fi or VPN certificate).
+4. Name it something recognisable (e.g. `Woosoo Local CA`).
+
+> Skip this step if the tablet already trusts the certificate from a previous setup.
+
+### Step 2 — Open the app in Chrome
+
+1. Open **Chrome** on the tablet.
+2. Navigate to `https://192.168.1.31:4443`.
+3. If the browser shows a certificate warning, tap **Advanced → Proceed** (this only happens once after installing the CA).
+4. The Woosoo welcome screen should appear.
+
+### Step 3 — Create a device record in Admin
+
+1. On a PC or laptop, open `https://192.168.1.31` and log in.
+2. Go to **Devices** in the left sidebar.
+3. Click **Add Device** (or **New Device**).
+4. Enter:
+   - **Name**: a descriptive label, e.g. `Table 3 Tablet`
+   - **IP address**: the tablet's current LAN IP (visible in Android Settings → Wi-Fi → your network)
+   - **Table**: assign the table this tablet covers (optional but recommended)
+5. Save the device record.
+6. After saving, click the device row and find **Generate Token**. Click it.
+7. **Copy the token immediately** — it is shown only once.
+
+### Step 4 — Register the device on the tablet
+
+1. On the welcome screen, tap the **gear icon** (bottom corner) to open Settings.
+2. Enter the Settings PIN. If setting a PIN for the first time, choose a numeric PIN that staff will remember.
+3. In Settings, find **Device Registration** and paste the token you copied in Step 3.
+4. Tap **Register**. The tablet should confirm registration with a success message.
+5. Return to the welcome screen. The tablet is now ready for service.
+
+### Step 5 — Add the app to the home screen (kiosk mode)
+
+1. In Chrome, tap the **three-dot menu** (top right).
+2. Tap **Add to Home screen**.
+3. Confirm with **Add**.
+4. Close Chrome and launch the app from the home screen shortcut — it should open full-screen with no browser controls visible.
+5. Enable Android **Screen Pinning** (Settings → Security → Screen Pinning) and pin the app so guests cannot navigate outside it.
+
+### Step 6 — Verify the tablet is operational
+
+1. In Admin → Devices, find the tablet entry. The **Last Seen** timestamp should be recent.
+2. On the tablet, tap **Begin the Feast** and place a test order.
+3. Confirm the order appears in Admin → Orders.
+4. Confirm the order reaches the POS (Krypton).
+
+---
+
+## Print Bridge Setup
+
+Complete this once for each Android device that will act as a print relay.
+
+### Step 1 — Install and open the Print Bridge app
+
+1. Install the Woosoo Print Bridge APK on the Android device.
+2. Open the app.
+
+### Step 2 — Configure server connection
+
+1. In the app, go to **Settings** (gear icon).
+2. Set **Server URL** to `https://192.168.1.31`.
+3. Leave the WebSocket port as default unless the server is configured otherwise.
+
+### Step 3 — Create a device record for the Print Bridge
+
+1. In Nexus Admin → Devices, click **Add Device**.
+2. Enter:
+   - **Name**: e.g. `Kitchen Printer Relay`
+   - **IP address**: the Android device's LAN IP
+   - **Type**: Printer (if the type field is available)
+3. Save and click **Generate Token**. Copy the token.
+
+### Step 4 — Enter the device token in the app
+
+1. In the Print Bridge app Settings, paste the token into **Device Token**.
+2. Tap **Connect** or **Save**.
+3. The status indicator should turn green (connected).
+
+### Step 5 — Pair the Bluetooth or USB printer
+
+1. For Bluetooth: pair the printer through Android Bluetooth settings before opening the app.
+2. In the Print Bridge app, go to **Printer Settings** and select the paired printer from the list.
+3. Tap **Test Print** — a test receipt should print.
+
+### Step 6 — Verify end-to-end print flow
+
+1. Place a test order from a registered tablet.
+2. The Print Bridge app should receive the print event and show it in the **Print Log**.
+3. Confirm the physical printer prints the receipt.
+4. In Admin → Print Audit, verify the order shows `is_printed = true`.
+
+---
 
 ## Directory Structure
 
@@ -92,104 +217,253 @@ refresh the active tablet app.
 /etc/woosoo/woosoo.env
 ```
 
+---
+
 ## Common Commands
 
-Run commands from `/opt/woosoo/woosoo-platform` unless the step says otherwise.
+Run commands from `/opt/woosoo/woosoo-platform` unless a step says otherwise.
 
 ```bash
+# Navigate to platform root
 cd /opt/woosoo/woosoo-platform
-pwd
-ls -la
-cd woosoo-nexus
-cd ../tablet-ordering-pwa
-cd ..
-```
 
-```bash
+# Check service status
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml ps
+
+# Tail logs for each service
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 app
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 nginx
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 reverb
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 mysql redis
-```
 
-```bash
+# Run deployment helpers
 sudo bash scripts/deployment/doctor.sh
 sudo bash scripts/deployment/apply-woosoo-config.sh
 sudo bash scripts/deployment/deploy.sh
 ```
 
+---
+
 ## Smoke Checks
 
+Run these after every deployment to confirm the system is healthy.
+
 ```bash
+# Ping the POS host
 ping 192.168.1.32
+
+# Check Nexus admin is reachable
 curl -k https://192.168.1.31
+
+# Check Tablet PWA is reachable and has the correct build
 curl -k https://192.168.1.31:4443/build-info.json
+
+# Verify Laravel routes are loaded
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml exec -T app php artisan route:list
+
+# Clear cached config if environment changes were made
 docker compose --env-file ./woosoo-nexus/.env -f compose.yaml exec -T app php artisan config:clear
 ```
+
+---
 
 ## Workflows
 
 ### First-Time Restaurant Setup
 
-1. Set Krypton Woosoo PC IPv4 to `192.168.1.32`, `255.255.255.0`, gateway `192.168.1.1`.
+1. Set the Krypton Woosoo PC IPv4 to `192.168.1.32`, subnet mask `255.255.255.0`, gateway `192.168.1.1`.
 2. Confirm the Woosoo server/Pi is reachable at `192.168.1.31`.
-3. Confirm `/etc/woosoo/woosoo.env` exists and has restaurant values.
-4. Run `sudo bash scripts/deployment/doctor.sh`.
-5. Apply config and deploy from platform root.
-6. Open Nexus and Tablet PWA URLs.
-7. Register tablets and verify an order reaches POS and print flow.
+3. Confirm `/etc/woosoo/woosoo.env` exists and contains restaurant-specific values (not sample/placeholder values).
+4. Run `sudo bash scripts/deployment/doctor.sh` — resolve any failures before continuing.
+5. Apply config: `sudo bash scripts/deployment/apply-woosoo-config.sh`.
+6. Deploy: `sudo bash scripts/deployment/deploy.sh`.
+7. Open `https://192.168.1.31` (Nexus admin) and `https://192.168.1.31:4443` (Tablet PWA) in a browser.
+8. Register all tablets (see _Tablet Setup and Registration_).
+9. Set up the Print Bridge on the kitchen Android device (see _Print Bridge Setup_).
+10. Place a test order end-to-end: tablet → Nexus → POS → print.
 
 ### Daily Startup Check
 
-1. Verify all Docker services are up.
-2. Open Nexus admin.
-3. Open the tablet app.
-4. Ping the POS host.
-5. Check app, Reverb, MySQL, Redis, and nginx logs.
-6. Confirm printers are online in the bridge.
+Perform before the restaurant opens for the day.
 
-### Deployment And Redeployment
+1. **Check Docker services are up:**
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml ps
+   ```
+   All services (`nginx`, `app`, `queue`, `reverb`, `mysql`, `redis`, `tablet-pwa`) must show `Up` or `healthy`. If any service shows `Exit` or `Restarting`, restart it:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml restart <service-name>
+   ```
 
-1. Run preflight doctor.
-2. Confirm no uncommitted emergency changes exist on deployed repos.
+2. **Open Nexus admin** at `https://192.168.1.31` and verify the Dashboard loads correctly.
+
+3. **Open the Tablet PWA** at `https://192.168.1.31:4443` on at least one tablet and verify the welcome screen appears.
+
+4. **Ping the POS host:**
+   ```bash
+   ping 192.168.1.32
+   ```
+   Must return responses. If it fails, check Krypton PC power and network cable.
+
+5. **Check recent logs for errors:**
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=50 app nginx reverb
+   ```
+   Look for `ERROR` or `CRITICAL` lines. Investigate any that appeared since the last shutdown.
+
+6. **Verify Print Bridge is online:**
+   - Open the Print Bridge app on the kitchen Android device.
+   - Confirm the status indicator is green.
+   - Check Admin → Devices for the relay device — **Last Seen** should be within the last few minutes.
+
+7. **Run a smoke check** (optional but recommended before busy service):
+   ```bash
+   curl -k https://192.168.1.31:4443/build-info.json
+   ```
+   Confirms the tablet PWA is serving the expected build.
+
+### Deployment and Redeployment
+
+1. Run `sudo bash scripts/deployment/doctor.sh` — fix any preflight failures.
+2. Confirm no uncommitted emergency changes exist in the deployed repos.
 3. Run `sudo bash scripts/deployment/deploy.sh`.
-4. Check Docker service health.
-5. Clear and cache Laravel config if needed.
-6. Confirm tablet build info from `https://192.168.1.31:4443/build-info.json`.
-7. Run the acceptance checklist.
+4. After the script completes, check Docker service health with `docker compose ... ps`.
+5. Clear and recache Laravel config if environment variables changed:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml exec -T app php artisan config:clear
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml exec -T app php artisan config:cache
+   ```
+6. Confirm the tablet build is updated:
+   ```bash
+   curl -k https://192.168.1.31:4443/build-info.json
+   ```
+7. Run the acceptance checklist (see _Final Handover Acceptance_).
+
+---
+
+## Emergency Procedures
+
+### Server Unreachable — Admin Panel / Tablet App Not Loading
+
+1. SSH into the Pi server.
+2. Check Docker service status:
+   ```bash
+   cd /opt/woosoo/woosoo-platform
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml ps
+   ```
+3. If `nginx` is down, restart it:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml restart nginx
+   ```
+4. If `app` is down:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml restart app
+   ```
+5. If all services are down or the Pi has rebooted, bring everything back up:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml up -d
+   ```
+6. Wait 60 seconds then re-test `curl -k https://192.168.1.31`.
+
+### Tablets Cannot Connect or Show an Error Screen
+
+1. Confirm the Wi-Fi on the tablet is connected to the restaurant LAN.
+2. From the tablet's Chrome browser, navigate to `https://192.168.1.31` to check if the server itself is reachable.
+3. If the server is reachable but the PWA is broken, try a hard refresh:
+   - Chrome on Android: tap the three-dot menu → **Reload**.
+   - If a refresh does not fix it: tap the three-dot menu → **Settings → Privacy → Clear browsing data** (cookies and cached files), then reload.
+4. If the tablet is stuck and cannot be refreshed normally, navigate to `https://192.168.1.31:4443/sw-reset` to perform an emergency service-worker reset.
+5. After reset, return to `https://192.168.1.31:4443` and re-register the device if prompted.
+
+### Orders Not Printing
+
+1. Open the Print Bridge app and check the status indicator — if it is red, the relay lost connection to the server.
+   - Tap **Reconnect** or restart the app.
+2. Check Admin → Devices for the relay device — **Last Seen** shows when the last heartbeat arrived.
+3. If the printer is offline:
+   - Check Bluetooth is enabled and the printer is powered on.
+   - In Print Bridge app → Printer Settings, re-select the printer and tap **Test Print**.
+4. If print events are being received but not printing:
+   - In Print Bridge app → Print Log, look for failed entries and tap the entry to retry.
+5. In Nexus Admin → Print Audit, find affected orders. Mark them manually printed if needed to keep the kitchen informed.
+
+### POS Connection Fails — Orders Not Reaching Krypton
+
+1. `ping 192.168.1.32` — if this fails, the Krypton PC is unreachable. Check the PC is powered on and the Ethernet cable is connected.
+2. If the PC is on but unreachable, verify its IP has not changed (must be `192.168.1.32` static).
+3. Check Nexus app logs for database connection errors:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=50 app | grep -i "POS\|krypton\|2121"
+   ```
+4. If the POS service on Krypton has stopped, restart the Krypton Woosoo service on the PC.
+
+### Reverb / WebSocket Errors — Realtime Updates Not Working
+
+1. Check Reverb service:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=50 reverb
+   ```
+2. Restart Reverb if it has crashed:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml restart reverb
+   ```
+3. Clear and recache the app config:
+   ```bash
+   docker compose --env-file ./woosoo-nexus/.env -f compose.yaml exec -T app php artisan config:clear
+   ```
+4. In Admin → Configuration → Reverb Service, verify the status shows **running**.
+
+---
 
 ## Troubleshooting Matrix
 
-| Symptom | First Check | Command |
+| Symptom | First Check | Command / Action |
 |---|---|---|
-| Nexus admin unreachable | nginx/app health | `docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 nginx app` |
+| Nexus admin unreachable | nginx / app health | `docker compose ... logs --tail=100 nginx app` |
 | Tablet app unreachable | tablet container and HTTPS port | `curl -k https://192.168.1.31:4443/build-info.json` |
+| Tablet shows certificate warning | CA not installed on tablet | Install `docker/certs/fullchain.pem` as CA on tablet |
+| Tablet stuck on welcome screen after order | Session or device token issue | Check Admin → Devices for last-seen; re-register if token expired |
 | POS connection fails | Krypton PC network and DB port | `ping 192.168.1.32` |
-| Reverb/WebSocket fails | Reverb logs and app env | `docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 reverb app` |
-| MySQL/Redis unhealthy | service status and logs | `docker compose --env-file ./woosoo-nexus/.env -f compose.yaml logs --tail=100 mysql redis` |
-| Tablet stuck on old build | build-info endpoint | `curl -k https://192.168.1.31:4443/build-info.json` |
-| Orders do not print | bridge heartbeat and print events | Check Print Bridge app status and Nexus print-event logs |
-| Deployment script fails | preflight variables | `sudo bash scripts/deployment/doctor.sh` |
+| Orders not appearing in POS | App logs for DB errors | `docker compose ... logs --tail=50 app \| grep krypton` |
+| Reverb / WebSocket fails | Reverb logs and app env | `docker compose ... logs --tail=100 reverb app` |
+| MySQL / Redis unhealthy | Service status and logs | `docker compose ... logs --tail=100 mysql redis` |
+| Tablet stuck on old build | Build-info endpoint | `curl -k https://192.168.1.31:4443/build-info.json` |
+| Orders do not print | Print Bridge heartbeat and print events | Check Print Bridge app status; check Admin → Print Audit |
+| Print Bridge shows red / disconnected | Device token or server URL | Verify token in Print Bridge matches Nexus Admin → Devices |
+| Deployment script fails | Preflight variables | `sudo bash scripts/deployment/doctor.sh` |
+| Queue not processing jobs | Queue service status | `docker compose ... logs --tail=50 queue` then restart if needed |
+| Service requests not arriving | Session active on tablet | Confirm tablet is in `/order/in-session`; check realtime connection |
+
+---
 
 ## Screenshot Checklist
 
+Capture these screenshots during setup and attach to the handover report.
+
 - Windows adapter list with the active Ethernet adapter selected.
 - IPv4 dialog showing IP `192.168.1.32`, mask `255.255.255.0`, gateway `192.168.1.1`.
-- `/etc/woosoo/woosoo.env` with sensitive values hidden.
-- `docker compose ps` showing expected services.
-- Nexus admin login or dashboard.
+- `/etc/woosoo/woosoo.env` open with sensitive values hidden.
+- `docker compose ps` output showing all expected services.
+- Nexus admin dashboard loaded in browser.
 - Tablet PWA loaded at `https://192.168.1.31:4443`.
-- POS connectivity check.
-- Print Bridge status screen.
+- Admin → Devices showing registered tablet(s) with a recent **Last Seen** timestamp.
+- Print Bridge app status screen showing green (connected).
+- A test receipt printed by the Print Bridge.
+- POS connectivity confirmed (ping or Krypton UI).
+
+---
 
 ## Final Handover Acceptance
 
-- Nexus reachable at `https://192.168.1.31`.
-- Tablet PWA reachable at `https://192.168.1.31:4443`.
-- POS host `192.168.1.32` reachable.
-- One test order reaches POS.
-- Print flow verified through Print Bridge ACK or operator-confirmed print.
-- Logs reviewed with no unresolved deployment blockers.
-- Rollback path and backup location explained to operator.
+All items below must be confirmed before handover is complete.
+
+- [ ] Nexus admin reachable at `https://192.168.1.31`.
+- [ ] Tablet PWA reachable at `https://192.168.1.31:4443`.
+- [ ] POS host `192.168.1.32` reachable (ping responds).
+- [ ] All tablets registered in Admin → Devices with recent Last Seen.
+- [ ] One full end-to-end test order placed: tablet → Nexus → POS → receipt printed.
+- [ ] Print Bridge online and heartbeat confirmed in Admin → Devices.
+- [ ] Logs reviewed with no unresolved deployment blockers.
+- [ ] Rollback path and backup location explained to the operator.
+- [ ] Operator has confirmed they can log in to Nexus admin independently.
+- [ ] Operator has the Settings PIN for at least one registered tablet.

--- a/docs/operations/scripts-reference.md
+++ b/docs/operations/scripts-reference.md
@@ -2,24 +2,36 @@
 
 This document lists active operational script entrypoints.
 
-## Deployment scripts
+## Deployment Scripts
 
-- `scripts/deployment/verify-tablet-deploy-context.sh`
-- `scripts/deployment/deploy-tablet.sh`
-- `scripts/deployment/apply-woosoo-config.sh`
-- `scripts/deployment/woosoo-health.sh`
-- `scripts/deployment/woosoo-backup.sh`
+| Script | Purpose |
+|---|---|
+| `scripts/deployment/doctor.sh` | Preflight check — verifies environment, network, and config before deployment |
+| `scripts/deployment/apply-woosoo-config.sh` | Applies config from `/etc/woosoo/woosoo.env` to the platform |
+| `scripts/deployment/deploy.sh` | Full platform deploy (pulls latest, rebuilds, restarts services) |
+| `scripts/deployment/verify-tablet-deploy-context.sh` | Preflight only — validates Nexus and Tablet git state before tablet deploy |
+| `scripts/deployment/deploy-tablet.sh` | Deploy Tablet PWA from explicit Nexus and Tablet git refs |
+| `scripts/deployment/woosoo-health.sh` | Post-deploy health check |
+| `scripts/deployment/woosoo-backup.sh` | Database and volume backup |
 
-## Canonical execution context
+## Canonical Execution Context
 
-Run production deployment scripts from:
+Run all production deployment scripts from the platform root on the server:
 
-`E:\Projects\woosoo-nexus`
+```bash
+cd /opt/woosoo/woosoo-platform
+```
 
-Use Docker orchestration via:
+Docker orchestration is via `compose.yaml` in this directory:
 
-`compose.yaml`
+```bash
+docker compose --env-file ./woosoo-nexus/.env -f compose.yaml <command>
+```
 
-## Non-canonical scripts
+> **Note:** Do not run deployment scripts from a Windows path or from inside the `woosoo-nexus/`
+> subdirectory — always run from `/opt/woosoo/woosoo-platform` on the Pi server.
 
-Historical or deprecated script workflows are archived under `docs/archive/` and are not production authority.
+## Non-Canonical Scripts
+
+Historical or deprecated script workflows are archived under `docs/archive/` and are not
+production authority. Do not use them for live deployments.

--- a/docs/printer_manual.md
+++ b/docs/printer_manual.md
@@ -1,74 +1,29 @@
-# Printer API Temporary User Manual
+# Printer API — Deprecated Workaround Notice
 
-> **⚠️ DEPRECATED:** This document describes a **temporary workaround** for guest access to printer endpoints. This approach has **security implications** and should be replaced with proper device token authentication.
-> 
-> **For current printer integration:** See **[printer_readme.md](printer_readme.md)** for the authoritative integration guide with device authentication.
-
-## Purpose
-- Explain the temporary change allowing the printer app to call the printer API endpoints as guest.
-- Provide usage examples, security considerations, and rollback instructions for the print and ops teams.
-
-## Location
-- This file is stored at `docs/printer_manual.md` in the repository. Link from the main docs index if desired.
-
-What changed (temporary)
-- The following API routes were moved from the `auth:device` group to a guest-accessible group so the Flutter printer app can reach them without device tokens:
-  - POST /api/orders/{orderId}/printed
-  - GET  /api/orders/unprinted
-  - POST /api/orders/printed/bulk
-  - POST /api/printer/heartbeat
-- No URIs or controller handlers were modified — only route middleware changed.
-
-Quick usage (examples)
-- curl (Linux/macOS):
-
-  # Fetch unprinted orders (replace host/port)
-  curl "http://localhost/api/orders/unprinted"
-
-  # Mark multiple orders printed
-  curl -X POST "http://localhost/api/orders/printed/bulk" \
-    -H "Content-Type: application/json" \
-    -d '[1001,1002]'
-
-  # Mark single order printed
-  curl -X POST "http://localhost/api/orders/1001/printed" \
-    -H "Content-Type: application/json" \
-    -d '{}'
-
-  # Heartbeat
-  curl -X POST "http://localhost/api/printer/heartbeat" \
-    -H "Content-Type: application/json" \
-    -d '{"session_id":123}'
-
-- PowerShell (Windows):
-
-  Invoke-WebRequest -Uri http://localhost/api/orders/unprinted -UseBasicParsing
-  Invoke-WebRequest -Method POST -Uri http://localhost/api/orders/printed/bulk -ContentType 'application/json' -Body '[1001,1002]'
-  Invoke-WebRequest -Method POST -Uri http://localhost/api/orders/1001/printed -ContentType 'application/json' -Body '{}'
-  Invoke-WebRequest -Method POST -Uri http://localhost/api/printer/heartbeat -ContentType 'application/json' -Body '{"session_id":123}'
-
-Security notes (important)
-- These endpoints are now accessible without authentication. That increases risk of accidental or malicious calls that can mark orders as printed.
-- Recommended temporary mitigations (pick one):
-  1. IP whitelist middleware: only allow known printer IPs/subnets.
-  2. Shared-secret / HMAC header: require a secret header the printers include and verify server-side.
-  3. Rate limiting: throttle requests per IP to reduce abuse risk.
-- Long-term: revert to `auth:device` and ensure printer app authenticates using device tokens (preferred).
-
-Operational guidance
-- Verify that the printers can reach the app host and that any local firewall allows outbound traffic to the app port.
-- Run quick smoke tests (from the host or printer network) using the curl/PowerShell snippets above.
-- Monitor logs (`storage/logs/laravel.log`) for unusual activity after change.
-- If you need to restrict access quickly, I can implement an IP whitelist middleware and apply it to these routes.
-
-Rollback plan
-- Revert the single commit that moved middleware (or restore the prior `auth:device` group in `routes/api.php`).
-- Re-deploy and verify printers authenticate with tokens (if available).
-
-Contact & next steps
-- If you want me to implement a mitigation (IP whitelist or HMAC) before opening a PR, say which and I will implement it and add tests.
-- If you want this manual added to the documentation index, I can update `docs/api.md` or the docs index accordingly.
+> **ARCHIVED — DO NOT USE FOR NEW INTEGRATIONS**
+>
+> This document described a temporary workaround that removed authentication from printer API
+> endpoints. That change has been superseded. All printer API calls must now use a device
+> Bearer token obtained through device registration.
+>
+> **See the current integration guide:** [printer_readme.md](printer_readme.md)
 
 ---
-File: docs/printer_manual.md
-Created: temporary manual for printer team
+
+## What this document was
+
+This file documented a short-lived change that moved printer endpoints out of the
+`auth:device` middleware group so the Flutter printer app could call them without tokens.
+That approach was a temporary workaround with known security implications.
+
+## Current approach
+
+- Register the printer app as a device using `POST /api/devices/register`.
+- Use the returned Bearer token on all printer API calls.
+- See [printer_readme.md](printer_readme.md) for the full integration guide including endpoint
+  details, payload examples, WebSocket integration, and operational recommendations.
+
+## Archive note
+
+This file is retained for historical context only. It does not reflect the current system
+behaviour. If you are setting up a new print integration, follow `printer_readme.md`.


### PR DESCRIPTION
## Summary

- **`docs/deployment/restaurant-operations-handover-manual.md`** — Major expansion of the primary user-facing operations manual. Added step-by-step Tablet Registration (6 steps including CA cert install, device creation in admin, token entry, and kiosk pinning), a full Print Bridge Setup section (was completely missing), an expanded Daily Startup Check with actual commands, a new Emergency Procedures section covering server unreachable / tablets disconnected / prints failing / POS failure / Reverb failure, and an expanded Troubleshooting Matrix with 6 new rows including Print Bridge disconnect and queue failures.

- **`docs/printer_manual.md`** — Replaced the cluttered deprecated workaround with a clean archived notice. Retains the historical context (why it existed) but clearly redirects all readers to `printer_readme.md`. Removes the confusing security-workaround detail that should not be followed.

- **`docs/INDEX.md`** — Fixed broken references. The `resources/docs/guides/admin|tablet|relay` directories are empty placeholders; the index now marks them as `(guides pending)` so readers know they exist but have no content yet. Added the restaurant operations manual as a direct link. Added the archived `printer_manual.md` entry with a clear `archived` label.

- **`docs/operations/scripts-reference.md`** — Fixed execution context path from `E:\Projects\woosoo-nexus` (Windows, wrong) to `/opt/woosoo/woosoo-platform` (Linux Pi server, correct). Added a table of scripts with descriptions and a warning not to run from subdirectories.

## Test plan

- [ ] Read through `restaurant-operations-handover-manual.md` end-to-end and verify all steps are accurate for the actual restaurant setup
- [ ] Confirm tablet registration steps match the current admin panel UI
- [ ] Confirm Print Bridge setup steps match the actual Android app
- [ ] Verify all commands in the expanded Daily Startup and Emergency sections are correct
- [ ] Check INDEX.md links resolve to files that exist
- [ ] Confirm `scripts-reference.md` execution path matches the actual server layout at `/opt/woosoo/woosoo-platform`

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgnHzJ5tHDsEakVKgKFpxM)_