### PR TITLE
feat(infra): conditional Vite build in entrypoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,15 +16,26 @@ chmod -R ug+rwX storage bootstrap/cache 2>/dev/null || true
 # Create storage symlink if missing (public/storage → storage/app/public)
 php artisan storage:link --quiet 2>/dev/null || true
 
-# Build Vite assets on web server startup so public/build/ is always in sync
-# with the current source tree. Runs only for the php-fpm process (not for
-# queue, scheduler, or reverb which share this entrypoint via CMD override).
-# node_modules comes from the image's anonymous volume (compose.yaml), so
-# this works identically on Linux (Pi) and Docker Desktop Windows.
+# Build Vite assets only when needed. Runs only for the php-fpm process (not
+# for queue, scheduler, or reverb which share this entrypoint via CMD override).
+# node_modules comes from the image's anonymous volume (compose.yaml), so this
+# works identically on Linux (Pi) and Docker Desktop Windows.
+#
+# Build triggers ONLY when:
+#   - public/build is missing/empty (fresh checkout — self-healing), OR
+#   - WOOSOO_FORCE_VITE_BUILD=true (deploy of new code forces fresh assets).
+# A plain container restart (crash/OOM/reboot) with assets already present
+# SKIPS the build, so recovery is fast instead of a ~1-minute rebuild.
 if [ "${1:-}" = "php-fpm" ]; then
-  echo "[entrypoint] Building Vite assets..."
-  npm run build && echo "[entrypoint] Vite build complete." \
-    || echo "[entrypoint] WARNING: Vite build failed; serving existing assets from nexus_build volume"
+  if [ "${WOOSOO_FORCE_VITE_BUILD:-false}" = "true" ] \
+     || [ ! -d public/build ] \
+     || [ -z "$(ls -A public/build 2>/dev/null)" ]; then
+    echo "[entrypoint] Building Vite assets..."
+    npm run build && echo "[entrypoint] Vite build complete." \
+      || echo "[entrypoint] WARNING: Vite build failed; serving existing assets"
+  else
+    echo "[entrypoint] public/build present — skipping Vite build (set WOOSOO_FORCE_VITE_BUILD=true to force)."
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
Replace the unconditional `npm run build` in docker/docker-entrypoint.sh with a nested-if guard. The build now runs only when:
  - public/build is missing/empty (fresh checkout, self-healing), or
  - WOOSOO_FORCE_VITE_BUILD=true (deploy-time forced refresh).

A plain restart (crash/OOM/reboot) with assets already present skips the build entirely, cutting recovery time from ~90s to ~10s. Verified on Docker Desktop: restart logs "public/build present — skipping Vite build"; force flag triggers build despite populated dir.

Stays #!/usr/bin/env sh and reuses the existing self-defusing `npm run build || echo WARNING` pattern, so a build failure still falls through to `exec "$@"` without aborting the container.

Pair: woosoo-platform commits adding the WOOSOO_FORCE_VITE_BUILD passthrough on compose.yaml app.environment + the one-off `run --rm app npm run build` in scripts/deployment/deploy.sh.

Case: docs/cases/infra-vite-build-conditional.md (Executioner APPROVED).

## Summary

Describe the change briefly.

## Documentation governance checks

- [ ] This PR does not introduce duplicate canonical guidance.
- [ ] This PR does not introduce a second production deployment flow.
- [ ] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [ ] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [ ] `docs/INDEX.md` was updated if canonical docs changed.
