### PR TITLE
Enable Boost Tinker tool (local) and add team usage guide

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -14,6 +14,9 @@ APP_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 ASSET_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+# Laravel Boost: Tinker MCP tool. Disabled here — Boost only runs in local
+# environments, so this is off for the Docker/production profile.
+BOOST_TINKER_TOOL_ENABLED=false
 APP_KEY=base64:REPLACE_WITH_DOCKER_APP_KEY
 
 DB_CONNECTION=mysql

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -14,8 +14,9 @@ APP_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 ASSET_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
-# Laravel Boost: Tinker MCP tool. Disabled here — Boost only runs in local
-# environments, so this is off for the Docker/production profile.
+# Laravel Boost: Tinker MCP tool. Off for this Docker/production profile — and
+# because APP_ENV=production, Boost is inert and BOOST_TINKER_TOOL_ENABLED has no
+# effect here regardless. See docs/LARAVEL_BOOST_GUIDE.md.
 BOOST_TINKER_TOOL_ENABLED=false
 APP_KEY=base64:REPLACE_WITH_DOCKER_APP_KEY
 

--- a/.env.example
+++ b/.env.example
@@ -135,5 +135,8 @@ TELESCOPE_ENABLED=false
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
 
 # Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
-# agents. Local-only; set to false to opt out per developer.
+# agents. config/boost.php defaults to env('BOOST_TINKER_TOOL_ENABLED', false),
+# i.e. off as a safe fallback; this local template intentionally opts in. Set to
+# false to opt out. Local-only — inert when APP_ENV=production.
+# See docs/LARAVEL_BOOST_GUIDE.md.
 BOOST_TINKER_TOOL_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -133,3 +133,7 @@ LOG_LEVEL=error
 
 TELESCOPE_ENABLED=false
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+
+# Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
+# agents. Local-only; set to false to opt out per developer.
+BOOST_TINKER_TOOL_ENABLED=true

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,9 @@ APP_DEBUG=true
 APP_URL=http://127.0.0.1:8000
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+# Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
+# agents. Local-only; set to false to opt out per developer.
+BOOST_TINKER_TOOL_ENABLED=true
 APP_KEY=base64:REPLACE_WITH_LOCAL_APP_KEY
 
 DB_CONNECTION=mysql

--- a/config/boost.php
+++ b/config/boost.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Boost functionality - which
+    | will prevent Boost's routes from being registered and will also
+    | disable Boost's browser logging functionality from operating.
+    |
+    */
+
+    'enabled' => env('BOOST_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Browser Logs Watcher
+    |--------------------------------------------------------------------------
+    |
+    | The following option may be used to enable or disable the browser logs
+    | watcher feature within Laravel Boost. The log watcher will read any
+    | errors within the browser's console to give Boost better context.
+    |
+    */
+
+    'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Tinker Tool
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Boost exposes an MCP tool that executes arbitrary PHP in the
+    | application context (the programmatic equivalent of `php artisan tinker`).
+    | It only operates in local environments and is opt-in per developer. Keep
+    | it disabled if you do not want agents running code against your dev data.
+    |
+    */
+
+    'tinker_tool_enabled' => env('BOOST_TINKER_TOOL_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Executables Paths
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to specify custom paths for the executables that
+    | Boost uses. When configured, they take precedence over the automatic
+    | discovery mechanism. Leave empty to use defaults from your $PATH.
+    |
+    */
+
+    'executable_paths' => [
+        'php' => env('BOOST_PHP_EXECUTABLE_PATH'),
+        'composer' => env('BOOST_COMPOSER_EXECUTABLE_PATH'),
+        'npm' => env('BOOST_NPM_EXECUTABLE_PATH'),
+        'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
+        'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
+    ],
+
+];

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -5,6 +5,7 @@ This is the authoritative navigation root for active documentation.
 ## AI Agent Onboarding
 
 - [`docs/AI_ONBOARDING.md`](AI_ONBOARDING.md) — detailed Claude Code onboarding (setup, architecture, patterns); load on demand
+- [`docs/LARAVEL_BOOST_GUIDE.md`](LARAVEL_BOOST_GUIDE.md) — Laravel Boost day-to-day usage, MCP tools, and guardrails
 
 ## Deployment
 

--- a/docs/LARAVEL_BOOST_GUIDE.md
+++ b/docs/LARAVEL_BOOST_GUIDE.md
@@ -65,8 +65,10 @@ application (the equivalent of `php artisan tinker`) — useful for verifying an
 `OrderStatus` transition, a `lorisleiva/laravel-actions` action, a Spatie
 permission, or an Eloquent relationship against real data.
 
-It is **enabled for local development** in this repo via
-`BOOST_TINKER_TOOL_ENABLED=true` (see the env example files).
+`config/boost.php` reads `env('BOOST_TINKER_TOOL_ENABLED', false)` — so the
+config default is **off** as a safe fallback. The local env templates
+(`.env.example`, `.env.local.example`) intentionally opt in by setting
+`BOOST_TINKER_TOOL_ENABLED=true`; the Docker/production template sets it `false`.
 
 Safety:
 

--- a/docs/LARAVEL_BOOST_GUIDE.md
+++ b/docs/LARAVEL_BOOST_GUIDE.md
@@ -1,0 +1,91 @@
+---
+status: canonical
+last_reviewed: 2026-06-05
+scope: woosoo-nexus
+---
+
+# Laravel Boost — Day-to-Day Usage
+
+[Laravel Boost](https://laravel.com/docs/boost) gives AI coding agents
+Laravel-specific, version-pinned context and live tooling for this codebase. This
+guide explains how to use it day-to-day and the guardrails to be aware of. It is
+**additive** to the agent operating model — the always-on rules still live in the
+root `../AGENTS.md` and per-app `.agents.md`; Boost just makes agents more
+accurate inside those rules.
+
+## What was installed
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Version-pinned AI guidelines (Laravel 12, Inertia/Vue, Pulse, Reverb, Sanctum, Pest, Pint, PHP 8.2). Auto-loaded by Claude Code. |
+| `.mcp.json` | Registers the Boost MCP server (`php artisan boost:mcp`) for Claude Code. |
+| `boost.json` | Boost feature/agent config (guidelines + MCP, Claude Code). |
+| `config/boost.php` | Published config — master switch, browser logs, Tinker toggle. |
+| `composer.json` | `laravel/boost` (require-dev). |
+
+`CLAUDE.md` and `config/boost.php` are managed/refreshable by Boost — prefer
+`php artisan boost:update` over hand-editing `CLAUDE.md`.
+
+## Prerequisite: local environment only
+
+Boost is **inert unless `APP_ENV=local`** (or `APP_DEBUG=true`). It never runs in
+production/CI by design. Confirm it is active:
+
+```bash
+php artisan list | grep boost      # should list boost:install, boost:mcp, boost:update, ...
+```
+
+In an editor that supports MCP (e.g. Claude Code), the `laravel-boost` server
+loads automatically from `.mcp.json`.
+
+## The MCP tools and when to use them
+
+| Tool | Use it for |
+|------|-----------|
+| `search-docs` | Version-matched docs for installed packages. Pull these instead of guessing or pasting large docs into context. |
+| `application-info` | Installed PHP/Laravel/package versions. Good first call in a new session. |
+| `database-schema` | Real table/column structure — including the read-only `pos`/`krypton_woosoo` connection — before writing queries or migrations. |
+| `database-query` | Run **read-only** SQL (SELECT/SHOW/EXPLAIN/DESCRIBE only; writes are rejected). |
+| `database-connections` | List configured DB connections. |
+| `last-error` / `read-log-entries` | Inspect recent application errors/logs. |
+| `browser-logs` | Read browser console errors/exceptions (Inertia/Vue SPA). |
+| `get-absolute-url` | Resolve correct scheme/host/port for project URLs. |
+| `tinker` | Execute PHP in the app context (see safety note below). |
+
+### `search-docs` and web sessions
+
+`search-docs` calls `boost.laravel.com`. On a **local** machine it works out of
+the box. In **Claude Code on the web**, the environment's network policy must
+allowlist `boost.laravel.com` (the other tools run locally and need no network).
+
+## The Tinker tool — power and safety
+
+The `tinker` MCP tool lets an agent execute **arbitrary PHP** in the live
+application (the equivalent of `php artisan tinker`) — useful for verifying an
+`OrderStatus` transition, a `lorisleiva/laravel-actions` action, a Spatie
+permission, or an Eloquent relationship against real data.
+
+It is **enabled for local development** in this repo via
+`BOOST_TINKER_TOOL_ENABLED=true` (see the env example files).
+
+Safety:
+
+- It runs **local-only** (Boost's environment gate) — never in production.
+- The primary `woosoo` connection uses a privileged DB user, so treat it like a
+  live tinker shell: **don't run destructive code**. The `pos` connection is
+  read-only at the DB-user level.
+- To opt out, set `BOOST_TINKER_TOOL_ENABLED=false` in your `.env` (or unset it —
+  it defaults to off in `config/boost.php`).
+
+## Maintenance
+
+```bash
+php artisan boost:update     # refresh guidelines/skills to the latest guidance
+php artisan boost:install    # re-run to add more agents/editors or change features
+```
+
+## Relationship to governance
+
+`CLAUDE.md` (Boost coding conventions) and `AGENTS.md` / `.agents.md` (the agent
+operating model and hard rules) are complementary and both loaded — Boost does
+not replace or modify the governance docs.


### PR DESCRIPTION
## Summary

Follow-up to the Laravel Boost install (#165). Two opt-in enhancements:

1. **Enable Boost's Tinker MCP tool for local dev.** Publishes `config/boost.php` and adds a `tinker_tool_enabled` key driven by `BOOST_TINKER_TOOL_ENABLED` (defaults off). With it on, agents can execute PHP in the app context to verify behavior (order-state transitions, actions, permissions, Eloquent) instead of guessing. Runs **local-only** per Boost's environment gate — never in production.
2. **Add a team-facing usage guide** so the team actually benefits from Boost.

## Changes
- `config/boost.php` (new, published) — adds `'tinker_tool_enabled' => env('BOOST_TINKER_TOOL_ENABLED', false)`
- `.env.example`, `.env.local.example` — `BOOST_TINKER_TOOL_ENABLED=true` (local profiles)
- `.env.docker.example` — `BOOST_TINKER_TOOL_ENABLED=false` (production profile; Boost is off in prod regardless)
- `docs/LARAVEL_BOOST_GUIDE.md` (new) — day-to-day usage, MCP tools, `search-docs` allowlist note, Tinker safety
- `docs/INDEX.md` — register the new guide under AI Agent Onboarding

## Safety
- Tinker is **arbitrary code execution**, but local-only; the `woosoo` connection is privileged so the guide warns against destructive code, and the `pos`/`krypton_woosoo` connection is read-only at the DB-user level.
- Reversible per developer: set `BOOST_TINKER_TOOL_ENABLED=false` (or unset — config default is off).

## Verification
- `php artisan config:show boost.tinker_tool_enabled` → `true` with env on, `false` by default
- MCP `tools/list` now returns **10 tools including `tinker`** (was 9)
- Pest: **439 passed, 1 skipped**
- `vendor/bin/pint --dirty` clean

## Documentation governance checks

- [x] This PR does not introduce duplicate canonical guidance.
- [x] This PR does not introduce a second production deployment flow.
- [x] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [x] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [x] `docs/INDEX.md` was updated if canonical docs changed.

https://claude.ai/code/session_01ExDBcyP7oakMGqokZeCdan

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExDBcyP7oakMGqokZeCdan)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a configurable Tinker MCP tool for local PHP execution, disabled in production environments and enabled locally by default.
  * Added feature toggles and executable path overrides for Boost configuration.

* **Documentation**
  * Added comprehensive Laravel Boost usage guide covering activation, available tools, and maintenance commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->