### PR TITLE
Exclude handoff directory from ESLint checks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ export default defineConfigWithVueTs(
     vue.configs['flat/essential'],
     vueTsConfigs.recommended,
     {
-        ignores: ['vendor', 'node_modules', 'public', 'bootstrap/ssr', 'tailwind.config.js', 'resources/js/components/ui/*'],
+        ignores: ['vendor', 'node_modules', 'public', 'bootstrap/ssr', 'tailwind.config.js', 'resources/js/components/ui/*', 'handoff'],
     },
     {
         rules: {


### PR DESCRIPTION
## Summary

Added `'handoff'` to the ESLint ignore list in `eslint.config.js` to prevent linting of files in the handoff directory.

## Documentation governance checks

- [x] This PR does not introduce duplicate canonical guidance.
- [x] This PR does not introduce a second production deployment flow.
- [x] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [x] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [x] `docs/INDEX.md` was updated if canonical docs changed.

## Test Plan

No testing needed. This is a configuration change that excludes a directory from linting.

https://claude.ai/code/session_01Smfsm69raxuoD7Cf44uQ4y