### PR TITLE
feat(infra): run npm run build in entrypoint on php-fpm startup

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,4 +16,15 @@ chmod -R ug+rwX storage bootstrap/cache 2>/dev/null || true
 # Create storage symlink if missing (public/storage → storage/app/public)
 php artisan storage:link --quiet 2>/dev/null || true
 
+# Build Vite assets on web server startup so public/build/ is always in sync
+# with the current source tree. Runs only for the php-fpm process (not for
+# queue, scheduler, or reverb which share this entrypoint via CMD override).
+# node_modules comes from the image's anonymous volume (compose.yaml), so
+# this works identically on Linux (Pi) and Docker Desktop Windows.
+if [ "${1:-}" = "php-fpm" ]; then
+  echo "[entrypoint] Building Vite assets..."
+  npm run build && echo "[entrypoint] Vite build complete." \
+    || echo "[entrypoint] WARNING: Vite build failed; serving existing assets from nexus_build volume"
+fi
+
 exec "$@"


### PR DESCRIPTION
On web server container startup, rebuild Vite assets before php-fpm starts. This keeps public/build (nexus_build named volume) in sync with whatever source files the bind-mount provides without requiring manual npm run build on the host.

Only runs when CMD is php-fpm, not for queue/scheduler/reverb. Build failure is non-fatal: logs a warning and continues with existing volume contents so the container does not crash-loop.

## Summary

Describe the change briefly.

## Documentation governance checks

- [ ] This PR does not introduce duplicate canonical guidance.
- [ ] This PR does not introduce a second production deployment flow.
- [ ] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [ ] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [ ] `docs/INDEX.md` was updated if canonical docs changed.
