### PR TITLE
fix(nex-013): refresh POS detail values before broadcasting (PR #158 P1)

### DIFF
--- a/app/Console/Commands/ConsumePosOrderDetailEvents.php
+++ b/app/Console/Commands/ConsumePosOrderDetailEvents.php
@@ -133,18 +133,21 @@ class ConsumePosOrderDetailEvents extends Command
             $deviceOrder->guest_count = (int) $guestCount;
         }
 
-        $check = $pos->table('order_checks')->where('order_id', $posOrderId)->first();
+        $check = $pos->table('order_checks')
+            ->where('order_id', $posOrderId)
+            ->orderByDesc('id')
+            ->first();
         if ($check !== null) {
-            if (isset($check->subtotal_amount)) {
+            if (property_exists($check, 'subtotal_amount')) {
                 $deviceOrder->subtotal = $check->subtotal_amount;
             }
-            if (isset($check->tax_amount)) {
+            if (property_exists($check, 'tax_amount')) {
                 $deviceOrder->tax = $check->tax_amount;
             }
-            if (isset($check->discount_amount)) {
+            if (property_exists($check, 'discount_amount')) {
                 $deviceOrder->discount = $check->discount_amount;
             }
-            if (isset($check->total_amount)) {
+            if (property_exists($check, 'total_amount')) {
                 $deviceOrder->total = $check->total_amount;
             }
         }

--- a/app/Console/Commands/ConsumePosOrderDetailEvents.php
+++ b/app/Console/Commands/ConsumePosOrderDetailEvents.php
@@ -78,6 +78,14 @@ class ConsumePosOrderDetailEvents extends Command
                     );
                 }
 
+                // Refresh POS-authoritative detail values onto the local row
+                // BEFORE broadcasting. The outbox row carries only pos_order_id;
+                // guest_count lives on POS `orders` and the monetary totals on
+                // POS `order_checks`. Without this, OrderBroadcastPayload would
+                // serialize the stale local columns and the detail update the
+                // trigger fired for would be silently lost.
+                $this->refreshDetailFromPos($deviceOrder, $posOrderId);
+
                 $broadcaster->detailsUpdated($deviceOrder);
 
                 DB::connection('pos')
@@ -105,6 +113,45 @@ class ConsumePosOrderDetailEvents extends Command
         $this->info("POS detail outbox consumed: processed={$processed}, failed={$failed}, limit={$limit}");
 
         return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Re-read POS-authoritative detail columns and persist them onto the local
+     * DeviceOrder so the broadcast carries fresh values. POS is the source of
+     * truth: `guest_count` on `orders`, monetary totals on `order_checks`
+     * (`Order` hasOne `OrderCheck` by `order_id`). The tablet renders these
+     * read-only and never recomputes pricing. The POS connection is already
+     * proven reachable (the outbox read above succeeded), so a missing row
+     * simply returns null and is skipped rather than treated as an error.
+     */
+    private function refreshDetailFromPos(DeviceOrder $deviceOrder, int $posOrderId): void
+    {
+        $pos = DB::connection('pos');
+
+        $guestCount = $pos->table('orders')->where('id', $posOrderId)->value('guest_count');
+        if ($guestCount !== null) {
+            $deviceOrder->guest_count = (int) $guestCount;
+        }
+
+        $check = $pos->table('order_checks')->where('order_id', $posOrderId)->first();
+        if ($check !== null) {
+            if (isset($check->subtotal_amount)) {
+                $deviceOrder->subtotal = $check->subtotal_amount;
+            }
+            if (isset($check->tax_amount)) {
+                $deviceOrder->tax = $check->tax_amount;
+            }
+            if (isset($check->discount_amount)) {
+                $deviceOrder->discount = $check->discount_amount;
+            }
+            if (isset($check->total_amount)) {
+                $deviceOrder->total = $check->total_amount;
+            }
+        }
+
+        if ($deviceOrder->isDirty()) {
+            $deviceOrder->save();
+        }
     }
 
     private function recordFailure(object $row, \Throwable $e): void

--- a/tests/Feature/Pos/PosOrderDetailSyncTest.php
+++ b/tests/Feature/Pos/PosOrderDetailSyncTest.php
@@ -161,6 +161,74 @@ class PosOrderDetailSyncTest extends TestCase
         $this->assertSame('order.details.updated', $event->broadcastAs());
     }
 
+    public function test_consumer_uses_latest_order_check_when_multiple_exist(): void
+    {
+        Event::fake([OrderDetailsUpdated::class]);
+
+        $order = DeviceOrder::factory()->confirmed()->create([
+            'order_id' => 900304,
+            'subtotal' => 0.00,
+            'tax'      => 0.00,
+            'discount' => 0.00,
+            'total'    => 0.00,
+        ]);
+
+        $this->seedPosOrder(900304, guestCount: 2);
+
+        // Lower-ID check: stale inflated values that must NOT be picked up.
+        DB::connection('pos')->table('order_checks')->insert([
+            'order_id'        => 900304,
+            'subtotal_amount' => 999.00,
+            'tax_amount'      => 99.00,
+            'discount_amount' => 0.00,
+            'total_amount'    => 1098.00,
+        ]);
+
+        // Higher-ID check: the real values the consumer must use.
+        $this->seedPosCheck(900304, subtotal: 50.00, tax: 5.00, discount: 2.00, total: 53.00);
+
+        $outboxId = $this->insertDetailOutboxRow($order->order_id);
+
+        $this->artisan('pos:consume-order-detail-events')->assertExitCode(0);
+
+        $this->assertOutboxProcessed($outboxId);
+
+        $order->refresh();
+        $this->assertEquals(50.00, (float) $order->subtotal);
+        $this->assertEquals(5.00, (float) $order->tax);
+        $this->assertEquals(2.00, (float) $order->discount);
+        $this->assertEquals(53.00, (float) $order->total);
+    }
+
+    public function test_consumer_persists_null_pos_totals_over_stale_local_values(): void
+    {
+        Event::fake([OrderDetailsUpdated::class]);
+
+        $order = DeviceOrder::factory()->confirmed()->create([
+            'order_id' => 900305,
+            'discount' => 50.00,
+        ]);
+
+        $this->seedPosOrder(900305, guestCount: 1);
+
+        // POS check has a null discount — must propagate and overwrite the stale local value.
+        DB::connection('pos')->table('order_checks')->insert([
+            'order_id'        => 900305,
+            'subtotal_amount' => 100.00,
+            'tax_amount'      => 10.00,
+            'discount_amount' => null,
+            'total_amount'    => 110.00,
+        ]);
+
+        $outboxId = $this->insertDetailOutboxRow($order->order_id);
+
+        $this->artisan('pos:consume-order-detail-events')->assertExitCode(0);
+
+        $this->assertOutboxProcessed($outboxId);
+
+        $this->assertNull(DeviceOrder::find($order->id)->discount);
+    }
+
     private function seedPosOrder(int $posOrderId, int $guestCount): void
     {
         DB::connection('pos')->table('orders')->insert([

--- a/tests/Feature/Pos/PosOrderDetailSyncTest.php
+++ b/tests/Feature/Pos/PosOrderDetailSyncTest.php
@@ -41,24 +41,63 @@ class PosOrderDetailSyncTest extends TestCase
             $table->text('last_error')->nullable();
             $table->timestamps();
         });
+
+        // POS source tables the consumer re-reads to refresh authoritative
+        // detail values (guest_count on `orders`, totals on `order_checks`).
+        $schema->dropIfExists('orders');
+        $schema->create('orders', function (Blueprint $table): void {
+            $table->unsignedBigInteger('id')->primary();
+            $table->unsignedInteger('guest_count')->nullable();
+        });
+        $schema->dropIfExists('order_checks');
+        $schema->create('order_checks', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->unsignedBigInteger('order_id')->index();
+            $table->decimal('subtotal_amount', 12, 2)->nullable();
+            $table->decimal('tax_amount', 12, 2)->nullable();
+            $table->decimal('discount_amount', 12, 2)->nullable();
+            $table->decimal('total_amount', 12, 2)->nullable();
+        });
     }
 
-    public function test_consumer_dispatches_order_details_updated_for_matched_pos_order_id(): void
+    public function test_consumer_refreshes_pos_detail_values_before_dispatching(): void
     {
         Event::fake([OrderDetailsUpdated::class]);
 
+        // Local row holds the PRE-edit values.
         $order = DeviceOrder::factory()->confirmed()->create([
-            'order_id' => 900301,
+            'order_id'    => 900301,
+            'guest_count' => 2,
+            'subtotal'    => 90.00,
+            'tax'         => 10.00,
+            'discount'    => 0.00,
+            'total'       => 100.00,
         ]);
+
+        // POS cashier edits the order: +2 guests and new totals.
+        $this->seedPosOrder(900301, guestCount: 4);
+        $this->seedPosCheck(900301, subtotal: 180.00, tax: 20.00, discount: 5.00, total: 195.00);
+
         $outboxId = $this->insertDetailOutboxRow($order->order_id);
 
         $this->artisan('pos:consume-order-detail-events')->assertExitCode(0);
 
         $this->assertOutboxProcessed($outboxId);
 
+        // The local row must be refreshed from POS (the fix) — not left stale.
+        $order->refresh();
+        $this->assertSame(4, (int) $order->guest_count);
+        $this->assertEquals(180.00, (float) $order->subtotal);
+        $this->assertEquals(20.00, (float) $order->tax);
+        $this->assertEquals(5.00, (float) $order->discount);
+        $this->assertEquals(195.00, (float) $order->total);
+
+        // And the broadcast must carry the fresh values, not the stale ones.
         Event::assertDispatched(
             OrderDetailsUpdated::class,
             fn (OrderDetailsUpdated $event): bool => $event->order->order_id === $order->order_id
+                && (int) $event->order->guest_count === 4
+                && (float) $event->order->total === 195.00
         );
     }
 
@@ -120,6 +159,25 @@ class PosOrderDetailSyncTest extends TestCase
             'detail-update must not fan out on the legacy device channel'
         );
         $this->assertSame('order.details.updated', $event->broadcastAs());
+    }
+
+    private function seedPosOrder(int $posOrderId, int $guestCount): void
+    {
+        DB::connection('pos')->table('orders')->insert([
+            'id'          => $posOrderId,
+            'guest_count' => $guestCount,
+        ]);
+    }
+
+    private function seedPosCheck(int $posOrderId, float $subtotal, float $tax, float $discount, float $total): void
+    {
+        DB::connection('pos')->table('order_checks')->insert([
+            'order_id'        => $posOrderId,
+            'subtotal_amount' => $subtotal,
+            'tax_amount'      => $tax,
+            'discount_amount' => $discount,
+            'total_amount'    => $total,
+        ]);
     }
 
     private function insertDetailOutboxRow(int $posOrderId, int $attempts = 0): int


### PR DESCRIPTION
Follow-up to #158. Fixes the P1 review comment: `ConsumePosOrderDetailEvents` broadcast the stale local `DeviceOrder` without re-reading the updated POS `orders.guest_count` / `order_checks` totals, so the tablet received stale values and the outbox row was marked processed (update lost).

**Fix:** `refreshDetailFromPos()` re-reads POS authoritative detail columns and persists them onto the local row before broadcasting. Test seeds the POS source tables and asserts the broadcast carries fresh values. Full suite 438 passed (1537 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)