### PR TITLE
Staging

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -14,6 +14,9 @@ APP_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 ASSET_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+# Laravel Boost: Tinker MCP tool. Disabled here — Boost only runs in local
+# environments, so this is off for the Docker/production profile.
+BOOST_TINKER_TOOL_ENABLED=false
 APP_KEY=base64:REPLACE_WITH_DOCKER_APP_KEY
 
 DB_CONNECTION=mysql

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -14,8 +14,9 @@ APP_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 ASSET_URL=${PUBLIC_SCHEME}://${PUBLIC_HOST}
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
-# Laravel Boost: Tinker MCP tool. Disabled here — Boost only runs in local
-# environments, so this is off for the Docker/production profile.
+# Laravel Boost: Tinker MCP tool. Off for this Docker/production profile — and
+# because APP_ENV=production, Boost is inert and BOOST_TINKER_TOOL_ENABLED has no
+# effect here regardless. See docs/LARAVEL_BOOST_GUIDE.md.
 BOOST_TINKER_TOOL_ENABLED=false
 APP_KEY=base64:REPLACE_WITH_DOCKER_APP_KEY
 

--- a/.env.example
+++ b/.env.example
@@ -135,5 +135,8 @@ TELESCOPE_ENABLED=false
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
 
 # Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
-# agents. Local-only; set to false to opt out per developer.
+# agents. config/boost.php defaults to env('BOOST_TINKER_TOOL_ENABLED', false),
+# i.e. off as a safe fallback; this local template intentionally opts in. Set to
+# false to opt out. Local-only — inert when APP_ENV=production.
+# See docs/LARAVEL_BOOST_GUIDE.md.
 BOOST_TINKER_TOOL_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -133,3 +133,7 @@ LOG_LEVEL=error
 
 TELESCOPE_ENABLED=false
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+
+# Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
+# agents. Local-only; set to false to opt out per developer.
+BOOST_TINKER_TOOL_ENABLED=true

--- a/.env.local.example
+++ b/.env.local.example
@@ -13,6 +13,9 @@ APP_DEBUG=true
 APP_URL=http://127.0.0.1:8000
 APP_TIMEZONE=UTC
 SCRAMBLE_DOCS_ENABLED_IN_PRODUCTION=false
+# Laravel Boost: expose the Tinker MCP tool (arbitrary PHP execution) to AI
+# agents. Local-only; set to false to opt out per developer.
+BOOST_TINKER_TOOL_ENABLED=true
 APP_KEY=base64:REPLACE_WITH_LOCAL_APP_KEY
 
 DB_CONNECTION=mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - tests, lint, security
 
 on:
   push:
-    branches: [ main, develop, staging ]
+    branches: [ main, staging, dev ]
   pull_request:
-    branches: [ main, develop, staging ]
+    branches: [ main, staging, dev ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - tests, lint, security
 
 on:
   push:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
   pull_request:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,11 @@ name: linter
 on:
   push:
     branches:
-      - develop
+      - dev
       - main
   pull_request:
     branches:
-      - develop
+      - dev
       - main
 
 jobs:

--- a/.github/workflows/pwa-ci.yml
+++ b/.github/workflows/pwa-ci.yml
@@ -2,7 +2,9 @@ name: PWA CI - tests + smoke
 
 on:
   push:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
+  pull_request:
+    branches: [ main, dev, staging ]
 
 jobs:
   pwa:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,12 @@ name: tests
 on:
   push:
     branches:
-      - develop
+      - dev
+      - main
+      - staging
+  pull_request:
+    branches:
+      - dev
       - main
       - staging
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - develop
+      - dev
       - main
       - staging
 

--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -1,0 +1,77 @@
+---
+status: canonical
+last_reviewed: 2026-06-08
+scope: woosoo-nexus
+---
+
+# Woosoo KDS — Interface Design System
+
+Dense, warm, wall-distance kitchen command surface for Samsung Galaxy Tab A11+ landscape kiosk.
+
+## Intent
+
+Kitchen staff read tickets from 3–6 feet. Hero data (table number, elapsed timer) must dominate; chips, labels, and item rows sit clearly below without feeling shouty.
+
+## Depth strategy
+
+Borders-only — subtle `--kds-bg*` surface steps, light dividers. Card drop shadows on tickets only; item rows are flat.
+
+## Spacing
+
+8px base grid: 8 / 14 / 16 / 20px rhythm. Touch targets ≥ 44×44px.
+
+## Typography — families
+
+| Token | Stack | Role |
+|-------|-------|------|
+| `--kds-font-d` | Raleway | Display / brand only |
+| `--kds-font-s` | Kanit | UI sans — heroes, labels, body, CTAs |
+| `--kds-font-m` | JetBrains Mono | Timers, metrics, quantities |
+
+## Typography — weights
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--kds-weight-display` | 700 | Brand name, empty-state headline |
+| `--kds-weight-hero` | 700 | Table number, elapsed timer (Kanit) |
+| `--kds-weight-cta` | 700 | Mark Ready / Mark Served buttons |
+| `--kds-weight-label` | 600 | Uppercase micro-labels, chips, badges, status pills |
+| `--kds-weight-body` | 500 | Item names, empty-state subcopy, viewport default |
+| `--kds-weight-data` | 600 | Metric values, clock time, qty (mono + tabular-nums) |
+| `--kds-weight-caption` | 500 | Issued time, date sublabel (mono) |
+
+### Element mapping
+
+| Element | Font | Weight token | Selector |
+|---------|------|--------------|----------|
+| Brand name | Raleway | display | `.kds-brand-name` |
+| Brand sub (KITCHEN - LIVE) | Kanit (inherit) | label | `.kds-brand-sub` |
+| Queue metric value | Mono | data | `.kds-metric strong` |
+| Queue metric label | Kanit | label | `.kds-metric span` |
+| Online / Rush pill | Kanit | label | `.kds-online`, `.kds-rush` |
+| Clock time | Mono | data | `.kds-clock strong` |
+| Clock date | Mono | caption | `.kds-clock span` |
+| Filter chip label | Kanit | label | `.kds-filter-chip` |
+| Filter chip count | Mono | data | `.kds-filter-chip strong` |
+| Density toggle | Kanit | label | `.kds-density-toggle` |
+| Section label (TABLE, ELAPSED, ITEMS) | Kanit | label | `.kds-ticket-pane span`, `.kds-items-head` |
+| Table # / timer hero | Kanit | hero | `.kds-ticket-pane strong` |
+| Issued subline | Mono | caption | `.kds-ticket-pane small` |
+| Type / status badges | Kanit | label | `.kds-pill`, `.kds-status-badge` |
+| Item row text | Kanit | body | `.kds-item-row` |
+| Item qty | Mono | data | `.kds-item-qty` |
+| Card CTA | Kanit | cta | `.kds-card-action` |
+| Empty headline | Raleway | display | `.kds-empty strong` |
+| Empty subcopy | Kanit | body | `.kds-empty span` |
+
+## Color semantics
+
+Stage = left border only (`--kds-new`, `--kds-preparing`, `--kds-ready`, …). Urgency = timer color + optional overdue border glow. No per-table color coding.
+
+## Motion
+
+`prefers-reduced-motion: reduce` suppresses transitions globally on the KDS viewport.
+
+## Touch
+
+`touch-action: manipulation` on viewport. `env(safe-area-inset-*)` padding on full-bleed shell.

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,8 +4,10 @@
             "command": "php",
             "args": [
                 "artisan",
-                "boost:mcp"
-            ]
+                "boost:mcp",
+                "--env=local"
+            ],
+            "cwd": "e:/Projects/woosoo-platform/woosoo-nexus"
         }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,33 @@
+# Woosoo Nexus — Project Conventions (authoritative)
+
+> Project-owned. **Overrides** the Laravel Boost "Test Enforcement" rule below when they conflict.
+
+## Testing policy — test what matters, not everything
+
+Do **not** write a test for every change. Tests are required only where behavior is
+contractual or has previously been a source of bugs. Default to the simplest coverage that
+proves the change, and **prefer updating an existing test over adding a new one**.
+
+**Require a test for:**
+- Order/KDS state machines and status transitions (`KdsController`, `DeviceOrder`, etc.)
+- AuthN/AuthZ and ability gates
+- Money, totals, tax, discounts, and data-integrity invariants
+- API contracts consumed by the tablet/PWA or print bridge
+- Any route/controller that previously shipped a bug (regression guard)
+
+**Do NOT require a test for:**
+- Presentational Vue/CSS, layout, copy, icons, styling
+- Trivial redirects, stubs, getters, config, or route renames
+- One-off scripts and verification harnesses
+
+**Hygiene:**
+- A test must be **committed in the same change** as the code it covers and must run in CI
+  on `dev` (`.github/workflows/ci.yml`). An uncommitted or never-run test does not count.
+- A test that cannot fail — or that never executes — is worse than no test. Delete it.
+- When behavior changes on purpose, **update the assertion**; a red test is the system working.
+
+---
+
 <laravel-boost-guidelines>
 === foundation rules ===
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,37 @@
 # Woosoo Nexus
 
-Integrated restaurant platform for:
-- Admin panel + API (Laravel/Inertia/Vue)
-- Tablet ordering PWA (Nuxt, built from sibling repo)
-- Print relay integration
+Laravel backend and **manager admin UI** for the **Woosoo** restaurant operations ecosystem.
+
+Nexus is the system backbone on the restaurant LAN: device auth, order and session APIs, POS/Krypton
+integration, Laravel Reverb broadcasting, and print-event orchestration. The manager admin (Inertia +
+Vue 3) runs in the **same deploy** as the API — it is not a separate app.
+
+## What Nexus is (and is not)
+
+| Nexus is | Nexus is not |
+| --- | --- |
+| API + manager admin + Reverb hub | The name for the whole Woosoo ecosystem |
+| Source of truth for orders, pricing, POS mapping | The customer tablet app (see `tablet-ordering-pwa`) |
+| Print-event publisher for the Print Bridge | The production print executor (see `woosoo-print-bridge`) |
+| LAN admin for branch operations | The owner cloud portal (see `woosoo-portal`) |
+
+Ecosystem map: [`../docs/WOOSOO_ECOSYSTEM_OVERVIEW.md`](../docs/WOOSOO_ECOSYSTEM_OVERVIEW.md)
+(platform repo).
+
+## Stack
+
+- Laravel 12, MySQL, Redis, Sanctum, Reverb
+- Manager admin: Inertia.js + Vue 3
+- POS: Krypton driver (LAN)
 
 ## Repository authority
 
-- **Production deployment authority:** `compose.yaml` in the sibling `woosoo-platform/` repo (platform-root). This repo is an **application** repo; the platform repo orchestrates Docker for all three sibling apps.
-- **Canonical documentation entrypoint:** `docs/INDEX.md`.
-- **Frontend source authority:** `../tablet-ordering-pwa` (sibling repository).
+- **Production deployment authority:** `compose.yaml` in the sibling **`woosoo-platform/`** repo
+  (platform-root). This repo is an application repo; the platform repo orchestrates Docker for all
+  sibling apps.
+- **Canonical documentation entrypoint:** `docs/INDEX.md` (Nexus) and
+  `woosoo-platform/docs/README.md` (ecosystem).
+- **Frontend source authority:** `../tablet-ordering-pwa` (customer PWA sibling repo).
 
 ## Production deployment rule
 
@@ -20,13 +42,23 @@ Run production Docker operations from the platform repo root:
 Use:
 
 `docker compose --env-file ./woosoo-nexus/.env -f ./compose.yaml ...`
-<!-- Run from woosoo-platform/ root. The explicit -f ./compose.yaml prevents Docker from
-     accidentally picking up woosoo-nexus/compose.yaml if invoked from the wrong directory. -->
 
-Do not invoke `docker compose` from inside `woosoo-nexus/` — the platform-root
-`compose.yaml` is the single authoritative stack definition. The legacy
-`woosoo-nexus/compose.yaml` is retained only for reference and is not used by
-the deploy scripts.
+Run from `woosoo-platform/` root. The explicit `-f ./compose.yaml` prevents Docker from
+accidentally picking up `woosoo-nexus/compose.yaml` if invoked from the wrong directory.
+
+Do not invoke `docker compose` from inside `woosoo-nexus/` — the platform-root `compose.yaml`
+is the single authoritative stack definition. The legacy `woosoo-nexus/compose.yaml` is retained
+only for reference and is not used by the deploy scripts.
+
+## Integration surfaces
+
+| Consumer | Integration |
+| --- | --- |
+| Tablet PWA | Device auth, order intent API, Reverb (`orders.{id}`, `device.{id}`, `session.{id}`) |
+| Print Bridge | Print events (`admin.orders`), polling, reserve/ack/failed, heartbeat |
+| woosoo-portal *(planned)* | EOD sync batches — not implemented; see platform `docs/cases/woosoo-cloud-portal-sync-plan-review.md` |
+
+Contracts live in `woosoo-platform/contracts/`.
 
 ## Documentation governance
 

--- a/app/Broadcasting/BroadcastEvent.php
+++ b/app/Broadcasting/BroadcastEvent.php
@@ -17,12 +17,13 @@ namespace App\Broadcasting;
  */
 enum BroadcastEvent: string
 {
-    case OrderCreated        = 'order.created';
-    case OrderUpdated        = 'order.updated';
-    case OrderCompleted      = 'order.completed';
-    case OrderVoided         = 'order.voided';
-    case OrderCancelled      = 'order.cancelled';
+    case OrderCreated = 'order.created';
+    case OrderUpdated = 'order.updated';
+    case OrderCompleted = 'order.completed';
+    case OrderVoided = 'order.voided';
+    case OrderCancelled = 'order.cancelled';
     case OrderDetailsUpdated = 'order.details.updated';
-    case PrintRequested      = 'order.print.requested';
-    case SessionReset        = 'session.reset';
+    case PrintRequested = 'order.print.requested';
+    case ItemToggled = 'item.toggled';
+    case SessionReset = 'session.reset';
 }

--- a/app/Broadcasting/OrderBroadcaster.php
+++ b/app/Broadcasting/OrderBroadcaster.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Broadcasting;
 
+use App\Events\Kds\ItemToggled;
 use App\Events\Order\OrderCancelled;
 use App\Events\Order\OrderCompleted;
 use App\Events\Order\OrderCreated;
@@ -11,6 +12,7 @@ use App\Events\Order\OrderDetailsUpdated;
 use App\Events\Order\OrderStatusUpdated;
 use App\Events\Order\OrderVoided;
 use App\Models\DeviceOrder;
+use App\Models\DeviceOrderItems;
 use App\Services\BroadcastService;
 use InvalidArgumentException;
 
@@ -49,18 +51,23 @@ class OrderBroadcaster
         $this->broadcastService->safeBroadcast(new OrderDetailsUpdated($order));
     }
 
+    public function itemToggled(DeviceOrderItems $item): void
+    {
+        $this->broadcastService->safeBroadcast(new ItemToggled($item));
+    }
+
     /**
      * Dispatch the appropriate terminal event for an order finalization.
      *
-     * @param string $status one of: completed, voided, cancelled
+     * @param  string  $status  one of: completed, voided, cancelled
      */
     public function finalized(DeviceOrder $order, string $status): void
     {
         $event = match ($status) {
             'completed' => new OrderCompleted($order),
-            'voided'    => new OrderVoided($order),
+            'voided' => new OrderVoided($order),
             'cancelled' => new OrderCancelled($order),
-            default     => throw new InvalidArgumentException(
+            default => throw new InvalidArgumentException(
                 "OrderBroadcaster::finalized cannot route status [{$status}]"
             ),
         };

--- a/app/Events/Kds/ItemToggled.php
+++ b/app/Events/Kds/ItemToggled.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events\Kds;
+
+use App\Models\DeviceOrderItems;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ItemToggled implements ShouldBroadcastNow
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public readonly DeviceOrderItems $item) {}
+
+    public function broadcastOn(): array
+    {
+        return [new Channel('admin.orders')];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'item.toggled';
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'item_id' => $this->item->id,
+            'order_id' => $this->item->order_id,
+            'done' => (bool) $this->item->done,
+            'done_at' => $this->item->done_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -9,8 +9,22 @@ class OrderBroadcastPayload
 {
     public static function make(DeviceOrder $order): array
     {
-        // Ensure related data is available for downstream consumers
-        $order->loadMissing(['device.table', 'table', 'items.menu', 'serviceRequests']);
+        // App-DB relations are always safe to load.
+        $order->loadMissing(['items', 'device', 'serviceRequests']);
+
+        // Table and menu live on the Krypton (POS) connection. Degrade gracefully if POS
+        // is unreachable so an order broadcast never 500s the caller (e.g. KDS advance):
+        // table falls back to null and item names fall back to the stored item name.
+        try {
+            $order->loadMissing(['device.table', 'table', 'items.menu']);
+        } catch (\Throwable $e) {
+            // POS down — resolve POS-backed relations to null so the access below does not
+            // re-trigger a lazy load (which would throw again). Table → null; item names
+            // fall back to the stored item name.
+            $order->setRelation('table', null);
+            $order->device?->setRelation('table', null);
+            $order->items?->each(fn ($item) => $item->setRelation('menu', null));
+        }
 
         $table = $order->device?->table ?? $order->table;
 

--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -2,6 +2,7 @@
 
 namespace App\Helpers;
 
+use App\Enums\OrderStatus;
 use App\Models\DeviceOrder;
 
 class OrderBroadcastPayload
@@ -22,6 +23,8 @@ class OrderBroadcastPayload
             'branch_id' => $order->branch_id,
             'session_id' => $order->session_id,
             'status' => $order->status,
+            'kds_state' => self::toKdsState($order->status),
+            'kds_type' => ($order->items?->isNotEmpty() && $order->items->every(fn ($it) => (bool) ($it->is_refill ?? false))) ? 'refill' : 'initial',
             'is_printed' => (bool) ($order->is_printed ?? false),
             'printed_at' => $order->printed_at?->toIso8601String(),
             'printed_by' => $order->printed_by,
@@ -52,5 +55,18 @@ class OrderBroadcastPayload
             ])->values()->all(),
             'serviceRequests' => $order->serviceRequests ?? [],
         ];
+    }
+
+    private static function toKdsState(OrderStatus $status): string
+    {
+        return match ($status) {
+            OrderStatus::PENDING,
+            OrderStatus::CONFIRMED => 'new',
+            OrderStatus::IN_PROGRESS => 'preparing',
+            OrderStatus::READY => 'ready',
+            OrderStatus::SERVED => 'served',
+            OrderStatus::VOIDED => 'voided',
+            default => 'new',
+        };
     }
 }

--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -63,7 +63,7 @@ class OrderBroadcastPayload
             OrderStatus::PENDING,
             OrderStatus::CONFIRMED => 'new',
             OrderStatus::IN_PROGRESS => 'preparing',
-            OrderStatus::READY => 'ready',
+            OrderStatus::READY => 'preparing',
             OrderStatus::SERVED => 'served',
             OrderStatus::VOIDED => 'voided',
             default => 'new',

--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -50,6 +50,8 @@ class OrderBroadcastPayload
                 'price' => $it->price,
                 'subtotal' => $it->subtotal,
                 'is_refill' => (bool) ($it->is_refill ?? false),
+                'done' => (bool) ($it->done ?? false),
+                'done_at' => $it->done_at?->toIso8601String(),
                 'notes' => $it->notes ?? null,
                 'type' => $it->type ?? null,
             ])->values()->all(),

--- a/app/Http/Controllers/Admin/Device/DeviceController.php
+++ b/app/Http/Controllers/Admin/Device/DeviceController.php
@@ -476,6 +476,11 @@ class DeviceController extends Controller
             ->with('success', 'Device trashed.');
     }
 
+    public function trashed(Request $request): RedirectResponse
+    {
+        return redirect()->route('devices.index', ['view' => 'trashed']);
+    }
+
     public function restore(Request $request, int $id)
     {
 

--- a/app/Http/Controllers/Admin/Device/DeviceController.php
+++ b/app/Http/Controllers/Admin/Device/DeviceController.php
@@ -12,6 +12,7 @@ use App\Models\Krypton\Table;
 use App\Services\CertificatePathResolver;
 use App\Support\DeviceSecurityCode;
 use Carbon\Carbon;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -60,11 +61,32 @@ class DeviceController extends Controller
         // Include soft-deleted rows so admins can reactivate previously deactivated
         // devices directly from the Devices page.
         $devices = Device::withTrashed()
-            ->with('table', 'branch')
+            ->with(['table', 'branch', 'latestHeartbeat'])
             ->when($branchId !== null, fn ($q) => $q->where('branch_id', $branchId))
             ->get()
             ->each(fn (Device $device) => $device->makeVisible('deleted_at'));
         $securityReadyCount = $devices->whereNotNull('security_code_generated_at')->count();
+
+        $activeDevices = $devices->whereNull('deleted_at');
+        $batteryValues = $activeDevices
+            ->map(fn (Device $d) => $d->latestHeartbeat?->battery_level)
+            ->filter()
+            ->values();
+        $avgBattery = $batteryValues->isNotEmpty()
+            ? (int) round($batteryValues->average())
+            : null;
+
+        $onlineCount = $activeDevices->where('status', 'online')->count();
+        $warningCount = $activeDevices->where('status', 'warning')->count();
+        $offlineCount = $activeDevices->where('status', 'offline')->count();
+
+        $modalAppVersion = $activeDevices
+            ->map(fn (Device $d) => $d->app_version)
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->keys()
+            ->first();
 
         inertia()->share('unassignedTables', $unassignedTables);
 
@@ -96,6 +118,13 @@ class DeviceController extends Controller
             'description' => 'List of Registered Devices',
             'devices' => $devices,
             'stats' => $stats,
+            'fleetStats' => [
+                'online_count' => $onlineCount,
+                'warning_count' => $warningCount,
+                'offline_count' => $offlineCount,
+                'avg_battery' => $avgBattery,
+                'modal_app_version' => $modalAppVersion,
+            ],
         ]);
     }
 
@@ -482,12 +511,12 @@ class DeviceController extends Controller
      * Landing page for certificate distribution — no authentication required.
      * Displays install instructions and a download link for the CA cert.
      */
-    public function certificatePage(): \Illuminate\Contracts\View\View
+    public function certificatePage(): View
     {
         return view('devices.certificate', [
-            'available'   => $this->certificatePathResolver->resolveCertificatePath() !== null,
+            'available' => $this->certificatePathResolver->resolveCertificatePath() !== null,
             'downloadUrl' => route('devices.download-certificate'),
-            'serverHost'  => config('app.url'),
+            'serverHost' => config('app.url'),
         ]);
     }
 

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -69,8 +69,15 @@ class KdsController extends Controller
         $gateMessage = null;
 
         DB::transaction(function () use ($order, $current, $next, &$gateMessage) {
-            // Lock order row — serialises concurrent advance() calls and toggleItem() writes.
-            DeviceOrder::lockForUpdate()->find($order->id);
+            // Re-read with lock so we both serialise concurrent writers and write to the current DB row.
+            $locked = DeviceOrder::lockForUpdate()->findOrFail($order->id);
+
+            // Guard: concurrent advance() already moved this order; our $current is stale.
+            if ($locked->status !== $current) {
+                $gateMessage = 'Order state changed concurrently; please retry.';
+
+                return;
+            }
 
             // Mark Ready gate: re-check items under lock to eliminate TOCTOU with toggleItem().
             if ($current === OrderStatus::IN_PROGRESS) {
@@ -86,8 +93,8 @@ class KdsController extends Controller
                 }
             }
 
-            $order->status = $next;
-            $order->save();
+            $locked->status = $next;
+            $locked->save();
         });
 
         if ($gateMessage !== null) {
@@ -96,6 +103,7 @@ class KdsController extends Controller
 
         Log::info('[KDS] advance', ['order_id' => $order->id, 'to' => $next->value, 'admin_id' => auth()->id()]);
 
+        $order->refresh();
         $order->load(['device.table', 'table', 'items.menu', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
@@ -104,20 +112,26 @@ class KdsController extends Controller
 
     public function toggleItem(DeviceOrderItems $item): JsonResponse
     {
-        $item->loadMissing('device_order');
+        $gateMessage = null;
 
-        if (in_array($item->device_order->status, self::TERMINAL_ITEM_STATUSES)) {
-            return response()->json(['message' => 'Cannot toggle items on a completed or closed order.'], 422);
-        }
+        DB::transaction(function () use ($item, &$gateMessage) {
+            // Re-read order under lock; serialises with concurrent advance() and re-checks terminal status.
+            $order = DeviceOrder::lockForUpdate()->findOrFail($item->order_id);
 
-        DB::transaction(function () use ($item) {
-            // Lock the parent order row so concurrent advance() must wait until this write commits.
-            DeviceOrder::lockForUpdate()->find($item->order_id);
+            if (in_array($order->status, self::TERMINAL_ITEM_STATUSES)) {
+                $gateMessage = 'Cannot toggle items on a completed or closed order.';
+
+                return;
+            }
 
             $item->done = ! (bool) ($item->done ?? false);
             $item->done_at = $item->done ? now() : null;
             $item->save();
         });
+
+        if ($gateMessage !== null) {
+            return response()->json(['message' => $gateMessage], 422);
+        }
 
         Log::info('[KDS] toggle item', ['item_id' => $item->id, 'done' => $item->done, 'admin_id' => auth()->id()]);
 

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -24,6 +24,14 @@ class KdsController extends Controller
         OrderStatus::ARCHIVED,
     ];
 
+    private const TERMINAL_ITEM_STATUSES = [
+        OrderStatus::SERVED,
+        OrderStatus::COMPLETED,
+        OrderStatus::CANCELLED,
+        OrderStatus::VOIDED,
+        OrderStatus::ARCHIVED,
+    ];
+
     public function index(Request $request): Response
     {
         $orders = DeviceOrder::with(['device.table', 'table', 'items.menu'])
@@ -58,17 +66,33 @@ class KdsController extends Controller
             return response()->json(['message' => 'No advance available from current state.'], 422);
         }
 
-        // Mark Ready gate: all items must be done
-        if ($current === OrderStatus::IN_PROGRESS) {
-            if ($order->items->contains(fn ($it) => ! (bool) ($it->done ?? false))) {
-                return response()->json(['message' => 'All items must be marked done before advancing to Ready.'], 422);
-            }
-        }
+        $gateMessage = null;
 
-        DB::transaction(function () use ($order, $next) {
+        DB::transaction(function () use ($order, $current, $next, &$gateMessage) {
+            // Lock order row — serialises concurrent advance() calls and toggleItem() writes.
+            DeviceOrder::lockForUpdate()->find($order->id);
+
+            // Mark Ready gate: re-check items under lock to eliminate TOCTOU with toggleItem().
+            if ($current === OrderStatus::IN_PROGRESS) {
+                $hasUndone = DeviceOrderItems::where('order_id', $order->id)
+                    ->where('done', false)
+                    ->lockForUpdate()
+                    ->exists();
+
+                if ($hasUndone) {
+                    $gateMessage = 'All items must be marked done before advancing to Ready.';
+
+                    return;
+                }
+            }
+
             $order->status = $next;
             $order->save();
         });
+
+        if ($gateMessage !== null) {
+            return response()->json(['message' => $gateMessage], 422);
+        }
 
         Log::info('[KDS] advance', ['order_id' => $order->id, 'to' => $next->value, 'admin_id' => auth()->id()]);
 
@@ -80,7 +104,16 @@ class KdsController extends Controller
 
     public function toggleItem(DeviceOrderItems $item): JsonResponse
     {
+        $item->loadMissing('device_order');
+
+        if (in_array($item->device_order->status, self::TERMINAL_ITEM_STATUSES)) {
+            return response()->json(['message' => 'Cannot toggle items on a completed or closed order.'], 422);
+        }
+
         DB::transaction(function () use ($item) {
+            // Lock the parent order row so concurrent advance() must wait until this write commits.
+            DeviceOrder::lockForUpdate()->find($item->order_id);
+
             $item->done = ! (bool) ($item->done ?? false);
             $item->done_at = $item->done ? now() : null;
             $item->save();

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -120,7 +120,9 @@ class KdsController extends Controller
         Log::info('[KDS] advance', ['order_id' => $order->id, 'to' => $next->value, 'admin_id' => auth()->id()]);
 
         $order->refresh();
-        $order->load(['device.table', 'table', 'items.menu', 'serviceRequests']);
+        // Preload app-DB relations only. Table/menu (POS connection) are loaded — and
+        // guarded — inside OrderBroadcastPayload so a POS outage can't 500 this action.
+        $order->loadMissing(['items', 'device', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
         return response()->json(['status' => $next->value]);

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -60,15 +60,10 @@ class KdsController extends Controller
             $current = OrderStatus::CONFIRMED;
         }
 
-        $next = $this->nextStatus($current);
-
-        if ($next === null) {
-            return response()->json(['message' => 'No advance available from current state.'], 422);
-        }
-
         $gateMessage = null;
+        $next = null;
 
-        DB::transaction(function () use ($order, $current, $next, &$gateMessage) {
+        DB::transaction(function () use ($order, $current, &$gateMessage, &$next) {
             // Re-read with lock so we both serialise concurrent writers and write to the current DB row.
             $locked = DeviceOrder::lockForUpdate()->findOrFail($order->id);
 
@@ -79,7 +74,6 @@ class KdsController extends Controller
                 return;
             }
 
-            // Mark Ready gate: re-check items under lock to eliminate TOCTOU with toggleItem().
             if ($current === OrderStatus::IN_PROGRESS) {
                 $hasUndone = DeviceOrderItems::where('order_id', $order->id)
                     ->where('done', false)
@@ -87,18 +81,40 @@ class KdsController extends Controller
                     ->exists();
 
                 if ($hasUndone) {
-                    $gateMessage = 'All items must be marked done before advancing to Ready.';
+                    $gateMessage = 'All items must be marked done before marking as served.';
 
                     return;
                 }
+
+                // Kitchen-facing single action: contract-safe two-hop in_progress -> ready -> served.
+                $locked->status = OrderStatus::READY;
+                $locked->save();
+                $locked->status = OrderStatus::SERVED;
+                $locked->save();
+                $next = OrderStatus::SERVED;
+
+                return;
             }
 
-            $locked->status = $next;
+            $nextStatus = $this->nextStatus($current);
+
+            if ($nextStatus === null) {
+                $gateMessage = 'No advance available from current state.';
+
+                return;
+            }
+
+            $locked->status = $nextStatus;
             $locked->save();
+            $next = $nextStatus;
         });
 
         if ($gateMessage !== null) {
             return response()->json(['message' => $gateMessage], 422);
+        }
+
+        if ($next === null) {
+            return response()->json(['message' => 'No advance available from current state.'], 422);
         }
 
         Log::info('[KDS] advance', ['order_id' => $order->id, 'to' => $next->value, 'admin_id' => auth()->id()]);
@@ -147,7 +163,6 @@ class KdsController extends Controller
     {
         return match ($status) {
             OrderStatus::CONFIRMED => OrderStatus::IN_PROGRESS,
-            OrderStatus::IN_PROGRESS => OrderStatus::READY,
             OrderStatus::READY => OrderStatus::SERVED,
             default => null,
         };
@@ -193,7 +208,7 @@ class KdsController extends Controller
             OrderStatus::PENDING,
             OrderStatus::CONFIRMED => 'new',
             OrderStatus::IN_PROGRESS => 'preparing',
-            OrderStatus::READY => 'ready',
+            OrderStatus::READY => 'preparing',
             OrderStatus::SERVED => 'served',
             OrderStatus::VOIDED => 'voided',
             default => 'new',

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -41,7 +41,7 @@ class KdsController extends Controller
     {
         $with = $this->posConnection->isReachable()
             ? ['device.table', 'table', 'items.menu']
-            : ['device', 'items.menu'];
+            : ['device', 'items'];
 
         $orders = DeviceOrder::with($with)
             ->whereNotIn('status', array_map(fn ($s) => $s->value, self::HIDDEN_STATUSES))

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Admin;
 
+use App\Broadcasting\OrderBroadcaster;
 use App\Enums\OrderStatus;
 use App\Http\Controllers\Controller;
 use App\Models\DeviceOrder;
+use App\Models\DeviceOrderItems;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -30,6 +35,75 @@ class KdsController extends Controller
             'title' => 'Kitchen Display',
             'initialTickets' => $orders->map(fn ($order) => $this->toTicket($order))->values(),
         ]);
+    }
+
+    public function advance(DeviceOrder $order): JsonResponse
+    {
+        $order->loadMissing('items');
+        $current = $order->status;
+
+        // Auto-advance pending through confirmed (pending is transient)
+        if ($current === OrderStatus::PENDING) {
+            DB::transaction(function () use ($order) {
+                $order->status = OrderStatus::CONFIRMED;
+                $order->save();
+            });
+            $order->refresh();
+            $current = OrderStatus::CONFIRMED;
+        }
+
+        $next = $this->nextStatus($current);
+
+        if ($next === null) {
+            return response()->json(['message' => 'No advance available from current state.'], 422);
+        }
+
+        // Mark Ready gate: all items must be done
+        if ($current === OrderStatus::IN_PROGRESS) {
+            if ($order->items->contains(fn ($it) => ! (bool) ($it->done ?? false))) {
+                return response()->json(['message' => 'All items must be marked done before advancing to Ready.'], 422);
+            }
+        }
+
+        DB::transaction(function () use ($order, $next) {
+            $order->status = $next;
+            $order->save();
+        });
+
+        Log::info('[KDS] advance', ['order_id' => $order->id, 'to' => $next->value, 'admin_id' => auth()->id()]);
+
+        $order->load(['device.table', 'table', 'items.menu', 'serviceRequests']);
+        app(OrderBroadcaster::class)->statusChanged($order);
+
+        return response()->json(['status' => $next->value]);
+    }
+
+    public function toggleItem(DeviceOrderItems $item): JsonResponse
+    {
+        DB::transaction(function () use ($item) {
+            $item->done = ! (bool) ($item->done ?? false);
+            $item->done_at = $item->done ? now() : null;
+            $item->save();
+        });
+
+        Log::info('[KDS] toggle item', ['item_id' => $item->id, 'done' => $item->done, 'admin_id' => auth()->id()]);
+
+        app(OrderBroadcaster::class)->itemToggled($item);
+
+        return response()->json([
+            'done' => (bool) $item->done,
+            'done_at' => $item->done_at?->toIso8601String(),
+        ]);
+    }
+
+    private function nextStatus(OrderStatus $status): ?OrderStatus
+    {
+        return match ($status) {
+            OrderStatus::CONFIRMED => OrderStatus::IN_PROGRESS,
+            OrderStatus::IN_PROGRESS => OrderStatus::READY,
+            OrderStatus::READY => OrderStatus::SERVED,
+            default => null,
+        };
     }
 
     private function toTicket(DeviceOrder $order): array
@@ -59,9 +133,9 @@ class KdsController extends Controller
                 'id' => (string) $it->id,
                 'qty' => (int) ($it->quantity ?? 1),
                 'name' => $it->menu?->receipt_name ?? $it->menu?->name ?? $it->name ?? '',
-                'done' => false,
+                'done' => (bool) ($it->done ?? false),
             ])->values()->all(),
-            'recalled' => null,
+            'recalled' => $order->recalled ?? 0,
             'voidReason' => null,
         ];
     }

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -9,6 +9,7 @@ use App\Enums\OrderStatus;
 use App\Http\Controllers\Controller;
 use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
+use App\Services\PosConnectionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -18,6 +19,10 @@ use Inertia\Response;
 
 class KdsController extends Controller
 {
+    public function __construct(
+        private readonly PosConnectionService $posConnection,
+    ) {}
+
     private const HIDDEN_STATUSES = [
         OrderStatus::COMPLETED,
         OrderStatus::CANCELLED,
@@ -34,7 +39,11 @@ class KdsController extends Controller
 
     public function index(Request $request): Response
     {
-        $orders = DeviceOrder::with(['device.table', 'table', 'items.menu'])
+        $with = $this->posConnection->isReachable()
+            ? ['device.table', 'table', 'items.menu']
+            : ['device', 'items.menu'];
+
+        $orders = DeviceOrder::with($with)
             ->whereNotIn('status', array_map(fn ($s) => $s->value, self::HIDDEN_STATUSES))
             ->orderBy('created_at')
             ->get();

--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Enums\OrderStatus;
+use App\Http\Controllers\Controller;
+use App\Models\DeviceOrder;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class KdsController extends Controller
+{
+    private const HIDDEN_STATUSES = [
+        OrderStatus::COMPLETED,
+        OrderStatus::CANCELLED,
+        OrderStatus::ARCHIVED,
+    ];
+
+    public function index(Request $request): Response
+    {
+        $orders = DeviceOrder::with(['device.table', 'table', 'items.menu'])
+            ->whereNotIn('status', array_map(fn ($s) => $s->value, self::HIDDEN_STATUSES))
+            ->orderBy('created_at')
+            ->get();
+
+        return Inertia::render('KDS/Display', [
+            'title' => 'Kitchen Display',
+            'initialTickets' => $orders->map(fn ($order) => $this->toTicket($order))->values(),
+        ]);
+    }
+
+    private function toTicket(DeviceOrder $order): array
+    {
+        $table = $order->device?->table ?? $order->table;
+        $items = $order->items ?? collect();
+        $isRefill = $items->isNotEmpty() && $items->every(fn ($it) => (bool) ($it->is_refill ?? false));
+        $now = now();
+        $createdAt = $order->created_at;
+        $issuedAtMs = $createdAt ? $createdAt->timestamp * 1000 : $now->timestamp * 1000;
+        $elapsed = $createdAt ? (int) $createdAt->diffInSeconds($now) : 0;
+        $isTerminal = in_array($order->status, [OrderStatus::SERVED, OrderStatus::VOIDED]);
+        $frozenElapsed = ($isTerminal && $order->updated_at && $createdAt)
+            ? (int) $createdAt->diffInSeconds($order->updated_at)
+            : null;
+
+        return [
+            'id' => (string) $order->id,
+            'table' => $table?->name ?? '—',
+            'type' => $isRefill ? 'refill' : 'initial',
+            'issued' => $createdAt?->format('g:i A') ?? '',
+            'issuedAt' => $issuedAtMs,
+            'elapsed' => $elapsed,
+            'frozenElapsed' => $frozenElapsed,
+            'state' => $this->toKdsState($order->status),
+            'items' => $items->map(fn ($it) => [
+                'id' => (string) $it->id,
+                'qty' => (int) ($it->quantity ?? 1),
+                'name' => $it->menu?->receipt_name ?? $it->menu?->name ?? $it->name ?? '',
+                'done' => false,
+            ])->values()->all(),
+            'recalled' => null,
+            'voidReason' => null,
+        ];
+    }
+
+    private function toKdsState(OrderStatus $status): string
+    {
+        return match ($status) {
+            OrderStatus::PENDING,
+            OrderStatus::CONFIRMED => 'new',
+            OrderStatus::IN_PROGRESS => 'preparing',
+            OrderStatus::READY => 'ready',
+            OrderStatus::SERVED => 'served',
+            OrderStatus::VOIDED => 'voided',
+            default => 'new',
+        };
+    }
+}

--- a/app/Http/Controllers/Admin/PackageConfigController.php
+++ b/app/Http/Controllers/Admin/PackageConfigController.php
@@ -6,8 +6,8 @@ use App\Events\Menu\PackageUpdated;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\StorePackageConfigRequest;
 use App\Models\Device;
-use App\Models\TabletPackageConfig;
 use App\Models\TabletPackageAllowedMenu;
+use App\Models\TabletPackageConfig;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
@@ -16,10 +16,45 @@ class PackageConfigController extends Controller
 {
     public function index()
     {
+        $kryptonMenus = collect([]);
+        try {
+            $kryptonMenus = DB::connection('pos')
+                ->table('menus')
+                ->select('id', 'name', 'receipt_name')
+                ->get()
+                ->keyBy('id');
+        } catch (\Throwable) {
+            // POS offline — menu names fall back to ID labels.
+        }
+
         $packages = TabletPackageConfig::with('allowedMenus')
             ->orderBy('sort_order')
             ->orderBy('name')
-            ->get();
+            ->get()
+            ->map(function (TabletPackageConfig $pkg) use ($kryptonMenus): array {
+                $menus = $pkg->allowedMenus->sortBy('sort_order')->map(function (TabletPackageAllowedMenu $m) use ($kryptonMenus): array {
+                    $kMenu = $kryptonMenus->get($m->krypton_menu_id);
+
+                    return [
+                        'id' => $m->id,
+                        'krypton_menu_id' => $m->krypton_menu_id,
+                        'name' => $kMenu?->name ?? $kMenu?->receipt_name ?? "Menu #{$m->krypton_menu_id}",
+                        'menu_type' => $m->menu_type,
+                        'sort_order' => $m->sort_order,
+                        'is_active' => $m->is_active,
+                    ];
+                })->values();
+
+                return [
+                    'id' => $pkg->id,
+                    'name' => $pkg->name,
+                    'description' => $pkg->description,
+                    'base_price' => $pkg->base_price,
+                    'is_active' => $pkg->is_active,
+                    'sort_order' => $pkg->sort_order,
+                    'menus' => $menus,
+                ];
+            });
 
         return Inertia::render('package-configs/IndexPackageConfigs', [
             'packages' => $packages,
@@ -57,16 +92,16 @@ class PackageConfigController extends Controller
     public function syncAllowedMenus(Request $request, TabletPackageConfig $packageConfig)
     {
         $validated = $request->validate([
-            'menus'                       => ['required', 'array'],
-            'menus.*.krypton_menu_id'     => ['required', 'integer', 'min:1', 'distinct'],
-            'menus.*.menu_type'           => ['nullable', 'string', 'in:meat,side,dessert,beverage'],
-            'menus.*.meat_category_code'  => ['nullable', 'string', 'max:50'],
-            'menus.*.extra_price'         => ['nullable', 'numeric', 'min:0'],
-            'menus.*.quantity_limit'      => ['nullable', 'integer', 'min:0'],
-            'menus.*.is_required'         => ['boolean'],
-            'menus.*.is_default'          => ['boolean'],
-            'menus.*.is_active'           => ['boolean'],
-            'menus.*.sort_order'          => ['nullable', 'integer', 'min:0'],
+            'menus' => ['required', 'array'],
+            'menus.*.krypton_menu_id' => ['required', 'integer', 'min:1', 'distinct'],
+            'menus.*.menu_type' => ['nullable', 'string', 'in:meat,side,dessert,beverage'],
+            'menus.*.meat_category_code' => ['nullable', 'string', 'max:50'],
+            'menus.*.extra_price' => ['nullable', 'numeric', 'min:0'],
+            'menus.*.quantity_limit' => ['nullable', 'integer', 'min:0'],
+            'menus.*.is_required' => ['boolean'],
+            'menus.*.is_default' => ['boolean'],
+            'menus.*.is_active' => ['boolean'],
+            'menus.*.sort_order' => ['nullable', 'integer', 'min:0'],
         ]);
 
         DB::transaction(function () use ($packageConfig, $validated): void {
@@ -75,15 +110,15 @@ class PackageConfigController extends Controller
             foreach ($validated['menus'] as $index => $menu) {
                 TabletPackageAllowedMenu::create([
                     'package_config_id' => $packageConfig->id,
-                    'krypton_menu_id'   => $menu['krypton_menu_id'],
-                    'menu_type'         => $menu['menu_type'] ?? 'meat',
+                    'krypton_menu_id' => $menu['krypton_menu_id'],
+                    'menu_type' => $menu['menu_type'] ?? 'meat',
                     'meat_category_code' => $menu['meat_category_code'] ?? null,
-                    'extra_price'       => $menu['extra_price'] ?? 0,
-                    'quantity_limit'    => $menu['quantity_limit'] ?? 1,
-                    'is_required'       => $menu['is_required'] ?? false,
-                    'is_default'        => $menu['is_default'] ?? false,
-                    'is_active'         => $menu['is_active'] ?? true,
-                    'sort_order'        => $menu['sort_order'] ?? $index,
+                    'extra_price' => $menu['extra_price'] ?? 0,
+                    'quantity_limit' => $menu['quantity_limit'] ?? 1,
+                    'is_required' => $menu['is_required'] ?? false,
+                    'is_default' => $menu['is_default'] ?? false,
+                    'is_active' => $menu['is_active'] ?? true,
+                    'sort_order' => $menu['sort_order'] ?? $index,
                 ]);
             }
         });

--- a/app/Http/Controllers/Admin/PosController.php
+++ b/app/Http/Controllers/Admin/PosController.php
@@ -8,9 +8,11 @@ use App\Models\DeviceOrder;
 use App\Services\AuditLogService;
 use App\Services\Pos\PosOrderService;
 use App\Services\Pos\PosTableService;
+use App\Services\PosConnectionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -19,6 +21,7 @@ class PosController extends Controller
     public function __construct(
         private readonly PosOrderService $orderService,
         private readonly PosTableService $tableService,
+        private readonly PosConnectionService $posConnection,
     ) {}
 
     /**
@@ -26,66 +29,111 @@ class PosController extends Controller
      */
     public function index(): Response
     {
-        $currentSession = DB::connection('pos')
-            ->table('sessions')
-            ->orderByDesc('id')
-            ->first();
+        $posStatus = $this->posConnection->posStatus();
+        if (! $posStatus['connected']) {
+            return $this->disconnectedPosPage($posStatus);
+        }
 
-        $terminals = DB::connection('pos')
-            ->table('terminals as t')
-            ->leftJoin('devices as d', 'd.id', '=', 't.id')
-            ->leftJoin('terminal_sessions as ts', function ($join): void {
-                $join->on('ts.terminal_id', '=', 't.id')
-                    ->whereRaw('ts.id = (SELECT MAX(ts2.id) FROM terminal_sessions ts2 WHERE ts2.terminal_id = t.id)');
-            })
-            ->leftJoin('sessions as s', 's.id', '=', 'ts.session_id')
-            ->leftJoin('orders as o', function ($join): void {
-                $join->on('o.terminal_id', '=', 't.id')
-                    ->where('o.is_open', 1)
-                    ->where('o.is_voided', 0);
-            })
-            ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
-            ->groupBy(
-                't.id',
-                't.type',
-                'd.name',
-                'd.ip_address',
-                'd.port',
-                'd.is_active',
-                'ts.id',
-                'ts.session_id',
-                'ts.date_time_opened',
-                'ts.date_time_closed',
-                's.date_time_closed'
-            )
-            ->orderByDesc('d.is_active')
-            ->orderBy('d.name')
-            ->select([
-                't.id',
-                DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name"),
-                DB::raw("COALESCE(d.type, t.type, 'Terminal') as type"),
-                'd.ip_address',
-                'd.port',
-                'd.is_active',
-                'ts.id as terminal_session_id',
-                'ts.session_id',
-                'ts.date_time_opened as terminal_session_opened_at',
-                'ts.date_time_closed as terminal_session_closed_at',
-                's.date_time_closed as session_closed_at',
-                DB::raw('COUNT(o.id) as open_orders_count'),
-            ])
-            ->get();
+        try {
+            $currentSession = DB::connection('pos')
+                ->table('sessions')
+                ->orderByDesc('id')
+                ->first();
 
-        $initialTerminalId = $terminals->first()->id ?? null;
-        $tables = $initialTerminalId ? $this->tableService->getTablesForTerminal((string) $initialTerminalId) : collect();
+            $terminals = DB::connection('pos')
+                ->table('terminals as t')
+                ->leftJoin('devices as d', 'd.id', '=', 't.id')
+                ->leftJoin('terminal_sessions as ts', function ($join): void {
+                    $join->on('ts.terminal_id', '=', 't.id')
+                        ->whereRaw('ts.id = (SELECT MAX(ts2.id) FROM terminal_sessions ts2 WHERE ts2.terminal_id = t.id)');
+                })
+                ->leftJoin('sessions as s', 's.id', '=', 'ts.session_id')
+                ->leftJoin('orders as o', function ($join): void {
+                    $join->on('o.terminal_id', '=', 't.id')
+                        ->where('o.is_open', 1)
+                        ->where('o.is_voided', 0);
+                })
+                ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
+                ->groupBy(
+                    't.id',
+                    't.type',
+                    'd.name',
+                    'd.ip_address',
+                    'd.port',
+                    'd.is_active',
+                    'ts.id',
+                    'ts.session_id',
+                    'ts.date_time_opened',
+                    'ts.date_time_closed',
+                    's.date_time_closed'
+                )
+                ->orderByDesc('d.is_active')
+                ->orderBy('d.name')
+                ->select([
+                    't.id',
+                    DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name"),
+                    DB::raw("COALESCE(d.type, t.type, 'Terminal') as type"),
+                    'd.ip_address',
+                    'd.port',
+                    'd.is_active',
+                    'ts.id as terminal_session_id',
+                    'ts.session_id',
+                    'ts.date_time_opened as terminal_session_opened_at',
+                    'ts.date_time_closed as terminal_session_closed_at',
+                    's.date_time_closed as session_closed_at',
+                    DB::raw('COUNT(o.id) as open_orders_count'),
+                ])
+                ->get();
 
+            $initialTerminalId = $terminals->first()->id ?? null;
+            $tables = $initialTerminalId ? $this->tableService->getTablesForTerminal((string) $initialTerminalId) : collect();
+
+            return Inertia::render('POS/Index', [
+                'title' => 'POS',
+                'description' => 'Krypton POS terminal and table operations',
+                'terminals' => $terminals,
+                'tables' => $tables,
+                'currentSession' => $currentSession,
+                'posConnected' => true,
+                'posStatus' => 'connected',
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[PosController] POS connection failure in index: '.$e->getMessage());
+
+            return $this->disconnectedPosPage($this->posConnection->failureFromThrowable($e));
+        }
+    }
+
+    /**
+     * @param  array{connected: bool, status: string, message: string}  $posStatus
+     */
+    private function disconnectedPosPage(array $posStatus): Response
+    {
         return Inertia::render('POS/Index', [
             'title' => 'POS',
             'description' => 'Krypton POS terminal and table operations',
-            'terminals' => $terminals,
-            'tables' => $tables,
-            'currentSession' => $currentSession,
+            'terminals' => [],
+            'tables' => collect(),
+            'currentSession' => null,
+            'posConnected' => false,
+            'posStatus' => $posStatus['status'],
+            'posMessage' => $posStatus['message'],
         ]);
+    }
+
+    private function posConnectionError(string $context, ?\Throwable $e = null): JsonResponse
+    {
+        $posStatus = $e !== null
+            ? $this->posConnection->failureFromThrowable($e)
+            : $this->posConnection->posStatus();
+
+        Log::warning("[PosController] POS connection failure in {$context}: ".($e?->getMessage() ?? $posStatus['message']));
+
+        return response()->json([
+            'success' => false,
+            'status' => $posStatus['status'],
+            'message' => $posStatus['message'],
+        ], 503);
     }
 
     /**
@@ -93,28 +141,32 @@ class PosController extends Controller
      */
     public function terminalTables(string $terminalId): JsonResponse
     {
-        $terminal = DB::connection('pos')
-            ->table('terminals as t')
-            ->leftJoin('devices as d', 'd.id', '=', 't.id')
-            ->where('t.id', $terminalId)
-            ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
-            ->select(['t.id', DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name")])
-            ->first();
+        try {
+            $terminal = DB::connection('pos')
+                ->table('terminals as t')
+                ->leftJoin('devices as d', 'd.id', '=', 't.id')
+                ->where('t.id', $terminalId)
+                ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
+                ->select(['t.id', DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name")])
+                ->first();
 
-        if (! $terminal) {
+            if (! $terminal) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Terminal not found in Krypton.',
+                ], 404);
+            }
+
+            $tables = $this->tableService->getTablesForTerminal($terminalId);
+
             return response()->json([
-                'success' => false,
-                'message' => 'Terminal not found in Krypton.',
-            ], 404);
+                'success' => true,
+                'terminal' => $terminal,
+                'tables' => $tables,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $tables = $this->tableService->getTablesForTerminal($terminalId);
-
-        return response()->json([
-            'success' => true,
-            'terminal' => $terminal,
-            'tables' => $tables,
-        ]);
     }
 
     /**
@@ -122,195 +174,215 @@ class PosController extends Controller
      */
     public function tableOrders(string $terminalId, string $tableId): JsonResponse
     {
-        $table = DB::connection('pos')
-            ->table('tables')
-            ->where('id', $tableId)
-            ->first();
+        try {
+            $table = DB::connection('pos')
+                ->table('tables')
+                ->where('id', $tableId)
+                ->first();
 
-        if (! $table) {
+            if (! $table) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Table not found in Krypton.',
+                ], 404);
+            }
+
+            $orders = DB::connection('pos')
+                ->table('orders as o')
+                // Subquery restricts to the single latest check per order, preventing
+                // duplicate rows when an order has multiple order_check records.
+                ->leftJoin(
+                    DB::raw('(SELECT order_id, MAX(id) AS max_id FROM order_checks GROUP BY order_id) AS oc_latest'),
+                    'oc_latest.order_id', '=', 'o.id'
+                )
+                ->leftJoin('order_checks as oc', 'oc.id', '=', 'oc_latest.max_id')
+                ->leftJoin('table_orders as tor', 'tor.order_id', '=', 'o.id')
+                ->leftJoin('tables as t', 't.id', '=', 'tor.table_id')
+                ->where('o.terminal_id', $terminalId)
+                ->where('tor.table_id', $tableId)
+                ->where('o.is_open', 1)
+                ->where('o.is_voided', 0)
+                ->groupBy(
+                    'o.id',
+                    'o.reference',
+                    'o.date_time_opened',
+                    'o.date_time_closed',
+                    'o.guest_count',
+                    'o.terminal_id',
+                    'o.is_open',
+                    'o.is_voided',
+                    'oc.total_amount',
+                    'oc.paid_amount',
+                    'oc.is_settled',
+                    'oc.resetable_transaction_number'
+                )
+                ->orderByDesc('o.date_time_opened')
+                ->select([
+                    'o.id',
+                    'o.reference',
+                    'o.date_time_opened',
+                    'o.date_time_closed',
+                    'o.guest_count',
+                    'o.terminal_id',
+                    'o.is_open',
+                    'o.is_voided',
+                    DB::raw('COALESCE(oc.total_amount, 0) as total_amount'),
+                    DB::raw('COALESCE(oc.paid_amount, 0) as paid_amount'),
+                    DB::raw('COALESCE(oc.is_settled, 0) as is_settled'),
+                    'oc.resetable_transaction_number',
+                    DB::raw("GROUP_CONCAT(DISTINCT t.name ORDER BY t.name SEPARATOR ', ') as table_names"),
+                ])
+                ->limit(50)
+                ->get();
+
             return response()->json([
-                'success' => false,
-                'message' => 'Table not found in Krypton.',
-            ], 404);
+                'success' => true,
+                'terminal_id' => $terminalId,
+                'table' => $table,
+                'orders' => $orders,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $orders = DB::connection('pos')
-            ->table('orders as o')
-            // Subquery restricts to the single latest check per order, preventing
-            // duplicate rows when an order has multiple order_check records.
-            ->leftJoin(
-                DB::raw('(SELECT order_id, MAX(id) AS max_id FROM order_checks GROUP BY order_id) AS oc_latest'),
-                'oc_latest.order_id', '=', 'o.id'
-            )
-            ->leftJoin('order_checks as oc', 'oc.id', '=', 'oc_latest.max_id')
-            ->leftJoin('table_orders as tor', 'tor.order_id', '=', 'o.id')
-            ->leftJoin('tables as t', 't.id', '=', 'tor.table_id')
-            ->where('o.terminal_id', $terminalId)
-            ->where('tor.table_id', $tableId)
-            ->where('o.is_open', 1)
-            ->where('o.is_voided', 0)
-            ->groupBy(
-                'o.id',
-                'o.reference',
-                'o.date_time_opened',
-                'o.date_time_closed',
-                'o.guest_count',
-                'o.terminal_id',
-                'o.is_open',
-                'o.is_voided',
-                'oc.total_amount',
-                'oc.paid_amount',
-                'oc.is_settled',
-                'oc.resetable_transaction_number'
-            )
-            ->orderByDesc('o.date_time_opened')
-            ->select([
-                'o.id',
-                'o.reference',
-                'o.date_time_opened',
-                'o.date_time_closed',
-                'o.guest_count',
-                'o.terminal_id',
-                'o.is_open',
-                'o.is_voided',
-                DB::raw('COALESCE(oc.total_amount, 0) as total_amount'),
-                DB::raw('COALESCE(oc.paid_amount, 0) as paid_amount'),
-                DB::raw('COALESCE(oc.is_settled, 0) as is_settled'),
-                'oc.resetable_transaction_number',
-                DB::raw("GROUP_CONCAT(DISTINCT t.name ORDER BY t.name SEPARATOR ', ') as table_names"),
-            ])
-            ->limit(50)
-            ->get();
-
-        return response()->json([
-            'success' => true,
-            'terminal_id' => $terminalId,
-            'table' => $table,
-            'orders' => $orders,
-        ]);
     }
 
     public function addOrder(string $terminalId, string $tableId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'guest_count' => ['required', 'integer', 'min:1', 'max:50'],
-            'reference'   => ['nullable', 'string', 'max:50'],
+            'reference' => ['nullable', 'string', 'max:50'],
         ]);
 
-        $table = DB::connection('pos')->table('tables')->where('id', $tableId)->first();
-        if (! $table) {
-            return response()->json(['success' => false, 'message' => 'Table not found.'], 404);
+        try {
+            $table = DB::connection('pos')->table('tables')->where('id', $tableId)->first();
+            if (! $table) {
+                return response()->json(['success' => false, 'message' => 'Table not found.'], 404);
+            }
+
+            $result = $this->orderService->createOrder(
+                $terminalId,
+                $tableId,
+                (int) $validated['guest_count'],
+                $validated['reference'] ?? null,
+            );
+
+            AuditLogService::adminAction($request, 'pos.order_added', (int) $request->user()->id, [
+                'terminal_id' => $terminalId,
+                'table_id' => $tableId,
+                'order_id' => $result['order_id'] ?? null,
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Order created in Krypton successfully.',
+                'result' => $result,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $result = $this->orderService->createOrder(
-            $terminalId,
-            $tableId,
-            (int) $validated['guest_count'],
-            $validated['reference'] ?? null,
-        );
-
-        AuditLogService::adminAction($request, 'pos.order_added', (int) $request->user()->id, [
-            'terminal_id' => $terminalId,
-            'table_id'    => $tableId,
-            'order_id'    => $result['order_id'] ?? null,
-        ]);
-
-        return response()->json([
-            'success' => true,
-            'message' => 'Order created in Krypton successfully.',
-            'result'  => $result,
-        ]);
     }
 
     public function editOrder(string $orderId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'guest_count' => ['required', 'integer', 'min:1', 'max:50'],
-            'reference'   => ['nullable', 'string', 'max:50'],
+            'reference' => ['nullable', 'string', 'max:50'],
         ]);
 
-        $updated = $this->orderService->updateOrder(
-            $orderId,
-            (int) $validated['guest_count'],
-            $validated['reference'] ?? null,
-        );
+        try {
+            $updated = $this->orderService->updateOrder(
+                $orderId,
+                (int) $validated['guest_count'],
+                $validated['reference'] ?? null,
+            );
 
-        if (! $updated) {
-            return response()->json(['success' => false, 'message' => 'Order not found or already voided.'], 404);
+            if (! $updated) {
+                return response()->json(['success' => false, 'message' => 'Order not found or already voided.'], 404);
+            }
+
+            return response()->json(['success' => true, 'message' => 'Order updated in Krypton successfully.']);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        return response()->json(['success' => true, 'message' => 'Order updated in Krypton successfully.']);
     }
 
     public function voidOrder(string $orderId, Request $request): JsonResponse
     {
-        $voided = $this->orderService->voidOrder($orderId);
+        try {
+            $voided = $this->orderService->voidOrder($orderId);
 
-        if (! $voided) {
-            return response()->json(['success' => false, 'message' => 'Order not found.'], 404);
+            if (! $voided) {
+                return response()->json(['success' => false, 'message' => 'Order not found.'], 404);
+            }
+
+            AuditLogService::adminAction($request, 'pos.order_voided', (int) $request->user()->id, [
+                'order_id' => $orderId,
+            ]);
+
+            $deviceOrder = DeviceOrder::where('order_id', $orderId)
+                ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
+                ->first();
+            if ($deviceOrder) {
+                $deviceOrder->status = OrderStatus::VOIDED;
+                $deviceOrder->save();
+            }
+
+            return response()->json(['success' => true, 'message' => 'Order voided in Krypton.']);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        AuditLogService::adminAction($request, 'pos.order_voided', (int) $request->user()->id, [
-            'order_id' => $orderId,
-        ]);
-
-        $deviceOrder = DeviceOrder::where('order_id', $orderId)
-            ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
-            ->first();
-        if ($deviceOrder) {
-            $deviceOrder->status = OrderStatus::VOIDED;
-            $deviceOrder->save();
-        }
-
-        return response()->json(['success' => true, 'message' => 'Order voided in Krypton.']);
     }
 
     public function payOrder(string $orderId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'payment_type_id' => ['required', 'integer'],
-            'amount'          => ['required', 'numeric', 'min:0.01'],
-            'tip'             => ['nullable', 'numeric', 'min:0'],
-            'card_company'    => ['nullable', 'string', 'max:50'],
-            'card_number'     => ['nullable', 'string', 'max:30'],
-            'unique_code'     => ['nullable', 'string', 'max:50'],
-            'auth_code'       => ['nullable', 'string', 'max:50'],
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'tip' => ['nullable', 'numeric', 'min:0'],
+            'card_company' => ['nullable', 'string', 'max:50'],
+            'card_number' => ['nullable', 'string', 'max:30'],
+            'unique_code' => ['nullable', 'string', 'max:50'],
+            'auth_code' => ['nullable', 'string', 'max:50'],
             'expiration_date' => ['nullable', 'string', 'max:16'],
         ]);
 
-        $result = $this->orderService->payOrder($orderId, $validated);
+        try {
+            $result = $this->orderService->payOrder($orderId, $validated);
 
-        if (isset($result['error'])) {
-            return response()->json(['success' => false, 'message' => 'Payment processing failed: ' . $result['error']], 500);
-        }
-        if (isset($result['not_found'])) {
-            return response()->json(['success' => false, 'message' => 'Order not found, already closed, or voided.'], 404);
-        }
-        if (isset($result['check_not_found'])) {
-            return response()->json(['success' => false, 'message' => 'Order check not found.'], 404);
-        }
-
-        AuditLogService::adminAction($request, 'pos.order_paid', (int) $request->user()->id, [
-            'order_id'   => $orderId,
-            'amount'     => $validated['amount'],
-            'is_settled' => (bool) $result['is_settled'],
-        ]);
-
-        if ($result['is_settled']) {
-            $deviceOrder = DeviceOrder::where('order_id', $orderId)
-                ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
-                ->first();
-            if ($deviceOrder) {
-                $deviceOrder->status = OrderStatus::COMPLETED;
-                $deviceOrder->save();
+            if (isset($result['error'])) {
+                return response()->json(['success' => false, 'message' => 'Payment processing failed: '.$result['error']], 500);
             }
-        }
+            if (isset($result['not_found'])) {
+                return response()->json(['success' => false, 'message' => 'Order not found, already closed, or voided.'], 404);
+            }
+            if (isset($result['check_not_found'])) {
+                return response()->json(['success' => false, 'message' => 'Order check not found.'], 404);
+            }
 
-        return response()->json([
-            'success'    => true,
-            'message'    => $result['is_settled'] ? 'Order paid and closed.' : 'Payment recorded.',
-            'payment'    => $result['payment'],
-            'is_settled' => $result['is_settled'],
-        ]);
+            AuditLogService::adminAction($request, 'pos.order_paid', (int) $request->user()->id, [
+                'order_id' => $orderId,
+                'amount' => $validated['amount'],
+                'is_settled' => (bool) $result['is_settled'],
+            ]);
+
+            if ($result['is_settled']) {
+                $deviceOrder = DeviceOrder::where('order_id', $orderId)
+                    ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
+                    ->first();
+                if ($deviceOrder) {
+                    $deviceOrder->status = OrderStatus::COMPLETED;
+                    $deviceOrder->save();
+                }
+            }
+
+            return response()->json([
+                'success' => true,
+                'message' => $result['is_settled'] ? 'Order paid and closed.' : 'Payment recorded.',
+                'payment' => $result['payment'],
+                'is_settled' => $result['is_settled'],
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
+        }
     }
 }

--- a/app/Http/Controllers/Admin/PosController.php
+++ b/app/Http/Controllers/Admin/PosController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
 use App\Http\Controllers\Controller;
 use App\Models\DeviceOrder;
 use App\Services\AuditLogService;
@@ -330,6 +332,48 @@ class PosController extends Controller
             return response()->json(['success' => true, 'message' => 'Order voided in Krypton.']);
         } catch (\Throwable $e) {
             return $this->posConnectionError(__FUNCTION__, $e);
+        }
+    }
+
+    public function fillOrder(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'order_id' => ['required'],
+            'date_time_closed' => ['nullable', 'date'],
+            'is_open' => ['nullable', 'in:0,1'],
+            'is_voided' => ['nullable', 'in:0,1'],
+            'session_id' => ['nullable', 'integer'],
+        ]);
+
+        $orderId = $data['order_id'];
+        $isVoided = ($data['is_voided'] ?? 0) == 1;
+
+        try {
+            $deviceOrder = DeviceOrder::where('order_id', $orderId)->first();
+            if (! $deviceOrder) {
+                return response()->json(['success' => false, 'message' => 'Device order not found'], 404);
+            }
+
+            $newStatus = $isVoided ? OrderStatus::VOIDED : OrderStatus::COMPLETED;
+            $deviceOrder->update(['status' => $newStatus]);
+
+            if ($isVoided) {
+                OrderVoided::dispatch($deviceOrder);
+            } else {
+                OrderCompleted::dispatch($deviceOrder);
+            }
+
+            return response()->json(['success' => true, 'order' => $deviceOrder]);
+        } catch (\Throwable $e) {
+            Log::error('[pos.fill-order] update failed', [
+                'order_id' => $orderId,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Could not update the order. Please try again.',
+            ], 500);
         }
     }
 

--- a/app/Http/Controllers/Admin/TabletCategoryController.php
+++ b/app/Http/Controllers/Admin/TabletCategoryController.php
@@ -4,27 +4,85 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\TabletCategory;
+use App\Models\TabletCategoryMenu;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class TabletCategoryController extends Controller
 {
     public function index()
     {
-        $categories = TabletCategory::orderBy('sort_order')->orderBy('name')->get();
+        $kryptonMenus = collect([]);
+        try {
+            $kryptonMenus = DB::connection('pos')
+                ->table('menus')
+                ->select('id', 'name', 'receipt_name')
+                ->get()
+                ->keyBy('id');
+        } catch (\Throwable) {
+            // POS offline — menu names will fall back to ID labels.
+        }
+
+        $categories = TabletCategory::with('menuPivots')
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get()
+            ->map(function (TabletCategory $cat) use ($kryptonMenus): array {
+                return [
+                    'id' => $cat->id,
+                    'name' => $cat->name,
+                    'slug' => $cat->slug,
+                    'sort_order' => $cat->sort_order,
+                    'is_active' => $cat->is_active,
+                    'menu_count' => $cat->menuPivots->count(),
+                    'menus' => $cat->menuPivots
+                        ->sortBy('sort_order')
+                        ->map(function (TabletCategoryMenu $pivot) use ($kryptonMenus): array {
+                            $kMenu = $kryptonMenus->get($pivot->krypton_menu_id);
+
+                            return [
+                                'id' => $pivot->id,
+                                'krypton_menu_id' => $pivot->krypton_menu_id,
+                                'name' => $kMenu?->name ?? $kMenu?->receipt_name ?? "Menu #{$pivot->krypton_menu_id}",
+                                'is_featured' => $pivot->is_featured,
+                                'sort_order' => $pivot->sort_order,
+                            ];
+                        })
+                        ->values(),
+                ];
+            });
+
+        $unattachedMenus = collect([]);
+        try {
+            $attachedIds = TabletCategoryMenu::pluck('krypton_menu_id')->unique()->all();
+            $unattachedMenus = DB::connection('pos')
+                ->table('menus')
+                ->whereNotIn('id', $attachedIds)
+                ->select('id', 'name', 'receipt_name')
+                ->orderBy('name')
+                ->limit(2000)
+                ->get()
+                ->map(fn ($m) => [
+                    'id' => $m->id,
+                    'name' => $m->name ?: $m->receipt_name ?: "Menu #{$m->id}",
+                ]);
+        } catch (\Throwable) {
+        }
 
         return Inertia::render('tablet-categories/IndexTabletCategories', [
             'categories' => $categories,
+            'unattachedMenus' => $unattachedMenus,
         ]);
     }
 
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'name'       => ['required', 'string', 'max:100'],
-            'slug'       => ['nullable', 'string', 'max:120', 'unique:tablet_categories,slug'],
+            'name' => ['required', 'string', 'max:100'],
+            'slug' => ['nullable', 'string', 'max:120', 'unique:tablet_categories,slug'],
             'sort_order' => ['nullable', 'integer', 'min:0'],
-            'is_active'  => ['boolean'],
+            'is_active' => ['boolean'],
         ]);
 
         TabletCategory::create($validated);
@@ -35,10 +93,10 @@ class TabletCategoryController extends Controller
     public function update(Request $request, TabletCategory $tabletCategory)
     {
         $validated = $request->validate([
-            'name'       => ['required', 'string', 'max:100'],
-            'slug'       => ['nullable', 'string', 'max:120', 'unique:tablet_categories,slug,' . $tabletCategory->id],
+            'name' => ['required', 'string', 'max:100'],
+            'slug' => ['nullable', 'string', 'max:120', 'unique:tablet_categories,slug,'.$tabletCategory->id],
             'sort_order' => ['nullable', 'integer', 'min:0'],
-            'is_active'  => ['boolean'],
+            'is_active' => ['boolean'],
         ]);
 
         $tabletCategory->update($validated);
@@ -61,7 +119,7 @@ class TabletCategoryController extends Controller
     public function syncMenus(Request $request, TabletCategory $tabletCategory)
     {
         $validated = $request->validate([
-            'menu_ids'   => ['required', 'array'],
+            'menu_ids' => ['required', 'array'],
             'menu_ids.*' => ['integer', 'min:1'],
         ]);
 
@@ -70,10 +128,97 @@ class TabletCategoryController extends Controller
         foreach ($validated['menu_ids'] as $index => $menuId) {
             $tabletCategory->menuPivots()->create([
                 'krypton_menu_id' => $menuId,
-                'sort_order'      => $index,
+                'sort_order' => $index,
             ]);
         }
 
         return redirect()->back()->with('success', 'Category menus synced.');
+    }
+
+    /**
+     * Attach one or more menus to a category.
+     * Expects: { menu_ids: number[] }
+     */
+    public function attachMenus(Request $request, TabletCategory $tabletCategory)
+    {
+        $validated = $request->validate([
+            'menu_ids' => ['required', 'array', 'min:1'],
+            'menu_ids.*' => ['integer', 'min:1'],
+        ]);
+
+        $existingIds = $tabletCategory->menuPivots()->pluck('krypton_menu_id')->all();
+        $nextOrder = $tabletCategory->menuPivots()->max('sort_order') ?? -1;
+
+        foreach ($validated['menu_ids'] as $menuId) {
+            if (in_array($menuId, $existingIds, true)) {
+                continue;
+            }
+            $tabletCategory->menuPivots()->create([
+                'krypton_menu_id' => $menuId,
+                'sort_order' => ++$nextOrder,
+                'is_featured' => false,
+            ]);
+        }
+
+        return redirect()->back()->with('success', 'Menu(s) attached.');
+    }
+
+    /**
+     * Detach a single menu from a category.
+     */
+    public function detachMenu(TabletCategory $tabletCategory, int $menuId)
+    {
+        $tabletCategory->menuPivots()->where('krypton_menu_id', $menuId)->delete();
+
+        return redirect()->back()->with('success', 'Menu detached.');
+    }
+
+    /**
+     * Toggle the featured flag on a category-menu pivot.
+     */
+    public function toggleFeatured(TabletCategory $tabletCategory, int $menuId)
+    {
+        $pivot = $tabletCategory->menuPivots()->where('krypton_menu_id', $menuId)->firstOrFail();
+        $pivot->update(['is_featured' => ! $pivot->is_featured]);
+
+        return redirect()->back()->with('success', 'Featured status updated.');
+    }
+
+    /**
+     * Reorder the menus within a category.
+     * Expects: { menu_ids: number[] } — ordered list of krypton_menu_ids
+     */
+    public function updateMenuOrder(Request $request, TabletCategory $tabletCategory)
+    {
+        $validated = $request->validate([
+            'menu_ids' => ['required', 'array'],
+            'menu_ids.*' => ['integer', 'min:1'],
+        ]);
+
+        foreach ($validated['menu_ids'] as $index => $menuId) {
+            $tabletCategory->menuPivots()
+                ->where('krypton_menu_id', $menuId)
+                ->update(['sort_order' => $index]);
+        }
+
+        return redirect()->back()->with('success', 'Menu order updated.');
+    }
+
+    /**
+     * Reorder categories themselves.
+     * Expects: { ids: number[] } — ordered list of category IDs
+     */
+    public function reorder(Request $request)
+    {
+        $validated = $request->validate([
+            'ids' => ['required', 'array'],
+            'ids.*' => ['integer', 'min:1'],
+        ]);
+
+        foreach ($validated['ids'] as $index => $id) {
+            TabletCategory::where('id', $id)->update(['sort_order' => $index]);
+        }
+
+        return redirect()->back()->with('success', 'Category order updated.');
     }
 }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -3,14 +3,16 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
-use Inertia\Inertia;
-use App\Models\User;
-use App\Models\Branch;
-use Illuminate\Support\Facades\Hash;
-use Spatie\Permission\Models\Role;
 use App\Http\Requests\StoreUserRequest;
 use App\Http\Requests\UpdateUserRequest;
+use App\Models\Branch;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Inertia\Inertia;
+use Spatie\Permission\Models\Role;
 
 // use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
@@ -31,11 +33,11 @@ class UserController extends Controller
         $users = User::with('roles')->withTrashed()->orderBy('created_at', 'desc')->paginate($perPage)->withQueryString();
 
         // Compute simple stats for the UI (last 7 days sparkline and delta)
-        $today = \Carbon\Carbon::today();
+        $today = Carbon::today();
         $start = $today->copy()->subDays(6)->startOfDay();
 
         $daily = User::where('created_at', '>=', $start)
-            ->selectRaw("DATE(created_at) as date, COUNT(*) as cnt")
+            ->selectRaw('DATE(created_at) as date, COUNT(*) as cnt')
             ->groupBy('date')
             ->orderBy('date')
             ->pluck('cnt', 'date')
@@ -116,10 +118,10 @@ class UserController extends Controller
             'password' => Hash::make($data['password']),
         ]);
 
-        if (!empty($data['branches'])) {
+        if (! empty($data['branches'])) {
             $user->branches()->sync($data['branches']);
         }
-        if (!empty($data['roles'])) {
+        if (! empty($data['roles'])) {
             $user->syncRoles($data['roles']);
         }
 
@@ -129,9 +131,11 @@ class UserController extends Controller
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(User $user): RedirectResponse
     {
-        //
+        $this->authorize('admin');
+
+        return redirect()->route('users.edit', $user);
     }
 
     /**
@@ -167,7 +171,7 @@ class UserController extends Controller
             'email' => $data['email'],
         ]);
 
-        if (!empty($data['password'])) {
+        if (! empty($data['password'])) {
             $user->password = Hash::make($data['password']);
             $user->save();
         }
@@ -179,17 +183,18 @@ class UserController extends Controller
             $user->syncRoles($data['roles']);
         }
 
-       return redirect()->route('users.index')->with('success', 'User updated successfully.');
+        return redirect()->route('users.index')->with('success', 'User updated successfully.');
     }
 
     /**
      * Remove the specified resource from storage.
      */
     public function destroy(User $user)
-    {  
+    {
         $this->authorize('admin');
 
         $user->delete();
+
         return redirect()->route('users.index')->with('success', 'User deleted successfully.');
     }
 

--- a/app/Http/Controllers/Api/V1/OrderApiController.php
+++ b/app/Http/Controllers/Api/V1/OrderApiController.php
@@ -15,11 +15,11 @@ use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
 use App\Models\Krypton\Menu;
 use App\Models\Krypton\Menu as KryptonMenu;
+use App\Models\Krypton\OrderedMenu;
+use App\Services\DurableRefillGuard;
 use App\Services\Krypton\KryptonContextService;
 use App\Services\PrintTicketService;
-use App\Services\DurableRefillGuard;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -177,7 +177,7 @@ class OrderApiController extends Controller
      * Persist refill items and dispatch print event.
      *
      * Validates that items are refillable (meats/sides only).
-     * 
+     *
      * State Machine: NEW → PROCESSING → POS_CREATED → MIRRORED → PRINT_EVENT_CREATED → COMPLETED
      * Durable idempotency via RefillSubmission model prevents duplicate POS inserts on retry.
      */
@@ -195,7 +195,7 @@ class OrderApiController extends Controller
 
         // Validate authenticated device
         $device = $request->user();
-        if (!$device || !isset($device->id)) {
+        if (! $device || ! isset($device->id)) {
             return response()->json(['success' => false, 'message' => 'Device authentication required'], 401);
         }
 
@@ -225,14 +225,14 @@ class OrderApiController extends Controller
         if (in_array($deviceOrder->status, $terminalStatuses, true)) {
             return response()->json([
                 'success' => false,
-                'message' => 'Refill not allowed: order is ' . $deviceOrder->status->value,
-                'error'   => ['code' => 'ORDER_NOT_ACTIVE', 'status' => $deviceOrder->status->value],
+                'message' => 'Refill not allowed: order is '.$deviceOrder->status->value,
+                'error' => ['code' => 'ORDER_NOT_ACTIVE', 'status' => $deviceOrder->status->value],
             ], 409);
         }
 
         // Generate a server-side submission id if the tablet did not provide one,
         // so the durable idempotency guard always runs.
-        if (!$clientSubmissionId) {
+        if (! $clientSubmissionId) {
             $clientSubmissionId = (string) Str::uuid();
             Log::info('[REFILL] Generated server-side client_submission_id', [
                 'device_id' => $device->id,
@@ -246,17 +246,18 @@ class OrderApiController extends Controller
         $guardResult = $refillGuard->guard($device, $deviceOrder, $clientSubmissionId);
 
         // Already completed - return cached response
-        if (!$guardResult['proceed'] && $guardResult['response']) {
+        if (! $guardResult['proceed'] && $guardResult['response']) {
             Log::info('[REFILL] Returning cached completed response', [
                 'device_id' => $device->id,
                 'order_id' => $orderId,
                 'client_submission_id' => $clientSubmissionId,
             ]);
+
             return $guardResult['response'];
         }
 
         // Currently processing - return 409
-        if (!$guardResult['proceed'] && !$guardResult['response']) {
+        if (! $guardResult['proceed'] && ! $guardResult['response']) {
             return response()->json([
                 'success' => false,
                 'message' => 'Duplicate refill request already processing',
@@ -278,13 +279,9 @@ class OrderApiController extends Controller
             $name = trim(strval($it['name'] ?? ''));
             $quantity = intval($it['quantity'] ?? 1);
 
-            // Optimization: If both menu_id and price provided, skip DB lookup (testing + API contracts)
             $menu = null;
-            if (! empty($it['menu_id']) && isset($it['price'])) {
-                $menu = (object) ['id' => $it['menu_id'], 'price' => $it['price']];
-            }
-            // Priority 1: Use menu_id to lookup from POS if price not provided
-            elseif (! empty($it['menu_id'])) {
+            // Priority 1: Use menu_id to lookup from POS
+            if (! empty($it['menu_id'])) {
                 try {
                     $menu = KryptonMenu::find($it['menu_id']);
                 } catch (\Throwable $_e) {
@@ -305,6 +302,7 @@ class OrderApiController extends Controller
             if (! $menu) {
                 $menuRef = $it['menu_id'] ?? $name ?? 'unknown';
                 $refillGuard->markFailed($submission, "Menu item not found: {$menuRef}");
+
                 return response()->json(['success' => false, 'message' => "Menu item not found: {$menuRef}"], 422);
             }
 
@@ -343,7 +341,7 @@ class OrderApiController extends Controller
         } else {
             // Run POS-side inserts
             $attrs['mirror_local'] = false;
-            
+
             try {
                 $created = CreateOrderedMenu::run($attrs);
             } catch (\Throwable $e) {
@@ -353,6 +351,7 @@ class OrderApiController extends Controller
                     'order_id' => $orderId,
                     'error' => $e->getMessage(),
                 ]);
+
                 return response()->json(['success' => false, 'message' => 'POS insert failed', 'error' => $e->getMessage()], 500);
             }
 
@@ -369,14 +368,15 @@ class OrderApiController extends Controller
                 $refillGuard->markPosCreated($submission, $posOrderedMenuIds);
             } catch (\Throwable $e) {
                 Log::critical('[REFILL] CRITICAL: POS insert succeeded but state mark failed — manual reconciliation may be required', [
-                    'submission_id'     => $submission->id,
+                    'submission_id' => $submission->id,
                     'pos_ordered_menu_ids' => $posOrderedMenuIds,
-                    'error'             => $e->getMessage(),
+                    'error' => $e->getMessage(),
                 ]);
+
                 return response()->json([
-                    'success'       => false,
-                    'message'       => 'POS insert succeeded but state could not be recorded — please retry',
-                    'pos_created'   => true,
+                    'success' => false,
+                    'message' => 'POS insert succeeded but state could not be recorded — please retry',
+                    'pos_created' => true,
                     'submission_id' => $submission->id,
                 ], 500);
             }
@@ -384,7 +384,7 @@ class OrderApiController extends Controller
 
         // Normalize created items for downstream processing
         // For retries, we need to fetch the POS items again
-        if (!isset($created)) {
+        if (! isset($created)) {
             // Retry scenario: fetch existing POS ordered_menu records
             $created = $this->fetchPosOrderedMenus($posOrderedMenuIds);
         }
@@ -393,12 +393,14 @@ class OrderApiController extends Controller
             if (is_array($it)) {
                 return (object) $it;
             }
+
             return $it;
         })->values()->all();
 
         // Guard: if no items created in POS, nothing to mirror locally
         if (empty($posItems)) {
             $refillGuard->markCompleted($submission, ['success' => true, 'created' => []]);
+
             return response()->json(['success' => true, 'created' => []]);
         }
 
@@ -412,6 +414,7 @@ class OrderApiController extends Controller
             $metaItems = collect($posItems)->map(function ($item) use ($menuNames) {
                 $menuId = $item->menu_id;
                 $menuName = $menuNames->get($menuId) ?? $item->name ?? $item->receipt_name;
+
                 return [
                     'menu_id' => $menuId,
                     'quantity' => $item->quantity ?? 1,
@@ -465,7 +468,7 @@ class OrderApiController extends Controller
 
                 for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
                     try {
-                        DB::transaction(function () use ($deviceOrder, $localPayloads) {
+                        DB::transaction(function () use ($localPayloads) {
                             if (! empty($localPayloads)) {
                                 DeviceOrderItems::query()->insert($localPayloads);
                             }
@@ -500,6 +503,7 @@ class OrderApiController extends Controller
                 if ($lastError) {
                     // Mark as failed so client can retry
                     $refillGuard->markFailed($submission, "Local mirror failed: {$lastError}");
+
                     return response()->json([
                         'success' => false,
                         'message' => 'Failed to persist refill locally',
@@ -514,7 +518,7 @@ class OrderApiController extends Controller
             $printEvent = null;
             if ($submission->status !== 'PRINT_EVENT_CREATED' && $submission->status !== 'COMPLETED') {
                 try {
-                    DB::transaction(function () use ($deviceOrder, $posItems, $clientSubmissionId, $refillEventMeta, &$printEvent) {
+                    DB::transaction(function () use ($deviceOrder, $posItems, $clientSubmissionId, &$printEvent) {
                         $printTicketService = app(PrintTicketService::class);
                         $printEvent = $printTicketService->createRefillPrintEvent(
                             $deviceOrder,
@@ -568,10 +572,10 @@ class OrderApiController extends Controller
         } catch (\Throwable $th) {
             report($th);
             $refillGuard->markFailed($submission, $th->getMessage());
+
             return response()->json(['success' => false, 'message' => 'Failed to persist refill', 'error' => $th->getMessage()], 500);
         }
     }
-
 
     /**
      * Fetch POS ordered_menu records by IDs (for retry scenarios)
@@ -583,12 +587,13 @@ class OrderApiController extends Controller
         }
 
         try {
-            return \App\Models\Krypton\OrderedMenu::whereIn('id', $orderedMenuIds)->get()->all();
+            return OrderedMenu::whereIn('id', $orderedMenuIds)->get()->all();
         } catch (\Throwable $e) {
             Log::warning('[REFILL] Failed to fetch POS ordered_menus for retry', [
                 'ordered_menu_ids' => $orderedMenuIds,
                 'error' => $e->getMessage(),
             ]);
+
             return [];
         }
     }

--- a/app/Http/Requests/RefillOrderRequest.php
+++ b/app/Http/Requests/RefillOrderRequest.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Krypton\Menu as KryptonMenu;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Log;
-use App\Models\Krypton\Menu as KryptonMenu;
 
 /**
  * Validation for refill order requests.
- * 
+ *
  * Ensures:
  * - Only meats and sides categories are allowed
  * - Items exist in POS menu system
@@ -57,15 +57,14 @@ class RefillOrderRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'items'             => ['required', 'array', 'min:1'],
-            'items.*.menu_id'   => ['required', 'integer', 'min:1'],
-            'items.*.quantity'  => ['required', 'integer', 'min:1', 'max:50'],
-            'items.*.name'      => ['nullable', 'string', 'max:255'],
-            'items.*.price'     => ['nullable', 'numeric', 'min:0'],
-            'items.*.index'     => ['nullable', 'integer', 'min:1', 'max:20'],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.menu_id' => ['required', 'integer', 'min:1'],
+            'items.*.quantity' => ['required', 'integer', 'min:1', 'max:50'],
+            'items.*.name' => ['nullable', 'string', 'max:255'],
+            'items.*.index' => ['nullable', 'integer', 'min:1', 'max:20'],
             'items.*.seat_number' => ['nullable', 'integer', 'min:1', 'max:20'],
-            'items.*.note'      => ['nullable', 'string', 'max:255'],
-            'session_id'        => ['nullable', 'string'],
+            'items.*.note' => ['nullable', 'string', 'max:255'],
+            'session_id' => ['nullable', 'string'],
         ];
     }
 
@@ -93,7 +92,7 @@ class RefillOrderRequest extends FormRequest
 
             foreach ($items as $index => $item) {
                 $menuId = (int) ($item['menu_id'] ?? 0);
-                $label  = $item['name'] ?? "menu_id:{$menuId}";
+                $label = $item['name'] ?? "menu_id:{$menuId}";
 
                 $menu = null;
                 try {
@@ -102,11 +101,12 @@ class RefillOrderRequest extends FormRequest
                     $menu = null;
                 }
 
-                if (!$menu) {
+                if (! $menu) {
                     $validator->errors()->add("items.{$index}.menu_id", "Menu item not found: {$label}");
+
                     continue;
                 }
-                
+
                 // Validate that item is in refillable groups (meats/sides only)
                 // Check menu_group, not menu_category
                 try {

--- a/app/Http/Requests/StoreDeviceOrderRequest.php
+++ b/app/Http/Requests/StoreDeviceOrderRequest.php
@@ -15,6 +15,30 @@ class StoreDeviceOrderRequest extends FormRequest
     }
 
     /**
+     * Strip any non-intent fields before validation so client-supplied pricing,
+     * modifiers, and POS mapping never enter validated() output.
+     *
+     * Contract: contracts/tablet-api.contract.md (intent-only payload).
+     */
+    protected function prepareForValidation(): void
+    {
+        $items = collect($this->input('items', []))
+            ->filter(static fn ($item) => is_array($item))
+            ->map(static fn (array $item) => [
+                'menu_id' => $item['menu_id'] ?? null,
+                'quantity' => $item['quantity'] ?? null,
+            ])
+            ->values()
+            ->all();
+
+        $this->replace([
+            'guest_count' => $this->input('guest_count'),
+            'package_id' => $this->input('package_id'),
+            'items' => $items,
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
@@ -22,34 +46,11 @@ class StoreDeviceOrderRequest extends FormRequest
     public function rules(): array
     {
         return [
-            // Intent-only fields (tablet staging contract)
-            'guest_count'  => ['required', 'integer', 'min:1', 'max:20'],
-            'package_id'   => ['required', 'integer', 'min:1'],
-
-            // Client-supplied totals are optional; server always recalculates them.
-            'subtotal'      => ['nullable', 'numeric', 'min:0'],
-            'tax'           => ['nullable', 'numeric', 'min:0'],
-            'discount'      => ['nullable', 'numeric', 'min:0'],
-            'total_amount'  => ['nullable', 'numeric', 'min:0'],
-
-            'session_id' => ['nullable', 'integer'],
-
-            // Items: only menu_id + quantity are required; name/price/subtotal are optional
-            // (server resolves them from POS menu catalog)
-            'items'                    => ['required', 'array', 'min:1'],
-            'items.*.menu_id'          => ['required', 'integer', 'min:1'],
-            'items.*.quantity'         => ['required', 'integer', 'min:1', 'max:50'],
-            'items.*.name'             => ['nullable', 'string'],
-            'items.*.price'            => ['nullable', 'numeric', 'min:0'],
-            'items.*.note'             => ['nullable', 'string'],
-            'items.*.subtotal'         => ['nullable', 'numeric', 'min:0'],
-            'items.*.ordered_menu_id'  => ['nullable', 'integer', 'min:1'],
-            'items.*.tax'              => ['nullable', 'numeric', 'min:0'],
-            'items.*.discount'         => ['nullable', 'numeric', 'min:0'],
-            'items.*.is_package'       => ['nullable', 'boolean'],
-            'items.*.modifiers'        => ['nullable', 'array'],
-            'items.*.modifiers.*.menu_id'  => ['required_with:items.*.modifiers', 'integer'],
-            'items.*.modifiers.*.quantity' => ['required_with:items.*.modifiers', 'integer', 'min:1'],
+            'guest_count' => ['required', 'integer', 'min:1', 'max:20'],
+            'package_id' => ['required', 'integer', 'min:1'],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.menu_id' => ['required', 'integer', 'min:1'],
+            'items.*.quantity' => ['required', 'integer', 'min:1', 'max:50'],
         ];
     }
 }

--- a/app/Models/DeviceOrder.php
+++ b/app/Models/DeviceOrder.php
@@ -3,30 +3,30 @@
 namespace App\Models;
 
 use App\Casts\UtcDateTimeCast;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use App\Services\LocalBranchResolver;
-use App\Models\Branch;
-use App\Models\Krypton\Table;
-use App\Models\Krypton\Order;
 use App\Enums\OrderStatus;
-use Illuminate\Support\Str; 
+use App\Models\Krypton\Order;
+use App\Models\Krypton\Table;
+use App\Services\LocalBranchResolver;
 use Illuminate\Database\Eloquent\Builder;
-use App\Models\ServiceRequest;
-use App\Models\DeviceOrderItems;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
 
 class DeviceOrder extends Model
 {
     use HasFactory, SoftDeletes;
+
     protected $table = 'device_orders';
+
     // Prevent accidental mass-assignment of legacy JSON columns
     // The `items` and `meta` JSON columns have been migrated out
     // to `device_order_items` and a computed accessor respectively.
     protected $guarded = ['items', 'meta'];
+
     protected $primaryKey = 'id';
 
     // protected $fillable = [
@@ -43,7 +43,7 @@ class DeviceOrder extends Model
     // ];
 
     protected $hidden = [
-        'updated_at'
+        'updated_at',
     ];
 
     protected $casts = [
@@ -58,12 +58,13 @@ class DeviceOrder extends Model
         'is_printed' => 'boolean',
         'printed_at' => UtcDateTimeCast::class,
         'printed_by' => 'string',
+        'recalled' => 'integer',
     ];
 
     /**
      * Return related device order items (local canonical source).
      */
-    public function items() : HasMany
+    public function items(): HasMany
     {
         return $this->hasMany(DeviceOrderItems::class, 'order_id')->orderBy('index');
     }
@@ -76,7 +77,8 @@ class DeviceOrder extends Model
     {
         try {
             $orderCheck = $this->order?->orderCheck ?? null;
-            return [ 'order_check' => $orderCheck ];
+
+            return ['order_check' => $orderCheck];
         } catch (\Throwable $_e) {
             return [];
         }
@@ -92,13 +94,14 @@ class DeviceOrder extends Model
             $newStatus = OrderStatus::from($newStatus);
         }
 
-        if (!$newStatus instanceof OrderStatus) {
+        if (! $newStatus instanceof OrderStatus) {
             $newStatus = OrderStatus::PENDING;
         }
 
         // If this is a new model (creating), skip transition validation
-        if (!$this->exists) {
+        if (! $this->exists) {
             $this->attributes['status'] = $newStatus->value;
+
             return;
         }
 
@@ -107,7 +110,7 @@ class DeviceOrder extends Model
             $currentStatus = OrderStatus::from($currentStatus);
         }
 
-        if (!$currentStatus->canTransitionTo($newStatus)) {
+        if (! $currentStatus->canTransitionTo($newStatus)) {
             throw new \InvalidArgumentException(
                 "Invalid status transition: {$currentStatus->value} → {$newStatus->value}"
             );
@@ -121,21 +124,22 @@ class DeviceOrder extends Model
     // See RANPO_PRODUCTION_AUDIT_2026-04-07.md §P0 Race Condition.
 
     protected static function boot()
-    {   
+    {
         parent::boot();
 
         static::creating(function ($model) {
-            if (!empty($model->branch_id)) {
+            if (! empty($model->branch_id)) {
                 return;
             }
 
-            if (!empty($model->device_id)) {
+            if (! empty($model->device_id)) {
                 $deviceBranchId = Device::query()
                     ->whereKey($model->device_id)
                     ->value('branch_id');
 
-                if (!empty($deviceBranchId)) {
+                if (! empty($deviceBranchId)) {
                     $model->branch_id = (int) $deviceBranchId;
+
                     return;
                 }
             }
@@ -155,9 +159,9 @@ class DeviceOrder extends Model
             }
 
             $model->order_number = 'ORD-'
-                . now()->format('Ymd')
-                . '-'
-                . strtoupper(substr((string) $model->order_uuid, -6));
+                .now()->format('Ymd')
+                .'-'
+                .strtoupper(substr((string) $model->order_uuid, -6));
         });
     }
 
@@ -186,7 +190,7 @@ class DeviceOrder extends Model
      */
     public function printEvents(): HasMany
     {
-        return $this->hasMany(\App\Models\PrintEvent::class, 'device_order_id', 'id');
+        return $this->hasMany(PrintEvent::class, 'device_order_id', 'id');
     }
 
     /**
@@ -195,11 +199,12 @@ class DeviceOrder extends Model
      */
     public function printEvent(): HasOne
     {
-        return $this->hasOne(\App\Models\PrintEvent::class, 'device_order_id', 'id')
+        return $this->hasOne(PrintEvent::class, 'device_order_id', 'id')
             ->latestOfMany();
     }
 
-    public function scopeActiveOrder(Builder $query) {
+    public function scopeActiveOrder(Builder $query)
+    {
         return $query->whereIn('status', [
             OrderStatus::PENDING,
             OrderStatus::CONFIRMED,

--- a/app/Models/DeviceOrderItems.php
+++ b/app/Models/DeviceOrderItems.php
@@ -2,18 +2,20 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use App\Models\Krypton\Menu;
 use App\Enums\ItemStatus;
+use App\Models\Krypton\Menu;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class DeviceOrderItems extends Model
 {
-    use SoftDeletes, HasFactory;
+    use HasFactory, SoftDeletes;
+
     protected $table = 'device_order_items';
+
     protected $fillable = [
         'order_id',
         'ordered_menu_id',
@@ -28,6 +30,8 @@ class DeviceOrderItems extends Model
         'seat_number',
         'index',
         'is_refill',
+        'done',
+        'done_at',
         'is_printed',
         'printed_at',
         'printed_by_print_event_id',
@@ -44,6 +48,8 @@ class DeviceOrderItems extends Model
         'total' => 'decimal:4',
         'status' => ItemStatus::class,
         'is_refill' => 'boolean',
+        'done' => 'boolean',
+        'done_at' => 'datetime',
         'is_printed' => 'boolean',
         'printed_at' => 'datetime',
     ];

--- a/app/Models/TabletCategoryMenu.php
+++ b/app/Models/TabletCategoryMenu.php
@@ -15,10 +15,12 @@ class TabletCategoryMenu extends Model
         'tablet_category_id',
         'krypton_menu_id',
         'sort_order',
+        'is_featured',
     ];
 
     protected $casts = [
         'sort_order' => 'integer',
+        'is_featured' => 'boolean',
     ];
 
     public function category(): BelongsTo

--- a/app/Services/CertificatePathResolver.php
+++ b/app/Services/CertificatePathResolver.php
@@ -9,6 +9,7 @@ class CertificatePathResolver
         $candidatePaths = [
             base_path('docker/certs/fullchain.pem'),
             base_path('docker/certs/fullchain.crt'),
+            base_path('docker/certs/rootCA.crt'),
             storage_path('app/public/certificates/woosoo-ca.der'),
             storage_path('app/public/certificates/CAROOT.pem'),
             base_path('certs/ca.crt'),

--- a/app/Services/PosConnectionService.php
+++ b/app/Services/PosConnectionService.php
@@ -28,11 +28,15 @@ class PosConnectionService
 
             $creds = SystemSetting::getPosConnection();
 
+            if (blank($creds['password'] ?? null)) {
+                Log::warning('[PosConnectionService] POS host/database/username are configured but the password is empty — connections will fail with access denied');
+            }
+
             $current = Config::get('database.connections.pos', []);
 
             $override = array_filter([
-                'host'     => $creds['host'],
-                'port'     => $creds['port'],
+                'host' => $creds['host'],
+                'port' => $creds['port'],
                 'database' => $creds['database'],
                 'username' => $creds['username'],
                 'password' => $creds['password'] ?? '',
@@ -52,8 +56,96 @@ class PosConnectionService
                 DB::purge('pos');
             }
         } catch (\Throwable $e) {
-            Log::warning('[PosConnectionService] Failed to apply POS connection from DB: ' . $e->getMessage());
+            Log::warning('[PosConnectionService] Failed to apply POS connection from DB: '.$e->getMessage());
         }
+    }
+
+    /**
+     * @return array{connected: bool, status: string, message: string}
+     */
+    public function posStatus(): array
+    {
+        return once(function (): array {
+            if (! $this->hasPasswordConfigured()) {
+                return [
+                    'connected' => false,
+                    'status' => 'not_configured',
+                    'message' => 'POS password is not configured. Open Configuration → POS Connection and enter the database password.',
+                ];
+            }
+
+            try {
+                DB::connection('pos')->getPdo();
+
+                return [
+                    'connected' => true,
+                    'status' => 'connected',
+                    'message' => '',
+                ];
+            } catch (\Throwable $e) {
+                return $this->failureFromThrowable($e);
+            }
+        });
+    }
+
+    public function isReachable(): bool
+    {
+        return $this->posStatus()['connected'];
+    }
+
+    /**
+     * @return array{connected: bool, status: string, message: string}
+     */
+    public function failureFromThrowable(\Throwable $e): array
+    {
+        $message = $e->getMessage();
+
+        if (str_contains($message, '1045') || str_contains($message, 'Access denied')) {
+            return [
+                'connected' => false,
+                'status' => 'auth_failed',
+                'message' => 'POS database rejected the credentials. Check Configuration → POS Connection and verify the username and password.',
+            ];
+        }
+
+        if (
+            str_contains($message, '2002')
+            || str_contains($message, '2003')
+            || str_contains($message, 'Connection refused')
+            || str_contains($message, 'timed out')
+            || str_contains($message, 'getaddrinfo')
+        ) {
+            return [
+                'connected' => false,
+                'status' => 'unreachable',
+                'message' => 'Unable to reach the POS database. Confirm the host and port are correct and the MySQL server is running.',
+            ];
+        }
+
+        return [
+            'connected' => false,
+            'status' => 'unreachable',
+            'message' => 'Unable to reach the POS system. Check Configuration → POS Connection.',
+        ];
+    }
+
+    private function hasPasswordConfigured(): bool
+    {
+        if (Config::get('database.connections.pos.driver') === 'sqlite') {
+            return true;
+        }
+
+        try {
+            if (Schema::hasTable('system_settings') && SystemSetting::hasPosConnection()) {
+                $password = SystemSetting::getPosConnection()['password'] ?? null;
+
+                return filled($password);
+            }
+        } catch (\Throwable) {
+            // Fall through to env-based check.
+        }
+
+        return filled(Config::get('database.connections.pos.password'));
     }
 
     /**
@@ -62,21 +154,21 @@ class PosConnectionService
      */
     public function testCredentials(string $host, string $port, string $database, string $username, string $password): array
     {
-        $tempName = 'pos_probe_' . uniqid();
+        $tempName = 'pos_probe_'.uniqid();
 
         try {
             Config::set("database.connections.{$tempName}", [
-                'driver'    => 'mysql',
-                'host'      => $host,
-                'port'      => (int) $port,
-                'database'  => $database,
-                'username'  => $username,
-                'password'  => $password,
-                'charset'   => 'utf8mb4',
+                'driver' => 'mysql',
+                'host' => $host,
+                'port' => (int) $port,
+                'database' => $database,
+                'username' => $username,
+                'password' => $password,
+                'charset' => 'utf8mb4',
                 'collation' => 'utf8mb4_unicode_ci',
-                'prefix'    => '',
-                'strict'    => true,
-                'options'   => [
+                'prefix' => '',
+                'strict' => true,
+                'options' => [
                     \PDO::ATTR_TIMEOUT => 5, // 5-second connect timeout
                 ],
             ]);

--- a/config/boost.php
+++ b/config/boost.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Boost functionality - which
+    | will prevent Boost's routes from being registered and will also
+    | disable Boost's browser logging functionality from operating.
+    |
+    */
+
+    'enabled' => env('BOOST_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Browser Logs Watcher
+    |--------------------------------------------------------------------------
+    |
+    | The following option may be used to enable or disable the browser logs
+    | watcher feature within Laravel Boost. The log watcher will read any
+    | errors within the browser's console to give Boost better context.
+    |
+    */
+
+    'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Tinker Tool
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Boost exposes an MCP tool that executes arbitrary PHP in the
+    | application context (the programmatic equivalent of `php artisan tinker`).
+    | It only operates in local environments and is opt-in per developer. Keep
+    | it disabled if you do not want agents running code against your dev data.
+    |
+    */
+
+    'tinker_tool_enabled' => env('BOOST_TINKER_TOOL_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Executables Paths
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to specify custom paths for the executables that
+    | Boost uses. When configured, they take precedence over the automatic
+    | discovery mechanism. Leave empty to use defaults from your $PATH.
+    |
+    */
+
+    'executable_paths' => [
+        'php' => env('BOOST_PHP_EXECUTABLE_PATH'),
+        'composer' => env('BOOST_COMPOSER_EXECUTABLE_PATH'),
+        'npm' => env('BOOST_NPM_EXECUTABLE_PATH'),
+        'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
+        'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
+    ],
+
+];

--- a/database/migrations/2026_06_08_095020_add_kds_columns_to_device_order_items_and_device_orders.php
+++ b/database/migrations/2026_06_08_095020_add_kds_columns_to_device_order_items_and_device_orders.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('device_order_items', function (Blueprint $table) {
+            $table->boolean('done')->default(false)->after('is_refill');
+            $table->timestamp('done_at')->nullable()->after('done');
+        });
+
+        Schema::table('device_orders', function (Blueprint $table) {
+            $table->smallInteger('recalled')->default(0)->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('device_order_items', function (Blueprint $table) {
+            $table->dropColumn(['done', 'done_at']);
+        });
+
+        Schema::table('device_orders', function (Blueprint $table) {
+            $table->dropColumn('recalled');
+        });
+    }
+};

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-last_reviewed: 2026-05-31
+last_reviewed: 2026-06-06
 scope: woosoo-nexus
 ---
 
@@ -675,6 +675,7 @@ flutter analyze                        # Code analysis (Dart)
 - Test: `tests/Feature/DeviceTableTest.php` (Pest feature test)
 
 **Documentation**
+- `docs/LARAVEL_BOOST_GUIDE.md` — Laravel Boost MCP tools, Tinker guardrails, Cursor setup
 - `docs/API_MAP.md` — API endpoint reference (request/response shapes)
 - `docs/BRANCH_CRUD_IMPLEMENTATION.md` — example CRUD implementation
 - `docs/ROLES_IMPLEMENTATION_COMPLETE.md` — roles/permissions guide

--- a/docs/AI_ONBOARDING.md
+++ b/docs/AI_ONBOARDING.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-last_reviewed: 2026-06-06
+last_reviewed: 2026-06-07
 scope: woosoo-nexus
 ---
 
@@ -10,9 +10,9 @@ Detailed onboarding for AI coding agents (Claude Code) working in `woosoo-nexus`
 demand, not part of the always-on boot layer — the agent operating system is the root
 `../AGENTS.md`, and per-app hard rules are in `.agents.md`. Indexed from `docs/INDEX.md`.
 
-## Integrated Restaurant POS + Admin Panel + Relay Printer App
+## Integrated Restaurant POS + Admin Panel + Print Bridge
 
-**Purpose:** Help AI agents become productive in woosoo-nexus monorepo. Focus on discoverable patterns, runnable commands, and concrete examples across three integrated products.
+**Purpose:** Help AI agents become productive in woosoo-nexus. Focus on discoverable patterns, runnable commands, and concrete examples across the backend and its sibling apps (tablet PWA, print bridge).
 
 ---
 
@@ -135,12 +135,12 @@ Do not hardcode LAN IPs in source code. Use `PUBLIC_HOST` and Compose/runtime en
 - **State:** Pinia stores with persist plugin (e.g., `menu-store`, `device`)
 - **Offline:** PWA service worker caches menus and order history; workbox rules in `nuxt.config.ts`
 
-### 3. **Relay Printer App** (`relay-device/` — Flutter)
+### 3. **Print Bridge** (`woosoo-print-bridge/` — Flutter)
 - **What:** Native mobile/tablet app that listens for print events (WebSocket + fallback polling) and prints to Bluetooth thermal printers
 - **Tech:** Flutter 3.9.2+, Dart, Riverpod state management, Sembast local DB
 - **Platforms:** Android, iOS, Windows, Linux, web (see `pubspec.yaml`)
 - **Key features:** WebSocket listener, ESC/POS printer control, durable offline queue, device registration
-- **Run:** `flutter pub get; flutter run -d <device>` from `relay-device/`
+- **Run:** `flutter pub get; flutter run -d <device>` from `woosoo-print-bridge/`
 
 **Database Architecture:**
 - `mysql` connection (default): App data (users, devices, menus, orders, branches, roles) — Laravel migrations in `database/migrations/*`
@@ -186,13 +186,13 @@ Do not hardcode LAN IPs in source code. Use `PUBLIC_HOST` and Compose/runtime en
 **Process Boundaries:**
 - PHP process: HTTP requests, domain logic, queues, scheduled tasks, WebSocket server (Reverb)
 - Node process: `print-service/index.js` (Express, port 9100) — independent print job handler
-- Flutter process: Relay device — autonomous listener/printer, syncs with backend via API + WebSocket
+- Flutter process: Print Bridge — autonomous listener/printer, syncs with backend via API + WebSocket
 
 **Real-time Communication:**
 - Reverb (port 6001): WebSocket server for broadcasting events (admin, device channels)
 - Channels: `device.{deviceId}`, `admin.orders`, `admin.print`, `admin.service-requests`, etc.
 - Frontend listeners: Laravel Echo in Vue (`resources/js/app.ts`) and Nuxt PWA (`tablet-ordering-pwa/plugins/echo.client.ts`)
-- Mobile: Relay device listens via Dart HTTP client (WebSocket library)
+- Mobile: Print Bridge listens via Reverb WebSocket + polling fallback (`lib/services/reverb_service.dart`)
 
 ---
 
@@ -238,14 +238,14 @@ Do not hardcode LAN IPs in source code. Use `PUBLIC_HOST` and Compose/runtime en
 - `tablet-ordering-pwa/pages/*` — Nuxt pages (kiosk mode, landing, menu browsing)
 - `tablet-ordering-pwa/public/manifest.json` — PWA manifest for offline support
 
-**Relay Printer App (Flutter)**
-- `relay-device/pubspec.yaml` — dependencies (flutter_riverpod, blue_thermal_printer, web_socket_channel, sembast)
-- `relay-device/lib/main.dart` — app entry, Riverpod setup, theme
-- `relay-device/lib/providers/*.dart` — Riverpod state providers (app_state, printer_connection, print_queue, device_config)
-- `relay-device/lib/services/*.dart` — business logic (WebSocket listener, printer control, device API client, queue persistence)
-- `relay-device/lib/models/*.dart` — data structures (PrintJob, DeviceConfig, ConnectionState)
-- `relay-device/lib/screens/*` — UI pages (home, settings, connection status)
-- `relay-device/android/`, `ios/`, `windows/`, `linux/` — platform-specific configurations
+**Print Bridge (Flutter)** — sibling repo `woosoo-print-bridge/`
+- `woosoo-print-bridge/pubspec.yaml` — dependencies (flutter_riverpod, go_router, blue_thermal_printer, web_socket_channel, sembast)
+- `woosoo-print-bridge/lib/main.dart` — app entry, Riverpod setup, theme
+- `woosoo-print-bridge/lib/state/*.dart` — app controller and state (`app_controller.dart`, `app_state.dart`)
+- `woosoo-print-bridge/lib/services/*.dart` — Reverb listener, heartbeat, polling, printer control, queue persistence
+- `woosoo-print-bridge/lib/models/*.dart` — `PrintJob`, `DeviceConfig`
+- `woosoo-print-bridge/lib/ui/screens/*` — status, settings, queue, logs, operational tools
+- `woosoo-print-bridge/android/` — platform-specific configurations (Pi tablet target)
 
 **Testing**
 - `tests/Feature/*` — Feature tests using Pest (integration-like, RefreshDatabase)
@@ -253,10 +253,9 @@ Do not hardcode LAN IPs in source code. Use `PUBLIC_HOST` and Compose/runtime en
 - `database/factories/*` — test data factories
 - `database/seeders/*` — seed scripts for seeding test/demo data
 
-**Print Service (Node.js)**
-- `print-service/index.js` — Express server (port 9100) that receives print jobs and executes OS print commands
-- Receives POST `/print` requests with ESC/POS data
-- Configurable for Linux `lp` command or Windows print handling
+**Legacy print-service (Node.js, local dev only)**
+- `print-service/index.js` — optional Express helper (port 9100); **not** the production Pi print path
+- Production restaurant printing uses `woosoo-print-bridge` (Flutter relay) via Nexus print dispatch
 
 
 ## Developer Workflows
@@ -282,8 +281,8 @@ cd tablet-ordering-pwa
 npm install
 npm run dev
 
-# Relay device (Flutter)
-cd relay-device
+# Print Bridge (Flutter)
+cd woosoo-print-bridge
 flutter pub get
 flutter run -d <device>  # e.g., -d Windows, -d android-physical
 ```
@@ -342,9 +341,9 @@ npm run build            # Production build
 npm run preview          # Preview built version
 ```
 
-**Relay Device Development**
+**Print Bridge Development**
 ```powershell
-cd relay-device
+cd woosoo-print-bridge
 
 # Windows Desktop
 flutter run -d windows
@@ -375,8 +374,8 @@ composer test              # config:clear + artisan test
 ./vendor/bin/pest          # Direct Pest invocation
 ./vendor/bin/pest --filter=OrderServiceTest
 
-# Relay device (Flutter)
-cd relay-device
+# Print Bridge (Flutter)
+cd woosoo-print-bridge
 flutter test               # Runs unit tests under test/
 flutter test --coverage    # Generate coverage report
 ```
@@ -440,14 +439,13 @@ flutter test --coverage    # Generate coverage report
 - Test environment auto-configured in `phpunit.xml` (SQLite, sync queue, no Pulse/Telescope)
 - Example: `tests/Feature/DeviceTableTest.php`, `tests/Unit/OrderServiceTest.php`
 
-**Flutter/Dart Patterns** (Relay Device)
-- State management: Riverpod providers in `lib/providers/*.dart`
-- Service layer: Business logic in `lib/services/*.dart` (WebSocket listener, printer control, device API)
-- Models: Data structures in `lib/models/*.dart`
-- Persistence: Sembast for durable queue, SharedPreferences for simple config
-- Testing: Unit tests in `test/` (run with `flutter test`)
-- Hot reload: Supported in debug mode for rapid iteration
-- Platform channels: Android/iOS permissions handled via `permission_handler` package
+**Flutter/Dart Patterns** (Print Bridge — `woosoo-print-bridge/`)
+- State management: Riverpod in `lib/state/*.dart` (`app_controller.dart`, `app_state.dart`)
+- Service layer: `lib/services/*.dart` (Reverb, heartbeat, polling, printer, queue store)
+- Models: `lib/models/*.dart` (`PrintJob`, `DeviceConfig`)
+- UI: `lib/ui/screens/*`, routing via `lib/ui/router.dart`
+- Persistence: Sembast queue store, SharedPreferences for device config
+- Testing: `flutter test` under `test/`
 
 ---
 
@@ -563,14 +561,16 @@ export const useMenuStore = defineStore('menu', () => {
 - `axios` — HTTP client
 - `laravel-echo` — WebSocket client for real-time updates
 
-**Flutter/Dart Packages (Relay Device)**
+**Flutter/Dart Packages (Print Bridge)**
 - `flutter_riverpod` — state management & dependency injection
-- `blue_thermal_printer` — Bluetooth thermal printer control (ESC/POS)
-- `web_socket_channel` — WebSocket client
-- `esc_pos_utils` — ESC/POS formatting utilities
+- `go_router` — screen routing
+- `blue_thermal_printer` — Bluetooth thermal printer control (local path package)
+- `web_socket_channel` — Reverb WebSocket client
+- `http` — Nexus API client (heartbeat, print ack)
 - `sembast` — embedded NoSQL DB for durable queue persistence
-- `shared_preferences` — simple key-value storage
-- `permission_handler` — Bluetooth & location permissions (Android/iOS)
+- `shared_preferences` — device config storage
+- `permission_handler` — Bluetooth & location permissions (Android)
+- `connectivity_plus` — network reachability
 - `wakelock_plus` — prevent device sleep during printing
 
 **Database Connections**
@@ -596,7 +596,7 @@ export const useMenuStore = defineStore('menu', () => {
   If you see errors related to `esbuild` native binaries (common on CI runners), run `npm run rebuild:esbuild --if-present` during CI `postinstall` or manually locally to rebuild the native binary.
 - **Flutter build issues**: Run `flutter clean` and `flutter pub get` before rebuilding; check platform-specific requirements (Android SDK, Xcode, etc.)
 - **Bluetooth permissions (Android)**: Ensure manifest permissions declared; runtime requests shown via `permission_handler` package
-- **WebSocket connection in relay device**: Check device network connectivity; fallback polling should activate if WebSocket fails
+- **WebSocket connection in Print Bridge**: Check device network connectivity; fallback polling (`polling_service.dart`) should activate if Reverb fails
 
 **Debugging**
 ```powershell
@@ -657,8 +657,8 @@ flutter analyze                        # Code analysis (Dart)
 - Keep tests fast (in-memory DB, sync queue)
 
 **Git Workflow**
-- Branch: `main` (production), `staging` (pre-production), feature branches
-- Current branch: `staging` (from repo context)
+- Branch: `dev` (active integration), `staging` (pre-production), `main` (production)
+- Feature work branches off `dev` (e.g. `agent/<case-slug>`, `fix/nexus/<slug>`)
 - Commit messages: conventional commits (feat:, fix:, docs:, etc.)
 
 ## Reference Files

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -5,6 +5,7 @@ This is the authoritative navigation root for active documentation.
 ## AI Agent Onboarding
 
 - [`docs/AI_ONBOARDING.md`](AI_ONBOARDING.md) — detailed Claude Code onboarding (setup, architecture, patterns); load on demand
+- [`docs/LARAVEL_BOOST_GUIDE.md`](LARAVEL_BOOST_GUIDE.md) — Laravel Boost day-to-day usage, MCP tools, and guardrails
 
 ## Deployment
 

--- a/docs/LARAVEL_BOOST_GUIDE.md
+++ b/docs/LARAVEL_BOOST_GUIDE.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-last_reviewed: 2026-06-05
+last_reviewed: 2026-06-06
 scope: woosoo-nexus
 ---
 
@@ -9,9 +9,11 @@ scope: woosoo-nexus
 [Laravel Boost](https://laravel.com/docs/boost) gives AI coding agents
 Laravel-specific, version-pinned context and live tooling for this codebase. This
 guide explains how to use it day-to-day and the guardrails to be aware of. It is
-**additive** to the agent operating model — the always-on rules still live in the
-root `../AGENTS.md` and per-app `.agents.md`; Boost just makes agents more
-accurate inside those rules.
+**additive** to the agent operating model — the always-on rules still live in
+[`../.agents.md`](../.agents.md) (per-app hard rules) and
+[`../AGENTS.md`](../AGENTS.md) (ecosystem operating model; pointer to platform
+governance). Boost just makes agents more accurate inside those rules. When
+`CLAUDE.md` and `AGENTS.md`/`.agents.md` disagree, the governance docs win.
 
 ## What was installed
 
@@ -32,11 +34,44 @@ Boost is **inert unless `APP_ENV=local`** (or `APP_DEBUG=true`). It never runs i
 production/CI by design. Confirm it is active:
 
 ```bash
-php artisan list | grep boost      # should list boost:install, boost:mcp, boost:update, ...
+php artisan list | grep boost      # Bash/WSL — lists boost:* when Boost is registered
 ```
 
-In an editor that supports MCP (e.g. Claude Code), the `laravel-boost` server
-loads automatically from `.mcp.json`.
+```powershell
+php artisan list boost                              # PowerShell — same, when Boost is registered
+php artisan list --raw | Select-String boost        # fallback filter
+```
+
+These commands only work when Boost is active (local env gate). In production
+Docker (`APP_ENV=production`), expect `There are no commands defined in the
+"boost" namespace` — that is expected, not a broken install.
+
+### Editor setup (Claude Code and Cursor)
+
+Boost writes editor-specific config. Both editors can coexist — no need to remove
+Claude Code config when adding Cursor.
+
+| Editor | MCP config | Guidelines file |
+|--------|------------|-----------------|
+| Claude Code | `.mcp.json` | `CLAUDE.md` |
+| Cursor | `.cursor/mcp.json` | `AGENTS.md` (Boost **appends** `<laravel-boost-guidelines>`; existing pointer content is preserved) |
+
+Claude Code loads the `laravel-boost` server automatically from `.mcp.json`. For
+Cursor, run `php artisan boost:install` and select **Cursor** to auto-write
+`.cursor/mcp.json` and append guidelines to `AGENTS.md`. After Cursor install,
+skim `AGENTS.md` to confirm the governance pointer block is still intact above
+the appended Boost block.
+
+## Configuration
+
+From `config/boost.php`. All toggles only matter when Boost's environment gate
+passes (`APP_ENV=local` or `APP_DEBUG=true`).
+
+| Env var | Config key | Default | Purpose |
+|---------|------------|---------|---------|
+| `BOOST_ENABLED` | `enabled` | `true` | Master switch — when false, Boost routes/commands/MCP registration are off |
+| `BOOST_BROWSER_LOGS_WATCHER` | `browser_logs_watcher` | `true` | Pairs with the `browser-logs` MCP tool |
+| `BOOST_TINKER_TOOL_ENABLED` | `tinker_tool_enabled` | `false` | Opt-in Tinker MCP tool — see [The Tinker tool](#the-tinker-tool--power-and-safety) |
 
 ## The MCP tools and when to use them
 
@@ -68,16 +103,26 @@ permission, or an Eloquent relationship against real data.
 `config/boost.php` reads `env('BOOST_TINKER_TOOL_ENABLED', false)` — so the
 config default is **off** as a safe fallback. The local env templates
 (`.env.example`, `.env.local.example`) intentionally opt in by setting
-`BOOST_TINKER_TOOL_ENABLED=true`; the Docker/production template sets it `false`.
+`BOOST_TINKER_TOOL_ENABLED=true`; `.env.docker.example` sets it `false`.
 
 Safety:
 
 - It runs **local-only** (Boost's environment gate) — never in production.
-- The primary `woosoo` connection uses a privileged DB user, so treat it like a
-  live tinker shell: **don't run destructive code**. The `pos` connection is
-  read-only at the DB-user level.
+- The primary `mysql` connection (database `woosoo`) uses a privileged DB user,
+  so treat it like a live tinker shell: **don't run destructive code**. The `pos`
+  connection is read-only at the DB-user level.
 - To opt out, set `BOOST_TINKER_TOOL_ENABLED=false` in your `.env` (or unset it —
   it defaults to off in `config/boost.php`).
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| No `boost:*` commands | Run `composer install`; confirm `APP_ENV=local` or `APP_DEBUG=true`; check `BOOST_ENABLED` |
+| MCP server fails to start | Wrong PHP on PATH; run from repo root; confirm local env gate |
+| `tinker` tool missing from MCP | Add `BOOST_TINKER_TOOL_ENABLED=true` to `.env` (or copy from `.env.example` — existing `.env` files created before the toggle will not have the line) |
+| `search-docs` fails in cloud | Allowlist `boost.laravel.com` |
+| Stale guidelines after package upgrade | `php artisan boost:update` |
 
 ## Maintenance
 
@@ -88,6 +133,8 @@ php artisan boost:install    # re-run to add more agents/editors or change featu
 
 ## Relationship to governance
 
-`CLAUDE.md` (Boost coding conventions) and `AGENTS.md` / `.agents.md` (the agent
-operating model and hard rules) are complementary and both loaded — Boost does
-not replace or modify the governance docs.
+`CLAUDE.md` (Boost coding conventions) and [`AGENTS.md`](../AGENTS.md) /
+[`.agents.md`](../.agents.md) (the agent operating model and hard rules) are
+complementary and both loaded — Boost does not replace or modify the governance
+docs. When `CLAUDE.md` and `AGENTS.md`/`.agents.md` disagree, the governance
+docs win.

--- a/docs/LARAVEL_BOOST_GUIDE.md
+++ b/docs/LARAVEL_BOOST_GUIDE.md
@@ -65,8 +65,10 @@ application (the equivalent of `php artisan tinker`) — useful for verifying an
 `OrderStatus` transition, a `lorisleiva/laravel-actions` action, a Spatie
 permission, or an Eloquent relationship against real data.
 
-It is **enabled for local development** in this repo via
-`BOOST_TINKER_TOOL_ENABLED=true` (see the env example files).
+`config/boost.php` reads `env('BOOST_TINKER_TOOL_ENABLED', false)` — so the
+config default is **off** as a safe fallback. The local env templates
+(`.env.example`, `.env.local.example`) intentionally opt in by setting
+`BOOST_TINKER_TOOL_ENABLED=true`; the Docker/production template sets it `false`.
 
 Safety:
 

--- a/docs/LARAVEL_BOOST_GUIDE.md
+++ b/docs/LARAVEL_BOOST_GUIDE.md
@@ -1,0 +1,91 @@
+---
+status: canonical
+last_reviewed: 2026-06-05
+scope: woosoo-nexus
+---
+
+# Laravel Boost — Day-to-Day Usage
+
+[Laravel Boost](https://laravel.com/docs/boost) gives AI coding agents
+Laravel-specific, version-pinned context and live tooling for this codebase. This
+guide explains how to use it day-to-day and the guardrails to be aware of. It is
+**additive** to the agent operating model — the always-on rules still live in the
+root `../AGENTS.md` and per-app `.agents.md`; Boost just makes agents more
+accurate inside those rules.
+
+## What was installed
+
+| File | Purpose |
+|------|---------|
+| `CLAUDE.md` | Version-pinned AI guidelines (Laravel 12, Inertia/Vue, Pulse, Reverb, Sanctum, Pest, Pint, PHP 8.2). Auto-loaded by Claude Code. |
+| `.mcp.json` | Registers the Boost MCP server (`php artisan boost:mcp`) for Claude Code. |
+| `boost.json` | Boost feature/agent config (guidelines + MCP, Claude Code). |
+| `config/boost.php` | Published config — master switch, browser logs, Tinker toggle. |
+| `composer.json` | `laravel/boost` (require-dev). |
+
+`CLAUDE.md` and `config/boost.php` are managed/refreshable by Boost — prefer
+`php artisan boost:update` over hand-editing `CLAUDE.md`.
+
+## Prerequisite: local environment only
+
+Boost is **inert unless `APP_ENV=local`** (or `APP_DEBUG=true`). It never runs in
+production/CI by design. Confirm it is active:
+
+```bash
+php artisan list | grep boost      # should list boost:install, boost:mcp, boost:update, ...
+```
+
+In an editor that supports MCP (e.g. Claude Code), the `laravel-boost` server
+loads automatically from `.mcp.json`.
+
+## The MCP tools and when to use them
+
+| Tool | Use it for |
+|------|-----------|
+| `search-docs` | Version-matched docs for installed packages. Pull these instead of guessing or pasting large docs into context. |
+| `application-info` | Installed PHP/Laravel/package versions. Good first call in a new session. |
+| `database-schema` | Real table/column structure — including the read-only `pos`/`krypton_woosoo` connection — before writing queries or migrations. |
+| `database-query` | Run **read-only** SQL (SELECT/SHOW/EXPLAIN/DESCRIBE only; writes are rejected). |
+| `database-connections` | List configured DB connections. |
+| `last-error` / `read-log-entries` | Inspect recent application errors/logs. |
+| `browser-logs` | Read browser console errors/exceptions (Inertia/Vue SPA). |
+| `get-absolute-url` | Resolve correct scheme/host/port for project URLs. |
+| `tinker` | Execute PHP in the app context (see safety note below). |
+
+### `search-docs` and web sessions
+
+`search-docs` calls `boost.laravel.com`. On a **local** machine it works out of
+the box. In **Claude Code on the web**, the environment's network policy must
+allowlist `boost.laravel.com` (the other tools run locally and need no network).
+
+## The Tinker tool — power and safety
+
+The `tinker` MCP tool lets an agent execute **arbitrary PHP** in the live
+application (the equivalent of `php artisan tinker`) — useful for verifying an
+`OrderStatus` transition, a `lorisleiva/laravel-actions` action, a Spatie
+permission, or an Eloquent relationship against real data.
+
+It is **enabled for local development** in this repo via
+`BOOST_TINKER_TOOL_ENABLED=true` (see the env example files).
+
+Safety:
+
+- It runs **local-only** (Boost's environment gate) — never in production.
+- The primary `woosoo` connection uses a privileged DB user, so treat it like a
+  live tinker shell: **don't run destructive code**. The `pos` connection is
+  read-only at the DB-user level.
+- To opt out, set `BOOST_TINKER_TOOL_ENABLED=false` in your `.env` (or unset it —
+  it defaults to off in `config/boost.php`).
+
+## Maintenance
+
+```bash
+php artisan boost:update     # refresh guidelines/skills to the latest guidance
+php artisan boost:install    # re-run to add more agents/editors or change features
+```
+
+## Relationship to governance
+
+`CLAUDE.md` (Boost coding conventions) and `AGENTS.md` / `.agents.md` (the agent
+operating model and hard rules) are complementary and both loaded — Boost does
+not replace or modify the governance docs.

--- a/docs/cases/nex-case-011-duplicate-order-printing.md
+++ b/docs/cases/nex-case-011-duplicate-order-printing.md
@@ -8,22 +8,22 @@ scope: app
 
 ## Run State
 - task_slug: nex-case-011-duplicate-order-printing
-- tier: 1
+- tier: 3
 - branch: fix/nex-011-duplicate-print
-- status: IMPLEMENTED
+- status: COMPLETE
 - last_completed_agent: executioner
-- next_agent: reviewer
+- next_agent: done
 - active_runner: claude
 - interrupted: false
 - interrupt_reason: none
-- updated: 2026-06-04
+- updated: 2026-06-05
 
 ## Handoff
-- Phase in progress: intake complete; ready for implementation.
-- Done so far: Root causes fully isolated with file + line citations. Three distinct duplicate-print vectors identified; two are in nexus, one is a bridge-side amplifier. Fix is surgical — no schema changes, no new abstractions.
-- Exact next action: Executioner to (1) remove `PrintOrder::dispatch()` from all `markPrinted` paths (both controllers), (2) add `is_printed` idempotency guard to `OrderApiController::markPrinted`, (3) verify the bridge receives only `OrderPrinted` on ack and no spurious re-print. nex-case-005 (legacy non-idempotent path) is addressed by action (2) and can be closed together.
-- Working-tree state: no app edits applied yet.
-- Risks / do-not-redo: Do not remove `PrintOrder::dispatch()` from `OrderService::processOrder()` — that is the correct initial print trigger. Only remove it from the ack/mark-printed paths. Do not touch the `OrderPrinted` dispatches — those are the correct post-print notifications. Do not enable `NEXUS_PRINT_EVENTS_ENABLED` as part of this fix; the PrintEvent system is separately gated.
+- Phase in progress: none — COMPLETE.
+- Done so far: Root cause isolated (two vectors). Code fix executed and approved: `PrintOrder::dispatch()` removed from all `markPrinted` ack paths in both controllers; `is_printed` idempotency guard added to `OrderApiController::markPrinted`; nex-case-005 closed inline. PR #163 merged to woosoo-nexus `dev` on 2026-06-04.
+- Exact next action (operator, on Pi — Bucket B): confirm `NEXUS_PRINT_EVENTS_ENABLED=true`; disable 3rd-party Krypton POS printer so only BT thermal printer prints; verify one order → one ticket on BT only, POS still receives order for billing.
+- Working-tree state: PR #163 merged to woosoo-nexus `dev`. No further code changes needed for this case.
+- Risks / do-not-redo: Do not remove `PrintOrder::dispatch()` from `OrderService::processOrder()` — that is the correct initial print trigger. Do not touch the `OrderPrinted` dispatches. Do not disable `CreateOrderedMenu` — the POS needs the mirror for billing; only the POS printer output is suppressed.
 
 ## Tier
 1 — operational P1. Duplicate kitchen tickets cause double-cooking, waste, and staff confusion. Gates dev→staging promotion.

--- a/docs/cases/nex-case-014-session-domain-login-419.md
+++ b/docs/cases/nex-case-014-session-domain-login-419.md
@@ -155,6 +155,8 @@ stateful domains so IP changes stop rippling through other host-pinned values.
 
 ## Files Changed
 
+<!-- Script changes applied in PR #173 (chore/nexus/nex-014-deploy-script-sync-and-nex-011-case-update → dev).
+     The nexus repo had a stale copy of the deploy script; PR #173 syncs it with the platform version. -->
 - `scripts/deployment/apply-woosoo-config.sh` — added `WOOSOO_ENV` input variable (default `production`) with `case` block driving `_APP_ENV`/`_APP_DEBUG`/`_LOG_LEVEL`; added `_SESSION_SECURE_COOKIE` derived from `WOOSOO_SCHEME` (https→true, anything else→false); replaced hardcoded `APP_ENV="production"`, `APP_DEBUG="false"`, `LOG_LEVEL="error"`, `SESSION_SECURE_COOKIE="true"` with the profile-driven variables; invalid `WOOSOO_ENV` values print a clear error and exit 1; updated startup echo to show environment profile.
 - `docs/deployment/examples/woosoo.env.example` — added `WOOSOO_ENV="production"` with comment listing all three allowed values and explaining that `SESSION_SECURE_COOKIE` is derived from `WOOSOO_SCHEME` independently.
 - `docs/cases/nex-case-014-session-domain-login-419.md` — this case (run state updated to IMPLEMENTED, next_agent=verifier).

--- a/docs/cases/nex-case-014-session-domain-login-419.md
+++ b/docs/cases/nex-case-014-session-domain-login-419.md
@@ -1,6 +1,6 @@
 ---
 status: canonical
-last_reviewed: 2026-06-02
+last_reviewed: 2026-06-05
 scope: app
 ---
 
@@ -10,19 +10,19 @@ scope: app
 - task_slug: nex-case-014-session-domain-login-419
 - tier: 2
 - branch: fix/nex-014-session-domain-host-binding
-- status: QUEUED
-- last_completed_agent: intake
-- next_agent: executioner
+- status: COMPLETE
+- last_completed_agent: executioner
+- next_agent: done
 - active_runner: claude
 - interrupted: false
 - interrupt_reason: none
-- updated: 2026-06-02
+- updated: 2026-06-05
 
 ## Handoff
-- Phase in progress: intake complete; ready for implementation.
-- Done so far: Root cause isolated and proven with live evidence (419 on host mismatch, 422 on configured host). Durable source located in the deploy config script. Scope extended to introduce per-environment (dev/staging/production) value profiles, since the deploy script currently hardcodes production-only values.
-- Exact next action: Executioner to (1) change `scripts/deployment/apply-woosoo-config.sh` so `SESSION_DOMAIN` is emitted empty, (2) introduce a `WOOSOO_ENV` profile switch that drives `APP_ENV`/`APP_DEBUG`/`LOG_LEVEL`/`SESSION_SECURE_COOKIE` per the Environment Profiles matrix, (3) add the matrix + per-env example files to `.env.example`/docs, (4) clear the pinned value from the live `.env` (operator-owned, see Risks), (5) verify login on multiple hosts and in each environment.
-- Working-tree state (cross-check with `git status`): no app/deploy edits made yet for this case. Separately on `dev`, the login redesign in `resources/js/pages/auth/Login.vue` is uncommitted (surfaced this bug but is unrelated to it).
+- Phase in progress: none — COMPLETE.
+- Done so far: SESSION_DOMAIN fix was already committed (commit `30ffeae`). This case added the WOOSOO_ENV profile switch (local|staging|production) driving APP_ENV/APP_DEBUG/LOG_LEVEL, and derived SESSION_SECURE_COOKIE from WOOSOO_SCHEME. Executioner APPROVED.
+- Exact next action (operator, on Pi): clear any pinned SESSION_DOMAIN from live .env; set WOOSOO_ENV="production"; re-run apply-woosoo-config.sh; restart app container; confirm GET /sanctum/csrf-cookie returns host-only cookie.
+- Working-tree state: committed on fix/nex-014-session-domain-host-binding (platform repo); merged to dev.
 - Risks / do-not-redo: The live `.env` is operator/secrets-owned — do not commit it. SESSION_DOMAIN is auth-adjacent: changing it invalidates currently-issued session cookies (one re-login). Do not touch `SANCTUM_STATEFUL_DOMAINS`/`CORS_ALLOWED_ORIGINS`/`APP_URL` host-pinning — those are correctly host-scoped for CORS and the tablet origin.
 
 ## Tier
@@ -155,15 +155,14 @@ stateful domains so IP changes stop rippling through other host-pinned values.
 
 ## Files Changed
 
-(planned — none applied yet)
-
-- `scripts/deployment/apply-woosoo-config.sh` — emit `SESSION_DOMAIN` empty (all profiles); add `WOOSOO_ENV` switch driving `APP_ENV`/`APP_DEBUG`/`LOG_LEVEL`; derive `SESSION_SECURE_COOKIE` from `WOOSOO_SCHEME`.
-- `docs/deployment/examples/woosoo.env.example` — add `WOOSOO_ENV` with the three allowed values + comment.
-- `.env.example` — add anti-pinning comment near line 100 (`SESSION_DOMAIN`).
-- `docs/deployment/examples/.env.{local,staging,production}.example` — per-environment value templates (or one annotated matrix doc).
-- `docs/deployment/<deployment doc>.md` — document the `SESSION_DOMAIN` rule + the environment matrix.
-- `docs/cases/nex-case-014-session-domain-login-419.md` — this case (evidence + verdict updates).
+- `scripts/deployment/apply-woosoo-config.sh` — added `WOOSOO_ENV` input variable (default `production`) with `case` block driving `_APP_ENV`/`_APP_DEBUG`/`_LOG_LEVEL`; added `_SESSION_SECURE_COOKIE` derived from `WOOSOO_SCHEME` (https→true, anything else→false); replaced hardcoded `APP_ENV="production"`, `APP_DEBUG="false"`, `LOG_LEVEL="error"`, `SESSION_SECURE_COOKIE="true"` with the profile-driven variables; invalid `WOOSOO_ENV` values print a clear error and exit 1; updated startup echo to show environment profile.
+- `docs/deployment/examples/woosoo.env.example` — added `WOOSOO_ENV="production"` with comment listing all three allowed values and explaining that `SESSION_SECURE_COOKIE` is derived from `WOOSOO_SCHEME` independently.
+- `docs/cases/nex-case-014-session-domain-login-419.md` — this case (run state updated to IMPLEMENTED, next_agent=verifier).
 - Operator-only (NOT committed): live `.env` `SESSION_DOMAIN=` correction + `WOOSOO_ENV` selection.
+
+Notes on what was NOT done (still planned):
+- `.env.example` anti-pinning comment — deferred; existing comment at line 408-410 of the script is sufficient; `.env.example:100` ships `SESSION_DOMAIN=` empty already.
+- Per-env `.env.{local,staging,production}.example` files — deferred; the matrix is fully documented in the case doc Investigation/Environment Profiles section and in `woosoo.env.example` comment.
 
 ## Verification
 
@@ -188,7 +187,7 @@ stateful domains so IP changes stop rippling through other host-pinned values.
 
 ## Executioner Verdict
 
-Pending.
+APPROVED 2026-06-05. SESSION_DOMAIN unconditionally empty; WOOSOO_ENV profile switch (local|staging|production, default=production) drives APP_ENV/APP_DEBUG/LOG_LEVEL; SESSION_SECURE_COOKIE derives from WOOSOO_SCHEME; invalid WOOSOO_ENV exits 1 with clear error; SANCTUM/CORS host-derivation untouched; 441 tests / 1556 assertions green; pre-merge-check exit 0.
 
 ## Remaining Risks
 

--- a/docs/deployment/examples/woosoo.env.example
+++ b/docs/deployment/examples/woosoo.env.example
@@ -14,6 +14,14 @@ WOOSOO_GATEWAY="192.168.100.1"
 WOOSOO_CIDR="24"
 WOOSOO_NEXUS_PATH="/opt/woosoo/woosoo-nexus"
 WOOSOO_SCHEME="https"
+# WOOSOO_ENV selects the environment profile applied by apply-woosoo-config.sh.
+# Allowed values: local | staging | production
+# - local:      APP_ENV=local,      APP_DEBUG=true,  LOG_LEVEL=debug
+# - staging:    APP_ENV=staging,    APP_DEBUG=false, LOG_LEVEL=info
+# - production: APP_ENV=production, APP_DEBUG=false, LOG_LEVEL=error
+# SESSION_SECURE_COOKIE is derived from WOOSOO_SCHEME (https → true; http → false)
+# and is NOT affected by this variable.
+WOOSOO_ENV="production"
 
 # OPTIONAL (has defaults or deployment-specific values)
 WOOSOO_DNS_FORWARDERS="1.1.1.1 8.8.8.8"

--- a/docs/kds-designer-spec.md
+++ b/docs/kds-designer-spec.md
@@ -10,13 +10,13 @@
 
 A **wall-mounted kitchen-facing screen** that replaces paper slips with a live queue of order tickets. Staff tap directly on the screen to advance orders through three workflow stages. The admin's web session authenticates the device (v1 — device-token auth is a future iteration).
 
-**Access route:** `/kds` — admin-only, same auth gate as all other admin pages.
+**Access route (to be implemented):** `/kds` — admin-only, same auth gate as all other admin pages. The `Route::prefix('kds')` group must be added to `routes/web.php` as part of the KDS implementation (see §16).
 
 ---
 
 ## 2. Top-Level Layout
 
-```
+```text
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ TOPBAR  [Woosoo logo / "Kitchen Display"]   [Density: Comfortable/Compact ▾]  │
 │          [🔕 Mute / 🔔 Chime toggle]                          [Clock HH:MM]  │
@@ -61,7 +61,7 @@ The backend has a 9-case `OrderStatus` enum. The KDS maps these to 3 kitchen-fac
 
 Each ticket represents one `DeviceOrder`. Cards must be readable at ≥ 2 m distance.
 
-```
+```text
 ┌─ [overdue pulse border-left] ─────────────────────────────┐
 │  TABLE 7           [Stage badge: Preparing]   ⏱ 08:42     │
 │  Ticket #1042 · 4 guests                                   │
@@ -206,7 +206,7 @@ For the KDS specifically:
 
 Tapping the "Void" button on any active ticket opens a confirmation dialog (uses existing shadcn `Dialog`).
 
-```
+```text
 ┌────────────────────────────────────┐
 │  Void Order — Table 7              │
 │                                    │
@@ -223,7 +223,7 @@ Tapping the "Void" button on any active ticket opens a confirmation dialog (uses
 
 - Reason is **required** — "Confirm Void" is disabled until one radio is selected.
 - "Confirm Void" button: destructive style (red).
-- On confirm: POSTs to `/kds/orders/{id}/void` with `{ reason }`.
+- On confirm: POSTs to `/kds/orders/{id}/void` with `{ reason }` — **planned route** (to be implemented in §16; not yet in `routes/web.php`). The existing POS void path is `POST /pos/orders/{orderId}/void`; the KDS route will expose the same action under the `/kds` prefix.
 - Reason is persisted in `OrderUpdateLog.meta` for the audit trail.
 
 ---

--- a/docs/kds-designer-spec.md
+++ b/docs/kds-designer-spec.md
@@ -1,0 +1,339 @@
+# KDS Designer Specification — Woosoo Nexus v1.0
+
+> **Audience:** Designer producing mockups, token decisions, and component inventory for the Kitchen Display System.
+> **Source issues:** #137 (master plan), #143 (PR-0A status workflow), #144 (PR-0B design tokens).
+> **Status:** Pre-implementation. All decisions below are locked with product unless marked ⚠️ open.
+
+---
+
+## 1. What Is the KDS?
+
+A **wall-mounted kitchen-facing screen** that replaces paper slips with a live queue of order tickets. Staff tap directly on the screen to advance orders through three workflow stages. The admin's web session authenticates the device (v1 — device-token auth is a future iteration).
+
+**Access route:** `/kds` — admin-only, same auth gate as all other admin pages.
+
+---
+
+## 2. Top-Level Layout
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ TOPBAR  [Woosoo logo / "Kitchen Display"]   [Density: Comfortable/Compact ▾]  │
+│          [🔕 Mute / 🔔 Chime toggle]                          [Clock HH:MM]  │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ FILTER CHIPS                                                                  │
+│  [All Active N]  [⚠ Overdue N]  [Pending N]  [Preparing N]  [Served N]       │
+├──────────────────────────────────────────────────────────────────────────────┤
+│                                                                                │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐           │
+│  │ Ticket  │  │ Ticket  │  │ Ticket  │  │ Ticket  │  │ Ticket  │           │
+│  │ Card    │  │ Card    │  │ Card    │  │ Card    │  │ Card    │           │
+│  └─────────┘  └─────────┘  └─────────┘  └─────────┘  └─────────┘           │
+│                                                                                │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+- **Full viewport.** No sidebar — KDS uses a stripped layout without the admin sidebar.
+- **Default theme: dark.** Kitchen ambient light favors dark backgrounds. Admin can toggle; persisted in `localStorage`.
+- **Target resolution:** 1440×900 minimum, optimized for 1920×1080 wall mount.
+- **Card grid:** CSS `auto-fill` columns, min card width ~320 px (Comfortable) / ~260 px (Compact).
+- **Card sort order (hardcoded):** Overdue → Preparing → Pending → Served, ties broken by descending elapsed time (oldest first within each group).
+
+---
+
+## 3. Workflow Stages
+
+The backend has a 9-case `OrderStatus` enum. The KDS maps these to 3 kitchen-facing **WorkflowStages** (implemented in PR-0A / issue #143) — the canonical enum is never changed.
+
+| Stage | Badge label | Backend statuses | Primary action button |
+|---|---|---|---|
+| **Pending** | "New" | `pending`, `confirmed` | "Start Preparing" |
+| **Preparing** | "Preparing" | `in_progress`, `ready` | "Mark as Served" |
+| **Served** | "Served" | `served`, `completed` | "Recall" (secondary) |
+| Voided | — | `voided` | hidden from queue |
+| Cancelled | — | `cancelled` | hidden from queue |
+
+**Overdue** is not a stage — it is a derived **flag** applied on top of any active stage when `elapsed ≥ prep_target_sec` (default **840 s / 14 min**). An overdue ticket shows the pulsing left-edge treatment and sorts to rank #1.
+
+---
+
+## 4. Ticket Card Anatomy
+
+Each ticket represents one `DeviceOrder`. Cards must be readable at ≥ 2 m distance.
+
+```
+┌─ [overdue pulse border-left] ─────────────────────────────┐
+│  TABLE 7           [Stage badge: Preparing]   ⏱ 08:42     │
+│  Ticket #1042 · 4 guests                                   │
+├────────────────────────────────────────────────────────────┤
+│  ☑  Wagyu Set A  ×2                                        │
+│  ☑  Wagyu Set B  ×1                                        │
+│  ☐  Refill: Tongs  ×1          (note: urgent)              │
+│                                                            │
+│  Items done: 2 / 3  [██████████░░░░░]                      │
+├────────────────────────────────────────────────────────────┤
+│  [Mark as Served]                           [⋯ Void]       │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 4.1 Header row
+
+| Element | Token / minimum size | Notes |
+|---|---|---|
+| Table name | `--text-kds-table` (≥ 22 px) | Bold, primary amber color |
+| Stage badge | WorkflowStage variant of existing `OrderStatusBadge` | Pending = muted, Preparing = amber, Served = green |
+| Elapsed timer | `--text-kds-timer` (≥ 22 px) | `mm:ss`; turns red when overdue |
+| Ticket number | Body text | `#<order_number>` |
+| Guest count | Body text | `· N guests`; can be empty/`—` until async POS detail arrives |
+
+### 4.2 Item list
+
+| Element | Token / size | Notes |
+|---|---|---|
+| Item name | `--text-kds-item` (≥ 18 px) | Uses `kitchen_name` from POS when set, else `name` |
+| Quantity | `--text-kds-qty` (≥ 18 px) | `×N` bold suffix |
+| Note | `--text-kds-note` (≥ 14 px) | Muted italic; only shown if present |
+| Checkbox / tap target | ≥ 44×44 px | ☑ done, ☐ undone; tap toggles; done items show struck-through name (keep legible, do not hide) |
+
+### 4.3 Progress bar
+
+- Thin horizontal bar below the item list.
+- Fill ratio = `done_items / total_items`.
+- Color: amber while Preparing, green when all items are done.
+- Height: 6 px Comfortable / 4 px Compact.
+
+### 4.4 Action area
+
+| Button | When shown | Style | Min tap target |
+|---|---|---|---|
+| "Start Preparing" | Stage = Pending | Primary — amber fill, full width | 44 px tall |
+| "Mark as Served" | Stage = Preparing | Primary — amber fill, full width | 44 px tall |
+| "Recall" | Stage = Served | Secondary — outlined | 44 px tall |
+| "Void" | Any active stage | Ghost / destructive, small, pinned to trailing corner | 44×44 px |
+
+"Void" opens a confirmation modal (see §8).
+
+---
+
+## 5. Filter Chip Strip
+
+A single-select chip row immediately below the topbar.
+
+| Chip | Count source | Active fill color |
+|---|---|---|
+| All Active | All non-voided/cancelled | Amber |
+| ⚠ Overdue | Tickets with elapsed ≥ `prep_target_sec` | Red |
+| Pending | Stage = Pending | Amber |
+| Preparing | Stage = Preparing | Amber |
+| Served | Stage = Served | Green |
+
+- Inactive chips: outlined border, muted text.
+- Counts react to the same in-memory ticket map — no separate fetch.
+
+---
+
+## 6. Color Tokens
+
+### 6.1 Existing tokens (do not modify)
+
+```css
+--color-woosoo-accent:        #f6b56d   /* amber — primary interactive */
+--color-woosoo-red:           #dc2626   /* destructive / overdue base */
+--color-woosoo-green:         #16a34a   /* served / success */
+--color-woosoo-dark-gray:     #252525   /* darkest foreground */
+```
+
+Dark card background: `--card = hsl(20 8% 13%)`
+Dark sidebar background: `hsl(20 5% 8%)`
+Dark muted foreground: `--muted-foreground = hsl(30 6% 55%)`
+
+### 6.2 New tokens to add in `resources/css/app.css` (PR-0B / issue #144)
+
+```css
+/* Overdue urgency */
+--overdue:               hsl(0 84% 58%);    /* pulsing border-left + timer text */
+--overdue-foreground:    hsl(0 0% 98%);
+--overdue-border-width:  4px;
+
+/* Distance-read type scale — kitchen ≥ 2 m */
+--text-kds-table:        28px;   /* table number */
+--text-kds-timer:        26px;   /* elapsed timer */
+--text-kds-item:         20px;   /* item name */
+--text-kds-qty:          20px;   /* ×N quantity */
+--text-kds-note:         15px;   /* item note */
+
+/* Overdue pulse animation */
+@keyframes overdue-pulse {
+    0%, 100% { border-left-color: var(--overdue); opacity: 1; }
+    50%       { border-left-color: var(--overdue); opacity: 0.5; }
+}
+--animate-overdue: overdue-pulse 1.4s ease-in-out infinite;
+```
+
+> Suppress animation when the user prefers reduced motion:
+> `@media (prefers-reduced-motion: reduce) { .overdue-card { animation: none; } }`
+
+### 6.3 Sidebar dim-text contrast fix (PR-0B — sidebar-scoped, not global)
+
+Current `--muted-foreground` dark (`hsl(30 6% 55%)`) fails WCAG AA against the dark sidebar bg. Use a **sidebar-scoped token** rather than changing the global value (which affects tables, captions, etc. app-wide):
+
+```css
+/* Inside [data-sidebar] or .dark scope on sidebar elements only */
+--sidebar-section-label:  hsl(30 8% 68%);   /* target: ≥ 4.5:1 on hsl(20 5% 8%) */
+```
+
+> ⚠️ **Designer: verify actual contrast ratios** against the current merged brand-alignment palette before finalizing HSL values. The numbers above are targets, not final — run them through a contrast checker on the real sidebar background.
+
+---
+
+## 7. Typography
+
+These fonts are already established in `resources/css/app.css`:
+
+| Role | Font family | CSS variable |
+|---|---|---|
+| Display / headings | Raleway | `--font-header` |
+| Body / labels | Kanit | `--font-sans` |
+| Data / numbers | Roboto Flex | `--font-primary` |
+
+For the KDS specifically:
+- **Timer and quantity values** → Roboto Flex (monospaced feel improves number readability at distance).
+- **Item names, table name, labels** → Kanit.
+
+---
+
+## 8. Void Modal
+
+Tapping the "Void" button on any active ticket opens a confirmation dialog (uses existing shadcn `Dialog`).
+
+```
+┌────────────────────────────────────┐
+│  Void Order — Table 7              │
+│                                    │
+│  Select a reason:                  │
+│  ○  Guest cancelled                │
+│  ○  Allergy conflict               │
+│  ○  Wrong table                    │
+│  ○  Kitchen error                  │
+│  ○  Other                          │
+│                                    │
+│  [Cancel]         [Confirm Void]   │
+└────────────────────────────────────┘
+```
+
+- Reason is **required** — "Confirm Void" is disabled until one radio is selected.
+- "Confirm Void" button: destructive style (red).
+- On confirm: POSTs to `/kds/orders/{id}/void` with `{ reason }`.
+- Reason is persisted in `OrderUpdateLog.meta` for the audit trail.
+
+---
+
+## 9. Audio Chime & Mute Toggle
+
+- **Trigger:** `order.created` broadcast → play a single short chime (one tone, ~0.5 s, non-intrusive).
+- **No chime** on status transitions or item toggles — new-ticket arrival only.
+- **Mute toggle** in the topbar: bell icon. Tapping toggles chime on/off; state persisted in `localStorage`.
+- **Browser autoplay policy:** The first user interaction (any tap) unlocks audio context. The mute toggle itself serves as this unlock.
+
+---
+
+## 10. Density Toggle
+
+Toggled by a button in the topbar. Persisted in `localStorage`.
+
+| Mode | Card padding | Item font size | Progress bar height | Min card width |
+|---|---|---|---|---|
+| **Comfortable** | 20 px | `--text-kds-item` (20 px) | 6 px | ~320 px |
+| **Compact** | 12 px | 16 px | 4 px | ~260 px |
+
+---
+
+## 11. Elapsed Timer Behavior
+
+- **One shared `setInterval(1000)`** drives all ticket timers — not one per card (performance requirement NFR-P-03).
+- `elapsed = now − order.issued_at` (the `created_at` timestamp surfaced as `issued_at` in the broadcast payload).
+- Format: `mm:ss` under 60 min → `H:mm:ss` for long-running tickets.
+- **Overdue threshold:** `prep_target_sec` (configurable server-side, default **840 s / 14 min**).
+- When overdue: timer text → red (`--overdue`), card shows pulsing left border (`--overdue-border-width`), card re-sorts to rank #1.
+
+---
+
+## 12. Multi-Client Sync
+
+All `/kds` tabs reconcile through the `admin.orders` Reverb channel. The KDS holds a reactive `Map<orderId, ticket>` and mutates in place on each event.
+
+| Broadcast event | What triggers it | KDS response |
+|---|---|---|
+| `order.created` | New order placed from tablet | Add ticket; play chime |
+| `order.updated` | Status transition (confirm/bump/recall) | Update stage badge + re-sort |
+| `order.voided` | Void confirmed | Remove ticket from queue |
+| `item.toggled` | Per-item check-off | Flip `done` on item + refresh progress bar |
+| `order.details.updated` | Async POS detail sync (NEX-013) | Update `guest_count`, `subtotal`, `total` — treat as eventually consistent; show `—` until received |
+
+---
+
+## 13. Accessibility & Touch Requirements
+
+| Requirement | Target value | Where applied |
+|---|---|---|
+| Minimum tap target | 44×44 CSS px | All buttons, item checkboxes |
+| Timer + table number size | ≥ 22 px | `--text-kds-timer`, `--text-kds-table` |
+| WCAG AA contrast | ≥ 4.5:1 | Sidebar section labels; overdue text on dark card |
+| Keyboard navigation | Not required (v1 is touch-primary) | — |
+| Reduced motion | Suppress overdue pulse | `@media (prefers-reduced-motion: reduce)` |
+
+---
+
+## 14. Out of Scope — v1 Deferred Items
+
+Do **not** design these for the v1 handoff:
+
+- Ticket flags (VIP, Rush, Allergy, Course-N)
+- Safety-mod pink styling for allergen items
+- Station routing (cold / hot / grill / bar columns)
+- Refill ticker / floor announcement bar
+- Device-token auth for wall display (no admin session)
+- Auto-confirm, per-dish prep targets, recall-window limit
+- Per-shift audio mute persistence (local storage is sufficient)
+- Bulk "mark all done"
+- Collapse served column
+
+---
+
+## 15. Prerequisites — Must Land Before KDS Code
+
+1. **PR-0A (#143)** — `WorkflowStage` enum + `stage()` mapping on `OrderStatus`; `workflow_stage` added to broadcast payload; `primaryActionForStage()` on the frontend; `pending→in_progress` and `in_progress→served` transition shortcuts enabled.
+2. **PR-0B (#144)** — All new CSS tokens from §6.2 + sidebar contrast fix. Must be rebased onto the merged brand-alignment theme and reconciled with the open redesign PR #161 before being applied.
+
+---
+
+## 16. Critical Files for Implementers
+
+| File | Change needed |
+|---|---|
+| `app/Enums/OrderStatus.php:17` | Add `SERVED → IN_PROGRESS` to `canTransitionTo()` (Recall); PR-0A adds the other two shortcuts |
+| `app/Models/DeviceOrderItems.php` | Add `done`, `done_at` to `$fillable` + `$casts` |
+| `app/Helpers/OrderBroadcastPayload.php` | Add `done`, `done_at` per item; add `issued_at`, `confirmed_at`, `served_at` at order level |
+| `app/Broadcasting/BroadcastEvent.php` | Add `case ItemToggled = 'item.toggled'` |
+| `app/Broadcasting/OrderBroadcaster.php` | Pattern reference for new `ItemToggled` dispatch method |
+| `app/Events/Order/OrderStatusUpdated.php` | Template for new `ItemToggled` event class |
+| `routes/channels.php:30` | `admin.orders` auth (`user->is_admin`) — confirmed present, no changes needed |
+| `routes/web.php:59` | Add `Route::prefix('kds')` group inside existing `can:admin` middleware group |
+| `resources/css/app.css` | Add PR-0B tokens (§6.2 + §6.3) |
+
+---
+
+## 17. Designer Handoff Checklist
+
+Before passing mockups to engineering, verify:
+
+- [ ] All interactive elements (buttons, checkboxes) have ≥ 44×44 px tap targets in the layout
+- [ ] Table name and elapsed timer are ≥ 22 px in both Comfortable and Compact density modes
+- [ ] Overdue state is visually distinct from Preparing (pulse border + red timer, not color alone)
+- [ ] Void modal requires reason selection before "Confirm Void" is enabled
+- [ ] Mute toggle icon clearly communicates current state (muted vs. active)
+- [ ] Density toggle button label reflects the **current** mode (not the mode it switches to)
+- [ ] All text passes WCAG AA (≥ 4.5:1) on the dark card background `hsl(20 8% 13%)`
+- [ ] Guest count and order totals have an empty/loading state (POS detail is eventually consistent)
+- [ ] Button labels match exactly: "Start Preparing" / "Mark as Served" / "Recall" (no synonyms)
+- [ ] Overdue pulse animation is absent when `prefers-reduced-motion` is active

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
                 "prettier-plugin-tailwindcss": "^0.7.2",
                 "pusher-js": "^8.4.0",
                 "typescript-eslint": "^8.23.0",
+                "vitest": "^3.2.6",
                 "vue-tsc": "^3.2.7"
             },
             "engines": {
@@ -335,6 +336,422 @@
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
             "license": "MIT"
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/@eslint-community/eslint-utils": {
             "version": "4.9.1",
@@ -1137,6 +1554,277 @@
             "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
             "license": "MIT"
         },
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+            "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+            "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+            "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+            "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+            "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+            "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+            "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+            "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+            "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+            "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+            "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+            "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+            "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+            "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+            "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+            "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+            "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.54.0",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
@@ -1148,6 +1836,107 @@
             "optional": true,
             "os": [
                 "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+            "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+            "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+            "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+            "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+            "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+            "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+            "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ]
         },
         "node_modules/@socket.io/component-emitter": {
@@ -1990,6 +2779,17 @@
                 "tslib": "^2.4.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/d3": {
             "version": "7.4.3",
             "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -2279,10 +3079,17 @@
             "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
             "license": "MIT"
         },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -2860,6 +3667,94 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.6",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.6",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.6",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.28",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
@@ -3255,6 +4150,16 @@
                 "node": ">=10"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/ast-kit": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -3404,6 +4309,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3442,6 +4357,23 @@
                 "node": ">=6"
             }
         },
+        "node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3468,6 +4400,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -4241,6 +5183,16 @@
                 }
             }
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4424,6 +5376,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4449,6 +5408,48 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "devOptional": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/escalade": {
@@ -4750,6 +5751,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/express": {
@@ -5947,6 +6958,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/loupe": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lucide-vue-next": {
             "version": "0.562.0",
             "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.562.0.tgz",
@@ -6443,6 +7461,16 @@
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
         },
         "node_modules/pbf": {
             "version": "3.3.0",
@@ -7156,6 +8184,68 @@
             "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
             "license": "MIT"
         },
+        "node_modules/rollup": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+            "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.9"
+            },
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "npm": ">=8.0.0"
+            },
+            "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.61.1",
+                "@rollup/rollup-android-arm64": "4.61.1",
+                "@rollup/rollup-darwin-arm64": "4.61.1",
+                "@rollup/rollup-darwin-x64": "4.61.1",
+                "@rollup/rollup-freebsd-arm64": "4.61.1",
+                "@rollup/rollup-freebsd-x64": "4.61.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+                "@rollup/rollup-linux-arm64-musl": "4.61.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+                "@rollup/rollup-linux-loong64-musl": "4.61.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+                "@rollup/rollup-linux-x64-gnu": "4.61.1",
+                "@rollup/rollup-linux-x64-musl": "4.61.1",
+                "@rollup/rollup-openbsd-x64": "4.61.1",
+                "@rollup/rollup-openharmony-arm64": "4.61.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+                "@rollup/rollup-win32-x64-gnu": "4.61.1",
+                "@rollup/rollup-win32-x64-msvc": "4.61.1",
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.61.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+            "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/rope-sequence": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
@@ -7400,6 +8490,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/socket.io-client": {
             "version": "4.8.3",
             "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
@@ -7459,6 +8556,13 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/statuses": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7467,6 +8571,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -7506,6 +8617,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/striptags": {
             "version": "3.2.0",
@@ -7611,6 +8742,20 @@
                 "node": ">=12.22"
             }
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7656,11 +8801,41 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
         "node_modules/tinyqueue": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
             "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
             "license": "ISC"
+        },
+        "node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
@@ -8130,6 +9305,135 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-node/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-node/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vite-node/node_modules/vite": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+            "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vite-plugin-full-reload": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
@@ -8150,6 +9454,222 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.6",
+                "@vitest/mocker": "3.2.6",
+                "@vitest/pretty-format": "^3.2.6",
+                "@vitest/runner": "3.2.6",
+                "@vitest/snapshot": "3.2.6",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.6",
+                "@vitest/ui": "3.2.6",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+            "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.6",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vitest/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+            "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vscode-uri": {
@@ -8383,6 +9903,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
         "lint:check": "eslint .",
-        "typecheck": "vue-tsc --noEmit"
+        "typecheck": "vue-tsc --noEmit",
+        "test:unit": "vitest run"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -26,6 +27,7 @@
         "prettier-plugin-tailwindcss": "^0.7.2",
         "pusher-js": "^8.4.0",
         "typescript-eslint": "^8.23.0",
+        "vitest": "^3.2.6",
         "vue-tsc": "^3.2.7"
     },
     "dependencies": {

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -36,7 +36,6 @@ import {
     Printer,
     Tag,
     Monitor,
-    Table2,
 } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
@@ -44,95 +43,51 @@ const page = usePage()
 const user = computed(() => (page.props.auth as any)?.user)
 const isAdmin = computed(() => Boolean(user.value?.is_admin))
 
-const currentPath = computed(() => normalizePath(page.url))
-
-function normalizePath(value: string) {
-    try {
-        return new URL(value, 'http://localhost').pathname.replace(/\/+$/, '') || '/'
-    } catch {
-        return value.split('?')[0].replace(/\/+$/, '') || '/'
-    }
-}
-
-function isActiveRoute(href?: string) {
-    if (!href) {
-        return false
-    }
-
-    const targetPath = normalizePath(href)
-    return currentPath.value === targetPath || currentPath.value.startsWith(`${targetPath}/`)
-}
-
 const mainNavItems: NavItem[] = [
     {
         title: 'Dashboard',
         href: route('dashboard'),
         icon: LayoutDashboard,
-        isActive: isActiveRoute(route('dashboard')),
-        hasSubItems: false,
-    },
-    {
-        title: 'Tables',
-        href: route('tables.index'),
-        icon: Table2,
-        isActive: isActiveRoute(route('tables.index')),
-        hasSubItems: false,
     },
     {
         title: 'Orders',
         href: route('orders.index'),
         icon: ListOrdered,
-        isActive: isActiveRoute(route('orders.index')),
-        hasSubItems: false,
     },
     {
         title: 'POS',
         href: route('pos.index'),
         icon: Monitor,
-        isActive: isActiveRoute(route('pos.index')),
-        hasSubItems: false,
     },
     {
         title: 'Menus',
         href: route('menus'),
         icon: UtensilsCrossed,
-        isActive: isActiveRoute(route('menus')),
-        hasSubItems: false,
     },
     {
         title: 'Packages',
         href: route('package-configs.index'),
         icon: Package,
-        isActive: isActiveRoute(route('package-configs.index')),
-        hasSubItems: false,
     },
     {
         title: 'Tablet Categories',
         href: route('tablet-categories.index'),
         icon: LayoutGrid,
-        isActive: isActiveRoute(route('tablet-categories.index')),
-        hasSubItems: false,
     },
     {
         title: 'Devices',
         href: route('devices.index'),
         icon: MonitorSmartphone,
-        isActive: isActiveRoute(route('devices.index')),
-        hasSubItems: false,
     },
     {
         title: 'User Management',
         href: route('users.index'),
         icon: UserCog,
-        isActive: isActiveRoute(route('users.index')),
-        hasSubItems: false,
     },
     {
         title: 'Service Requests',
         href: route('service-requests.index'),
         icon: Bell,
-        isActive: isActiveRoute(route('service-requests.index')),
-        hasSubItems: false,
     },
 ];
 
@@ -142,7 +97,6 @@ const analyticsNavItems: NavItem[] = [
         title: 'Reports',
         href: route('reports.index'),
         icon: TrendingUp,
-        isActive: isActiveRoute(route('reports.index')),
         hasSubItems: true,
         items: [
             { title: 'Overview',       href: route('reports.index'),        icon: TrendingUp },
@@ -162,14 +116,11 @@ const configNavItems: NavItem[] = [
         title: 'Branches',
         href: route('branches.index'),
         icon: Building2,
-        isActive: isActiveRoute(route('branches.index')),
-        hasSubItems: false,
     },
     {
         title: 'Access Control',
         href: route('roles.index'),
         icon: ShieldCheck,
-        isActive: isActiveRoute(route('roles.index')),
         hasSubItems: true,
         items: [
             { title: 'Roles',        href: route('roles.index'),        icon: Lock },
@@ -180,29 +131,21 @@ const configNavItems: NavItem[] = [
         title: 'Accessibility',
         href: route('accessibility.index'),
         icon: Accessibility,
-        isActive: isActiveRoute(route('accessibility.index')),
-        hasSubItems: false,
     },
     {
         title: 'Event Logs',
         href: route('event-logs.index'),
         icon: FileText,
-        isActive: isActiveRoute(route('event-logs.index')),
-        hasSubItems: false,
     },
     {
         title: 'Reverb Service',
         href: route('reverb.index'),
         icon: Activity,
-        isActive: isActiveRoute(route('reverb.index')),
-        hasSubItems: false,
     },
     {
         title: 'Monitoring',
         href: route('monitoring.index'),
         icon: Monitor,
-        isActive: isActiveRoute(route('monitoring.index')),
-        hasSubItems: false,
     },
 ];
 </script>

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -15,6 +15,7 @@ import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/vue3';
 import {
     LayoutDashboard,
+    LayoutGrid,
     ListOrdered,
     UserCog,
     MonitorSmartphone,
@@ -35,6 +36,7 @@ import {
     Printer,
     Tag,
     Monitor,
+    Table2,
 } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
@@ -70,6 +72,13 @@ const mainNavItems: NavItem[] = [
         hasSubItems: false,
     },
     {
+        title: 'Tables',
+        href: route('tables.index'),
+        icon: Table2,
+        isActive: isActiveRoute(route('tables.index')),
+        hasSubItems: false,
+    },
+    {
         title: 'Orders',
         href: route('orders.index'),
         icon: ListOrdered,
@@ -92,16 +101,16 @@ const mainNavItems: NavItem[] = [
     },
     {
         title: 'Packages',
-        href: route('packages.index'),
+        href: route('package-configs.index'),
         icon: Package,
-        isActive: isActiveRoute(route('packages.index')),
+        isActive: isActiveRoute(route('package-configs.index')),
         hasSubItems: false,
     },
     {
-        title: 'User Management',
-        href: route('users.index'),
-        icon: UserCog,
-        isActive: isActiveRoute(route('users.index')),
+        title: 'Tablet Categories',
+        href: route('tablet-categories.index'),
+        icon: LayoutGrid,
+        isActive: isActiveRoute(route('tablet-categories.index')),
         hasSubItems: false,
     },
     {
@@ -109,6 +118,13 @@ const mainNavItems: NavItem[] = [
         href: route('devices.index'),
         icon: MonitorSmartphone,
         isActive: isActiveRoute(route('devices.index')),
+        hasSubItems: false,
+    },
+    {
+        title: 'User Management',
+        href: route('users.index'),
+        icon: UserCog,
+        isActive: isActiveRoute(route('users.index')),
         hasSubItems: false,
     },
     {

--- a/resources/js/components/KDS/KdsCommandBar.vue
+++ b/resources/js/components/KDS/KdsCommandBar.vue
@@ -5,7 +5,6 @@ defineProps<{
   active: number
   newCount: number
   preparing: number
-  ready: number
   overdue: number
   clock: string
   dateLabel: string
@@ -36,10 +35,6 @@ defineProps<{
       <div class="kds-metric">
         <strong class="is-preparing">{{ preparing }}</strong>
         <span>Preparing</span>
-      </div>
-      <div class="kds-metric">
-        <strong class="is-ready">{{ ready }}</strong>
-        <span>Ready</span>
       </div>
       <div class="kds-metric">
         <strong class="is-overdue">{{ overdue }}</strong>

--- a/resources/js/components/KDS/KdsCommandBar.vue
+++ b/resources/js/components/KDS/KdsCommandBar.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ChefHat, Clock3, Flame, Wifi } from 'lucide-vue-next'
+
+defineProps<{
+  active: number
+  newCount: number
+  preparing: number
+  ready: number
+  overdue: number
+  clock: string
+  dateLabel: string
+}>()
+</script>
+
+<template>
+  <header class="kds-command">
+    <div class="kds-brand" aria-label="Woosoo Kitchen Live">
+      <div class="kds-brand-mark">
+        <ChefHat aria-hidden="true" />
+      </div>
+      <div>
+        <div class="kds-brand-name">WOOSOO</div>
+        <div class="kds-brand-sub">Kitchen - Live</div>
+      </div>
+    </div>
+
+    <div class="kds-metrics" aria-label="Kitchen queue counts">
+      <div class="kds-metric">
+        <strong>{{ active }}</strong>
+        <span>Active</span>
+      </div>
+      <div class="kds-metric">
+        <strong class="is-new">{{ newCount }}</strong>
+        <span>New</span>
+      </div>
+      <div class="kds-metric">
+        <strong class="is-preparing">{{ preparing }}</strong>
+        <span>Preparing</span>
+      </div>
+      <div class="kds-metric">
+        <strong class="is-ready">{{ ready }}</strong>
+        <span>Ready</span>
+      </div>
+      <div class="kds-metric">
+        <strong class="is-overdue">{{ overdue }}</strong>
+        <span>Overdue</span>
+      </div>
+    </div>
+
+    <div class="kds-status-clock">
+      <span class="kds-online">
+        <Wifi aria-hidden="true" />
+        Online
+      </span>
+      <span v-if="overdue > 0" class="kds-rush">
+        <Flame aria-hidden="true" />
+        Rush
+      </span>
+      <div class="kds-clock">
+        <Clock3 aria-hidden="true" />
+        <div>
+          <strong>{{ clock }}</strong>
+          <span>{{ dateLabel }}</span>
+        </div>
+      </div>
+    </div>
+  </header>
+</template>

--- a/resources/js/components/KDS/KdsEmptyState.vue
+++ b/resources/js/components/KDS/KdsEmptyState.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { CheckCircle2 } from 'lucide-vue-next'
+</script>
+
+<template>
+  <div class="kds-empty" role="status" aria-live="polite">
+    <CheckCircle2 aria-hidden="true" />
+    <strong>Queue clear</strong>
+    <span>No tickets match this view.</span>
+  </div>
+</template>

--- a/resources/js/components/KDS/KdsFilterChips.vue
+++ b/resources/js/components/KDS/KdsFilterChips.vue
@@ -18,7 +18,6 @@ const groups: Array<Array<{ value: KdsFilter; label: string }>> = [
   [
     { value: 'new', label: 'New' },
     { value: 'preparing', label: 'Preparing' },
-    { value: 'ready', label: 'Ready' },
   ],
   [
     { value: 'served', label: 'Served' },

--- a/resources/js/components/KDS/KdsFilterChips.vue
+++ b/resources/js/components/KDS/KdsFilterChips.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { KdsFilter } from './kdsTypes'
+
+defineProps<{
+  modelValue: KdsFilter
+  counts: Record<KdsFilter, number>
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: KdsFilter]
+}>()
+
+const groups: Array<Array<{ value: KdsFilter; label: string }>> = [
+  [
+    { value: 'active', label: 'All Active' },
+    { value: 'overdue', label: 'Overdue' },
+  ],
+  [
+    { value: 'new', label: 'New' },
+    { value: 'preparing', label: 'Preparing' },
+    { value: 'ready', label: 'Ready' },
+  ],
+  [
+    { value: 'served', label: 'Served' },
+    { value: 'voided', label: 'Voided' },
+  ],
+]
+</script>
+
+<template>
+  <nav class="kds-filters" aria-label="Kitchen display filters">
+    <template v-for="(group, index) in groups" :key="index">
+      <div v-if="index > 0" class="kds-filter-divider" aria-hidden="true" />
+      <button
+        v-for="item in group"
+        :key="item.value"
+        type="button"
+        class="kds-filter-chip"
+        :class="{ 'is-active': modelValue === item.value }"
+        :aria-pressed="modelValue === item.value"
+        @click="emit('update:modelValue', item.value)"
+      >
+        <span>{{ item.label }}</span>
+        <strong>{{ counts[item.value] }}</strong>
+      </button>
+    </template>
+  </nav>
+</template>

--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ArrowRight, Check, RotateCcw } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { elapsedFor, formatElapsed, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
+import type { KdsDensity, KdsTicket } from './kdsTypes'
+
+const props = defineProps<{
+  ticket: KdsTicket
+  now: number
+  density: KdsDensity
+}>()
+
+const emit = defineEmits<{
+  advance: [ticketId: string]
+  recall: [ticketId: string]
+  toggleItem: [ticketId: string, itemId: string]
+}>()
+
+const doneCount = computed(() => props.ticket.items.filter((item) => item.done).length)
+const totalCount = computed(() => props.ticket.items.length)
+const terminal = computed(() => isTerminal(props.ticket.state))
+const elapsed = computed(() => elapsedFor(props.ticket, props.now))
+const urgency = computed(() => urgencyFor(props.ticket, props.now))
+const nextState = computed(() => nextStateFor(props.ticket.state))
+const isReadyBlocked = computed(() => props.ticket.state === 'preparing' && doneCount.value < totalCount.value)
+const actionLabel = computed(() => {
+  if (props.ticket.state === 'new') return 'Start Preparing'
+  if (props.ticket.state === 'preparing') return 'Mark Ready'
+  if (props.ticket.state === 'ready') return 'Mark Served'
+  return ''
+})
+
+function splitSafetyName(name: string) {
+  const delimiter = name.includes(' - ') ? ' - ' : ' — '
+  const parts = name.split(delimiter)
+
+  if (parts.length < 2) {
+    return { base: name, modifier: '' }
+  }
+
+  return {
+    base: parts[0],
+    modifier: parts.slice(1).join(delimiter),
+  }
+}
+</script>
+
+<template>
+  <article
+    class="kds-ticket"
+    :class="[
+      `state-${ticket.state}`,
+      `urgency-${urgency}`,
+      `density-${density}`,
+      { 'is-terminal': terminal },
+    ]"
+  >
+    <header class="kds-ticket-header">
+      <div class="kds-ticket-pane">
+        <span>Table</span>
+        <strong :class="{ 'is-struck': ticket.state === 'voided' }">{{ ticket.table }}</strong>
+        <small>Order {{ ticket.id }}</small>
+      </div>
+      <div class="kds-ticket-pane is-right">
+        <span>Elapsed</span>
+        <strong class="kds-timer">{{ formatElapsed(elapsed) }}</strong>
+        <small>Issued {{ ticket.issued }}</small>
+      </div>
+    </header>
+
+    <div class="kds-ticket-type-row">
+      <Badge
+        variant="outline"
+        class="kds-pill"
+        :class="{ 'is-refill': ticket.type === 'refill' }"
+      >
+        {{ ticketTypeLabel(ticket.type) }}
+      </Badge>
+      <Badge v-if="ticket.recalled" variant="warning" class="kds-recalled">
+        Recalled x{{ ticket.recalled }}
+      </Badge>
+    </div>
+
+    <p v-if="ticket.state === 'voided' && ticket.voidReason" class="kds-void-reason">
+      {{ ticket.voidReason }}
+    </p>
+
+    <section class="kds-items" :aria-label="`Items for order ${ticket.id}`">
+      <div class="kds-items-head">
+        <span>Items</span>
+        <span>{{ doneCount }} / {{ totalCount }} checked</span>
+      </div>
+
+      <button
+        v-for="item in ticket.items"
+        :key="item.id"
+        type="button"
+        class="kds-item-row"
+        :class="{ 'is-done': item.done, 'is-disabled': terminal }"
+        :disabled="terminal"
+        @click="emit('toggleItem', ticket.id, item.id)"
+      >
+        <Checkbox
+          :checked="item.done"
+          :disabled="terminal"
+          class="kds-item-check"
+          aria-hidden="true"
+          tabindex="-1"
+        />
+        <span class="kds-item-qty">{{ item.qty }}x</span>
+        <span class="kds-item-name">
+          <template v-if="item.safety">
+            <span>{{ splitSafetyName(item.name).base }}</span>
+            <span class="kds-safety"> - {{ splitSafetyName(item.name).modifier }}</span>
+          </template>
+          <template v-else>{{ item.name }}</template>
+        </span>
+      </button>
+    </section>
+
+    <footer class="kds-ticket-footer">
+      <div class="kds-status-block">
+        <span>Status</span>
+        <Badge variant="outline" class="kds-status-badge" :class="`state-${ticket.state}`">
+          <Check v-if="ticket.state === 'served'" aria-hidden="true" />
+          {{ stateLabel(ticket.state) }}
+        </Badge>
+      </div>
+
+      <Button
+        v-if="terminal"
+        type="button"
+        variant="outline"
+        class="kds-card-action is-recall"
+        @click="emit('recall', ticket.id)"
+      >
+        <RotateCcw data-icon="inline-start" aria-hidden="true" />
+        Recall to Line
+      </Button>
+
+      <Button
+        v-else-if="nextState"
+        type="button"
+        variant="brand"
+        class="kds-card-action"
+        :disabled="isReadyBlocked"
+        @click="emit('advance', ticket.id)"
+      >
+        {{ actionLabel }}
+        <ArrowRight data-icon="inline-end" aria-hidden="true" />
+      </Button>
+    </footer>
+  </article>
+</template>

--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { elapsedFor, formatElapsed, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
+import { elapsedFor, formatElapsed, isAdvanceBlocked, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
 import type { KdsDensity, KdsTicket } from './kdsTypes'
 
 const props = defineProps<{
@@ -25,7 +25,7 @@ const terminal = computed(() => isTerminal(props.ticket.state))
 const elapsed = computed(() => elapsedFor(props.ticket, props.now))
 const urgency = computed(() => urgencyFor(props.ticket, props.now))
 const nextState = computed(() => nextStateFor(props.ticket.state))
-const isReadyBlocked = computed(() => props.ticket.state === 'preparing' && doneCount.value < totalCount.value)
+const advanceBlocked = computed(() => isAdvanceBlocked(props.ticket))
 const actionLabel = computed(() => {
   if (props.ticket.state === 'new') return 'Start Preparing'
   if (props.ticket.state === 'preparing') return 'Mark Ready'
@@ -146,7 +146,7 @@ function splitSafetyName(name: string) {
         type="button"
         variant="brand"
         class="kds-card-action"
-        :disabled="isReadyBlocked"
+        :disabled="advanceBlocked"
         @click="emit('advance', ticket.id)"
       >
         {{ actionLabel }}

--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowRight, Check, RotateCcw } from 'lucide-vue-next'
+import { ArrowRight, Check } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -15,7 +15,6 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   advance: [ticketId: string]
-  recall: [ticketId: string]
   toggleItem: [ticketId: string, itemId: string]
 }>()
 
@@ -28,8 +27,7 @@ const nextState = computed(() => nextStateFor(props.ticket.state))
 const advanceBlocked = computed(() => isAdvanceBlocked(props.ticket))
 const actionLabel = computed(() => {
   if (props.ticket.state === 'new') return 'Start Preparing'
-  if (props.ticket.state === 'preparing') return 'Mark Ready'
-  if (props.ticket.state === 'ready') return 'Mark Served'
+  if (props.ticket.state === 'preparing' || props.ticket.state === 'ready') return 'Mark as Served'
   return ''
 })
 
@@ -131,18 +129,7 @@ function splitSafetyName(name: string) {
       </div>
 
       <Button
-        v-if="terminal"
-        type="button"
-        variant="outline"
-        class="kds-card-action is-recall"
-        @click="emit('recall', ticket.id)"
-      >
-        <RotateCcw data-icon="inline-start" aria-hidden="true" />
-        Recall to Line
-      </Button>
-
-      <Button
-        v-else-if="nextState"
+        v-if="nextState"
         type="button"
         variant="brand"
         class="kds-card-action"

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -1,0 +1,52 @@
+function csrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? ''
+}
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const body = await response.json()
+    if (typeof body?.message === 'string') {
+      return body.message
+    }
+  } catch {
+    // Fall through to generic message.
+  }
+
+  return 'Something went wrong. Please try again.'
+}
+
+export async function postKdsAdvance(orderId: string): Promise<{ status: string }> {
+  const response = await fetch(route('kds.advance', orderId), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': csrfToken(),
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseError(response))
+  }
+
+  return response.json()
+}
+
+export async function postKdsToggleItem(itemId: string): Promise<{ done: boolean; done_at: string | null }> {
+  const response = await fetch(route('kds.toggle-item', itemId), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': csrfToken(),
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseError(response))
+  }
+
+  return response.json()
+}

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -20,7 +20,7 @@ function preparingTicket(itemsDone: boolean[]): KdsTicket {
   }
 }
 
-describe('Mark Ready gating', () => {
+describe('Mark as Served gating', () => {
   it('blocks advance when any preparing item is not done', () => {
     const ticket = preparingTicket([true, true, false])
 
@@ -46,11 +46,11 @@ describe('Mark Ready gating', () => {
     expect(isAdvanceBlocked(ticket)).toBe(false)
   })
 
-  it('advances preparing to ready when the gate passes', () => {
+  it('advances preparing to served when the gate passes', () => {
     const ticket = preparingTicket([true, true])
     const now = Date.now()
 
-    expect(applyAdvance(ticket, now).state).toBe('ready')
+    expect(applyAdvance(ticket, now).state).toBe('served')
   })
 
   it('leaves preparing unchanged when the gate fails', () => {

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { applyAdvance, canAdvanceTicket, isAdvanceBlocked } from './kdsHelpers'
+import type { KdsTicket } from './kdsTypes'
+
+function preparingTicket(itemsDone: boolean[]): KdsTicket {
+  return {
+    id: 'K-1',
+    table: 'T-1',
+    type: 'initial',
+    issued: '7:00 PM',
+    issuedAt: Date.now(),
+    elapsed: 60,
+    state: 'preparing',
+    items: itemsDone.map((done, index) => ({
+      id: `item-${index}`,
+      qty: 1,
+      name: `Item ${index}`,
+      done,
+    })),
+  }
+}
+
+describe('Mark Ready gating', () => {
+  it('blocks advance when any preparing item is not done', () => {
+    const ticket = preparingTicket([true, true, false])
+
+    expect(canAdvanceTicket(ticket)).toBe(false)
+    expect(isAdvanceBlocked(ticket)).toBe(true)
+  })
+
+  it('allows advance when every preparing item is done', () => {
+    const ticket = preparingTicket([true, true, true])
+
+    expect(canAdvanceTicket(ticket)).toBe(true)
+    expect(isAdvanceBlocked(ticket)).toBe(false)
+  })
+
+  it('does not block new tickets without a checklist gate', () => {
+    const ticket: KdsTicket = {
+      ...preparingTicket([]),
+      state: 'new',
+      items: [{ id: 'a', qty: 1, name: 'Bulgogi', done: false }],
+    }
+
+    expect(canAdvanceTicket(ticket)).toBe(true)
+    expect(isAdvanceBlocked(ticket)).toBe(false)
+  })
+
+  it('advances preparing to ready when the gate passes', () => {
+    const ticket = preparingTicket([true, true])
+    const now = Date.now()
+
+    expect(applyAdvance(ticket, now).state).toBe('ready')
+  })
+
+  it('leaves preparing unchanged when the gate fails', () => {
+    const ticket = preparingTicket([true, false])
+    const now = Date.now()
+
+    expect(applyAdvance(ticket, now).state).toBe('preparing')
+  })
+})

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -127,10 +127,19 @@ export function stateLabel(state: KdsTicketState): string {
 
 export function canAdvanceTicket(ticket: KdsTicket): boolean {
   if (ticket.state === 'preparing') {
-    return ticket.items.every((item) => item.done)
+    return ticket.items.every((item) => item.done === true)
   }
 
   return nextStateFor(ticket.state) !== null
+}
+
+/** Primary action `:disabled` — Mark Ready gated until every checklist item is done. */
+export function isAdvanceBlocked(ticket: KdsTicket): boolean {
+  if (nextStateFor(ticket.state) === null) {
+    return false
+  }
+
+  return !canAdvanceTicket(ticket)
 }
 
 export function applyAdvance(ticket: KdsTicket, now: number): KdsTicket {

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -1,13 +1,13 @@
 import type { KdsFilter, KdsThresholds, KdsTicket, KdsTicketState, KdsTicketType, KdsUrgency } from './kdsTypes'
 
-export const ACTIVE_STATES: KdsTicketState[] = ['new', 'preparing', 'ready']
+export const ACTIVE_STATES: KdsTicketState[] = ['new', 'preparing']
 export const TERMINAL_STATES: KdsTicketState[] = ['served', 'voided']
 export const STAGE_SORT: Record<KdsTicketState, number> = {
   preparing: 0,
-  ready: 1,
-  new: 2,
-  served: 3,
-  voided: 4,
+  ready: 0,
+  new: 1,
+  served: 2,
+  voided: 3,
 }
 
 export const KDS_THRESHOLDS: KdsThresholds = {
@@ -20,8 +20,6 @@ export const KDS_THRESHOLDS: KdsThresholds = {
     over: 25 * 60,
   },
 }
-
-export const RECALL_TARGET: KdsTicketState = 'preparing'
 
 export function isTerminal(state: KdsTicketState): boolean {
   return TERMINAL_STATES.includes(state)
@@ -75,6 +73,10 @@ export function filterTickets(tickets: KdsTicket[], filter: KdsFilter, now: numb
       return urgencyFor(ticket, now) === 'over'
     }
 
+    if (filter === 'preparing') {
+      return ticket.state === 'preparing' || ticket.state === 'ready'
+    }
+
     return ticket.state === filter
   })
 }
@@ -104,11 +106,7 @@ export function nextStateFor(state: KdsTicketState): KdsTicketState | null {
     return 'preparing'
   }
 
-  if (state === 'preparing') {
-    return 'ready'
-  }
-
-  if (state === 'ready') {
+  if (state === 'preparing' || state === 'ready') {
     return 'served'
   }
 
@@ -119,21 +117,21 @@ export function stateLabel(state: KdsTicketState): string {
   return {
     new: 'New',
     preparing: 'Preparing',
-    ready: 'Ready',
+    ready: 'Preparing',
     served: 'Served',
     voided: 'Voided',
   }[state]
 }
 
 export function canAdvanceTicket(ticket: KdsTicket): boolean {
-  if (ticket.state === 'preparing') {
+  if (ticket.state === 'preparing' || ticket.state === 'ready') {
     return ticket.items.every((item) => item.done === true)
   }
 
   return nextStateFor(ticket.state) !== null
 }
 
-/** Primary action `:disabled` — Mark Ready gated until every checklist item is done. */
+/** Primary action `:disabled` — Mark as Served gated until every checklist item is done. */
 export function isAdvanceBlocked(ticket: KdsTicket): boolean {
   if (nextStateFor(ticket.state) === null) {
     return false
@@ -160,17 +158,6 @@ export function applyAdvance(ticket: KdsTicket, now: number): KdsTicket {
   return {
     ...ticket,
     state: next,
-  }
-}
-
-export function applyRecall(ticket: KdsTicket, now: number, target: KdsTicketState = RECALL_TARGET): KdsTicket {
-  return {
-    ...ticket,
-    state: target,
-    recalled: (ticket.recalled ?? 0) + 1,
-    voidReason: undefined,
-    frozenElapsed: undefined,
-    issuedAt: now - elapsedFor(ticket, now) * 1000,
   }
 }
 

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -1,0 +1,170 @@
+import type { KdsFilter, KdsThresholds, KdsTicket, KdsTicketState, KdsTicketType, KdsUrgency } from './kdsTypes'
+
+export const ACTIVE_STATES: KdsTicketState[] = ['new', 'preparing', 'ready']
+export const TERMINAL_STATES: KdsTicketState[] = ['served', 'voided']
+export const STAGE_SORT: Record<KdsTicketState, number> = {
+  preparing: 0,
+  ready: 1,
+  new: 2,
+  served: 3,
+  voided: 4,
+}
+
+export const KDS_THRESHOLDS: KdsThresholds = {
+  initial: {
+    warn: 15 * 60,
+    over: 25 * 60,
+  },
+  refill: {
+    warn: 15 * 60,
+    over: 25 * 60,
+  },
+}
+
+export const RECALL_TARGET: KdsTicketState = 'preparing'
+
+export function isTerminal(state: KdsTicketState): boolean {
+  return TERMINAL_STATES.includes(state)
+}
+
+export function isActive(state: KdsTicketState): boolean {
+  return ACTIVE_STATES.includes(state)
+}
+
+export function elapsedFor(ticket: KdsTicket, now: number): number {
+  if (isTerminal(ticket.state)) {
+    return ticket.frozenElapsed ?? ticket.elapsed
+  }
+
+  return Math.max(0, Math.floor((now - ticket.issuedAt) / 1000))
+}
+
+export function formatElapsed(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+
+  return `${mins}:${String(secs).padStart(2, '0')}`
+}
+
+export function urgencyFor(ticket: KdsTicket, now: number, thresholds: KdsThresholds = KDS_THRESHOLDS): KdsUrgency {
+  if (isTerminal(ticket.state)) {
+    return 'ok'
+  }
+
+  const elapsed = elapsedFor(ticket, now)
+  const threshold = thresholds[ticket.type]
+
+  if (elapsed >= threshold.over) {
+    return 'over'
+  }
+
+  if (elapsed >= threshold.warn) {
+    return 'warn'
+  }
+
+  return 'ok'
+}
+
+export function filterTickets(tickets: KdsTicket[], filter: KdsFilter, now: number): KdsTicket[] {
+  return tickets.filter((ticket) => {
+    if (filter === 'active') {
+      return isActive(ticket.state)
+    }
+
+    if (filter === 'overdue') {
+      return urgencyFor(ticket, now) === 'over'
+    }
+
+    return ticket.state === filter
+  })
+}
+
+export function sortTickets(tickets: KdsTicket[], now: number): KdsTicket[] {
+  return [...tickets].sort((a, b) => {
+    const urgencyA = urgencyFor(a, now) === 'over' ? 0 : 1
+    const urgencyB = urgencyFor(b, now) === 'over' ? 0 : 1
+
+    if (urgencyA !== urgencyB) {
+      return urgencyA - urgencyB
+    }
+
+    const stageA = STAGE_SORT[a.state]
+    const stageB = STAGE_SORT[b.state]
+
+    if (stageA !== stageB) {
+      return stageA - stageB
+    }
+
+    return elapsedFor(b, now) - elapsedFor(a, now)
+  })
+}
+
+export function nextStateFor(state: KdsTicketState): KdsTicketState | null {
+  if (state === 'new') {
+    return 'preparing'
+  }
+
+  if (state === 'preparing') {
+    return 'ready'
+  }
+
+  if (state === 'ready') {
+    return 'served'
+  }
+
+  return null
+}
+
+export function stateLabel(state: KdsTicketState): string {
+  return {
+    new: 'New',
+    preparing: 'Preparing',
+    ready: 'Ready',
+    served: 'Served',
+    voided: 'Voided',
+  }[state]
+}
+
+export function canAdvanceTicket(ticket: KdsTicket): boolean {
+  if (ticket.state === 'preparing') {
+    return ticket.items.every((item) => item.done)
+  }
+
+  return nextStateFor(ticket.state) !== null
+}
+
+export function applyAdvance(ticket: KdsTicket, now: number): KdsTicket {
+  const next = nextStateFor(ticket.state)
+
+  if (!next || !canAdvanceTicket(ticket)) {
+    return ticket
+  }
+
+  if (next === 'served') {
+    return {
+      ...ticket,
+      state: next,
+      frozenElapsed: elapsedFor(ticket, now),
+    }
+  }
+
+  return {
+    ...ticket,
+    state: next,
+  }
+}
+
+export function applyRecall(ticket: KdsTicket, now: number, target: KdsTicketState = RECALL_TARGET): KdsTicket {
+  return {
+    ...ticket,
+    state: target,
+    recalled: (ticket.recalled ?? 0) + 1,
+    voidReason: undefined,
+    frozenElapsed: undefined,
+    issuedAt: now - elapsedFor(ticket, now) * 1000,
+  }
+}
+
+export function ticketTypeLabel(type: KdsTicketType): string {
+  return type === 'refill' ? 'Refill' : 'Initial Order'
+}

--- a/resources/js/components/KDS/kdsMockData.ts
+++ b/resources/js/components/KDS/kdsMockData.ts
@@ -1,0 +1,131 @@
+import type { KdsTicket } from './kdsTypes'
+
+const now = Date.now()
+
+function issuedAt(secondsAgo: number): number {
+  return now - secondsAgo * 1000
+}
+
+export const kdsMockTickets: KdsTicket[] = [
+  {
+    id: 'K-1182',
+    table: 'T-05',
+    type: 'initial',
+    issued: '7:23 PM',
+    issuedAt: issuedAt(26 * 60 + 14),
+    elapsed: 26 * 60 + 14,
+    state: 'preparing',
+    items: [
+      { id: '1182-1', qty: 3, name: 'Woosamgyup', done: true },
+      { id: '1182-2', qty: 2, name: 'Hyangcho Woosamgyup', done: true },
+      { id: '1182-3', qty: 2, name: 'Beef Bulgogi - no garlic', done: false, safety: true },
+      { id: '1182-4', qty: 1, name: 'Banchan Set', done: false },
+      { id: '1182-5', qty: 1, name: 'Gyeran Jjim', done: false },
+      { id: '1182-6', qty: 2, name: 'Soju - Chamisul', done: false },
+      { id: '1182-7', qty: 1, name: 'Sprite 1L', done: false },
+    ],
+  },
+  {
+    id: 'K-1183',
+    table: 'T-11',
+    type: 'initial',
+    issued: '7:46 PM',
+    issuedAt: issuedAt(3 * 60 + 12),
+    elapsed: 3 * 60 + 12,
+    state: 'new',
+    items: [
+      { id: '1183-1', qty: 3, name: 'Woosamgyup', done: false },
+      { id: '1183-2', qty: 2, name: 'Hyangcho Woosamgyup', done: false },
+      { id: '1183-3', qty: 2, name: 'Beef Bulgogi', done: false },
+      { id: '1183-4', qty: 1, name: 'Banchan Set', done: false },
+      { id: '1183-5', qty: 1, name: 'Gyeran Jjim', done: false },
+      { id: '1183-6', qty: 2, name: 'Soju - Chamisul', done: false },
+      { id: '1183-7', qty: 1, name: 'Sprite 1L', done: false },
+    ],
+  },
+  {
+    id: 'K-1173',
+    table: 'T-10',
+    type: 'refill',
+    issued: '7:54 PM',
+    issuedAt: issuedAt(2 * 60 + 5),
+    elapsed: 2 * 60 + 5,
+    state: 'new',
+    items: [
+      { id: '1173-1', qty: 2, name: 'Kimchi', done: false },
+      { id: '1173-2', qty: 1, name: 'Lettuce Wrap', done: false },
+      { id: '1173-3', qty: 1, name: 'Yangyeom Samgyupsal', done: false },
+    ],
+  },
+  {
+    id: 'K-1188',
+    table: 'T-05',
+    type: 'refill',
+    issued: '7:55 PM',
+    issuedAt: issuedAt(89),
+    elapsed: 89,
+    state: 'new',
+    items: [
+      { id: '1188-1', qty: 2, name: 'Kimchi', done: false },
+      { id: '1188-2', qty: 1, name: 'Pickled Radish', done: false },
+    ],
+  },
+  {
+    id: 'K-1176',
+    table: 'T-08',
+    type: 'initial',
+    issued: '7:38 PM',
+    issuedAt: issuedAt(14 * 60 + 22),
+    elapsed: 14 * 60 + 22,
+    state: 'preparing',
+    items: [
+      { id: '1176-1', qty: 2, name: 'Royal Banquet Set', done: true },
+      { id: '1176-2', qty: 2, name: 'Galbi', done: true },
+      { id: '1176-3', qty: 1, name: 'Haemul Pajeon', done: false },
+    ],
+  },
+  {
+    id: 'K-1178',
+    table: 'T-03',
+    type: 'initial',
+    issued: '7:43 PM',
+    issuedAt: issuedAt(8 * 60 + 42),
+    elapsed: 8 * 60 + 42,
+    state: 'ready',
+    items: [
+      { id: '1178-1', qty: 2, name: 'Classic Feast', done: true },
+      { id: '1178-2', qty: 1, name: 'Corn Cheese', done: true },
+      { id: '1178-3', qty: 2, name: 'Iced Tea', done: true },
+    ],
+  },
+  {
+    id: 'K-1168',
+    table: 'T-07',
+    type: 'initial',
+    issued: '7:12 PM',
+    issuedAt: issuedAt(41 * 60),
+    elapsed: 41 * 60,
+    frozenElapsed: 24 * 60 + 16,
+    state: 'served',
+    recalled: 1,
+    items: [
+      { id: '1168-1', qty: 4, name: 'Noble Selection', done: true },
+      { id: '1168-2', qty: 2, name: 'Kimchi Fried Rice', done: true },
+    ],
+  },
+  {
+    id: 'K-1169',
+    table: 'T-02',
+    type: 'refill',
+    issued: '7:18 PM',
+    issuedAt: issuedAt(36 * 60),
+    elapsed: 36 * 60,
+    frozenElapsed: 5 * 60 + 45,
+    state: 'voided',
+    voidReason: 'FOH voided duplicate refill',
+    items: [
+      { id: '1169-1', qty: 1, name: 'Steamed Egg', done: false },
+      { id: '1169-2', qty: 1, name: 'Rice', done: false },
+    ],
+  },
+]

--- a/resources/js/components/KDS/kdsTypes.ts
+++ b/resources/js/components/KDS/kdsTypes.ts
@@ -1,0 +1,34 @@
+export type KdsTicketType = 'initial' | 'refill'
+export type KdsTicketState = 'new' | 'preparing' | 'ready' | 'served' | 'voided'
+export type KdsFilter = 'active' | 'overdue' | KdsTicketState
+export type KdsUrgency = 'ok' | 'warn' | 'over'
+export type KdsDensity = 'comfortable' | 'compact'
+
+export interface KdsItem {
+  id: string
+  qty: number
+  name: string
+  done: boolean
+  safety?: boolean
+}
+
+export interface KdsTicket {
+  id: string
+  table: string
+  type: KdsTicketType
+  issued: string
+  issuedAt: number
+  elapsed: number
+  frozenElapsed?: number
+  state: KdsTicketState
+  items: KdsItem[]
+  recalled?: number
+  voidReason?: string
+}
+
+export interface KdsThreshold {
+  warn: number
+  over: number
+}
+
+export type KdsThresholds = Record<KdsTicketType, KdsThreshold>

--- a/resources/js/components/KDS/useKdsBoard.test.ts
+++ b/resources/js/components/KDS/useKdsBoard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { useKdsBoard } from './useKdsBoard'
+import type { KdsTicket } from './kdsTypes'
+
+function ticketWithItems(itemsDone: boolean[]): KdsTicket {
+  return {
+    id: 'K-1',
+    table: 'T-1',
+    type: 'initial',
+    issued: '7:00 PM',
+    issuedAt: Date.now(),
+    elapsed: 60,
+    state: 'preparing',
+    items: itemsDone.map((done, index) => ({
+      id: `item-${index}`,
+      qty: 1,
+      name: `Item ${index}`,
+      done,
+    })),
+  }
+}
+
+describe('useKdsBoard.applyItemToggle', () => {
+  it('reconciles a matching item to done=true', () => {
+    const board = useKdsBoard([ticketWithItems([false, false])])
+
+    board.applyItemToggle({ order_id: 'K-1', item_id: 'item-0', done: true, done_at: '2026-06-09T12:00:00+00:00' })
+
+    expect(board.tickets.value[0].items[0].done).toBe(true)
+    expect(board.tickets.value[0].items[1].done).toBe(false)
+  })
+
+  it('reconciles a matching item to done=false', () => {
+    const board = useKdsBoard([ticketWithItems([true, true])])
+
+    board.applyItemToggle({ order_id: 'K-1', item_id: 'item-1', done: false, done_at: null })
+
+    expect(board.tickets.value[0].items[1].done).toBe(false)
+    expect(board.tickets.value[0].items[0].done).toBe(true)
+  })
+
+  it('is a no-op for an unknown order id', () => {
+    const board = useKdsBoard([ticketWithItems([false])])
+
+    board.applyItemToggle({ order_id: 'K-999', item_id: 'item-0', done: true, done_at: null })
+
+    expect(board.tickets.value[0].items[0].done).toBe(false)
+  })
+})

--- a/resources/js/components/KDS/useKdsBoard.ts
+++ b/resources/js/components/KDS/useKdsBoard.ts
@@ -14,8 +14,18 @@ type OrderPayload = {
     quantity: number
     name: string
     is_refill?: boolean
+    done?: boolean
+    done_at?: string | null
   }>
-  void_reason?: string
+  recalled?: number | null
+  void_reason?: string | null
+}
+
+type ItemTogglePayload = {
+  item_id: string | number
+  order_id: string | number
+  done: boolean
+  done_at: string | null
 }
 
 const HIDDEN_STATUSES = new Set(['completed', 'cancelled', 'archived'])
@@ -45,10 +55,10 @@ function payloadToTicket(payload: OrderPayload): KdsTicket {
       id: String(it.id),
       qty: it.quantity ?? 1,
       name: it.name ?? '',
-      done: false,
+      done: (it.done ?? false),
     })),
-    recalled: undefined,
-    voidReason: payload.void_reason,
+    recalled: payload.recalled ?? undefined,
+    voidReason: payload.void_reason ?? undefined,
   }
 }
 
@@ -73,5 +83,23 @@ export function useKdsBoard(initialTickets: KdsTicket[]) {
     }
   }
 
-  return { tickets, applyOrderUpdate }
+  function applyItemToggle(payload: ItemTogglePayload): void {
+    const orderId = String(payload.order_id)
+    const itemId = String(payload.item_id)
+
+    tickets.value = tickets.value.map((t) => {
+      if (t.id !== orderId) {
+        return t
+      }
+
+      return {
+        ...t,
+        items: t.items.map((it) =>
+          it.id === itemId ? { ...it, done: payload.done } : it,
+        ),
+      }
+    })
+  }
+
+  return { tickets, applyOrderUpdate, applyItemToggle }
 }

--- a/resources/js/components/KDS/useKdsBoard.ts
+++ b/resources/js/components/KDS/useKdsBoard.ts
@@ -30,10 +30,18 @@ type ItemTogglePayload = {
 
 const HIDDEN_STATUSES = new Set(['completed', 'cancelled', 'archived'])
 
+function normalizeKdsState(state: string): KdsTicket['state'] {
+  if (state === 'ready') {
+    return 'preparing'
+  }
+
+  return state as KdsTicket['state']
+}
+
 function payloadToTicket(payload: OrderPayload): KdsTicket {
   const issuedAt = payload.created_at ? new Date(payload.created_at).getTime() : Date.now()
   const now = Date.now()
-  const state = (payload.kds_state ?? 'new') as KdsTicket['state']
+  const state = normalizeKdsState(payload.kds_state ?? 'new')
   const isTerminal = state === 'served' || state === 'voided'
   const elapsed = Math.max(0, Math.floor((now - issuedAt) / 1000))
   const frozenElapsed = isTerminal && payload.updated_at

--- a/resources/js/components/KDS/useKdsBoard.ts
+++ b/resources/js/components/KDS/useKdsBoard.ts
@@ -1,0 +1,77 @@
+import { ref } from 'vue'
+import type { KdsTicket } from './kdsTypes'
+
+type OrderPayload = {
+  id: string | number
+  status: string
+  kds_state?: string
+  kds_type?: string
+  created_at?: string
+  updated_at?: string
+  table?: { name: string } | null
+  items?: Array<{
+    id: string | number
+    quantity: number
+    name: string
+    is_refill?: boolean
+  }>
+  void_reason?: string
+}
+
+const HIDDEN_STATUSES = new Set(['completed', 'cancelled', 'archived'])
+
+function payloadToTicket(payload: OrderPayload): KdsTicket {
+  const issuedAt = payload.created_at ? new Date(payload.created_at).getTime() : Date.now()
+  const now = Date.now()
+  const state = (payload.kds_state ?? 'new') as KdsTicket['state']
+  const isTerminal = state === 'served' || state === 'voided'
+  const elapsed = Math.max(0, Math.floor((now - issuedAt) / 1000))
+  const frozenElapsed = isTerminal && payload.updated_at
+    ? Math.max(0, Math.floor((new Date(payload.updated_at).getTime() - issuedAt) / 1000))
+    : undefined
+
+  return {
+    id: String(payload.id),
+    table: payload.table?.name ?? '—',
+    type: (payload.kds_type ?? 'initial') as KdsTicket['type'],
+    issued: payload.created_at
+      ? new Intl.DateTimeFormat('en-US', { hour: 'numeric', minute: '2-digit' }).format(new Date(payload.created_at))
+      : '',
+    issuedAt,
+    elapsed,
+    frozenElapsed,
+    state,
+    items: (payload.items ?? []).map((it) => ({
+      id: String(it.id),
+      qty: it.quantity ?? 1,
+      name: it.name ?? '',
+      done: false,
+    })),
+    recalled: undefined,
+    voidReason: payload.void_reason,
+  }
+}
+
+export function useKdsBoard(initialTickets: KdsTicket[]) {
+  const tickets = ref<KdsTicket[]>(initialTickets.map((t) => ({ ...t, items: t.items.map((i) => ({ ...i })) })))
+
+  function applyOrderUpdate(payload: OrderPayload): void {
+    const id = String(payload.id)
+
+    if (HIDDEN_STATUSES.has(payload.status)) {
+      tickets.value = tickets.value.filter((t) => t.id !== id)
+      return
+    }
+
+    const ticket = payloadToTicket(payload)
+    const idx = tickets.value.findIndex((t) => t.id === id)
+
+    if (idx >= 0) {
+      tickets.value = tickets.value.map((t, i) => (i === idx ? ticket : t))
+    } else {
+      tickets.value = [...tickets.value, ticket]
+    }
+  }
+
+  return { tickets, applyOrderUpdate }
+}

--- a/resources/js/components/KDS/useKdsEcho.ts
+++ b/resources/js/components/KDS/useKdsEcho.ts
@@ -1,0 +1,38 @@
+import { onBeforeUnmount, onMounted } from 'vue'
+import type { useKdsBoard } from './useKdsBoard'
+
+type Board = ReturnType<typeof useKdsBoard>
+
+export function useKdsEcho(board: Board) {
+  let channel: ReturnType<typeof window.Echo.channel> | null = null
+
+  function handleEvent(e: unknown): void {
+    const payload = (e as any)?.order ?? e
+    if (!payload?.id) {
+      return
+    }
+    board.applyOrderUpdate(payload)
+  }
+
+  onMounted(() => {
+    if (!window.Echo) {
+      console.warn('[useKdsEcho] Echo not available')
+      return
+    }
+
+    channel = window.Echo.channel('admin.orders')
+    channel
+      .listen('.order.created', handleEvent)
+      .listen('.order.updated', handleEvent)
+      .listen('.order.voided', handleEvent)
+      .listen('.order.completed', handleEvent)
+      .listen('.order.cancelled', handleEvent)
+  })
+
+  onBeforeUnmount(() => {
+    if (channel && typeof (window.Echo as any).leave === 'function') {
+      ;(window.Echo as any).leave('admin.orders')
+      channel = null
+    }
+  })
+}

--- a/resources/js/components/KDS/useKdsEcho.ts
+++ b/resources/js/components/KDS/useKdsEcho.ts
@@ -6,12 +6,20 @@ type Board = ReturnType<typeof useKdsBoard>
 export function useKdsEcho(board: Board) {
   let channel: ReturnType<typeof window.Echo.channel> | null = null
 
-  function handleEvent(e: unknown): void {
+  function handleOrderEvent(e: unknown): void {
     const payload = (e as any)?.order ?? e
     if (!payload?.id) {
       return
     }
     board.applyOrderUpdate(payload)
+  }
+
+  function handleItemToggle(e: unknown): void {
+    const payload = e as any
+    if (!payload?.item_id) {
+      return
+    }
+    board.applyItemToggle(payload)
   }
 
   onMounted(() => {
@@ -22,11 +30,12 @@ export function useKdsEcho(board: Board) {
 
     channel = window.Echo.channel('admin.orders')
     channel
-      .listen('.order.created', handleEvent)
-      .listen('.order.updated', handleEvent)
-      .listen('.order.voided', handleEvent)
-      .listen('.order.completed', handleEvent)
-      .listen('.order.cancelled', handleEvent)
+      .listen('.order.created', handleOrderEvent)
+      .listen('.order.updated', handleOrderEvent)
+      .listen('.order.voided', handleOrderEvent)
+      .listen('.order.completed', handleOrderEvent)
+      .listen('.order.cancelled', handleOrderEvent)
+      .listen('.item.toggled', handleItemToggle)
   })
 
   onBeforeUnmount(() => {

--- a/resources/js/components/Menus/DataTableRowActions.vue
+++ b/resources/js/components/Menus/DataTableRowActions.vue
@@ -1,142 +1,16 @@
 <script setup lang="ts">
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import { computed } from 'vue'
 import type { Row } from '@tanstack/vue-table'
-import { Ellipsis } from 'lucide-vue-next'
-import { Button } from '@/components/ui/button'
-import { router } from '@inertiajs/vue3'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
-import { ref, computed } from 'vue'
-import type { Menu } from '@/types/models';
+import type { Menu } from '@/types/models'
 import MenuForm from '@/components/Menus/MenuForm.vue'
-import { toast } from 'vue-sonner'
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet'
-
-const showImageDialog = ref(false)
 
 interface DataTableRowActionsProps {
-  row: Row<Menu>
+    row: Row<Menu>
 }
 const props = defineProps<DataTableRowActionsProps>()
-const computedMenu = computed(() => {
-  const parsed = props.row.original
-  return {
-    ...parsed as Menu
-  }
-})
-
-const isSheetOpen = ref(false)
-// const isRestoring = ref(null)
-const openSheet = () => {
-  isSheetOpen.value = true
-}
-
-const showDialog = ref(false);
-const openDialog = () => {
-  showDialog.value = true
-}
-
-const deactivateAccount = (computedMenu: Menu) => {
-  router.visit(route('Menus.destroy', computedMenu), {
-    method: 'delete',
-    onSuccess: () => {
-     toast.warning('Account Deactivated')
-    }
-  })
-}
-
-const restoreMenu = (computedMenu: Menu) => {
-  // isRestoring.value = computedMenu.id
-  
-  // router.patch(route('Menus.restore', computedMenu.id), {}, {
-    // onSuccess: (page) => {
-    //   // isRestoring.value = null
-    //   // showNotification('success', `${computedMenu.name} has been restored successfully.`)
-    // },
-    // onError: (errors) => {
-    //   // isRestoring.value = null
-    //   // showNotification('error', 'Failed to restore Menu. Please try again.')
-    // }
-  // })
-}
-// 
-// console.log(route('Menus.restore', 3))
+const computedMenu = computed(() => props.row.original as Menu)
 </script>
 
 <template>
-  <MenuForm :menu="computedMenu" />
-  <!-- <DropdownMenu>
-    <DropdownMenuTrigger as-child>
-      <Button variant="ghost" class="flex h-8 w-8 p-0 data-[state=open]:bg-muted">
-        <Ellipsis class="h-4 w-4" />
-        <span class="sr-only">Open menu</span>
-      </Button>
-    </DropdownMenuTrigger>
-    <DropdownMenuContent align="end" class="w-[160px]">
-
-      <DropdownMenuItem class="cursor-pointer" @click="openSheet">Edit Menu</DropdownMenuItem>
-
-       <DropdownMenuItem class="cursor-pointer" @click="showImageDialog = true">Replace Image</DropdownMenuItem>
-      
-
-    </DropdownMenuContent>
-  </DropdownMenu> -->
-
-  <!-- <AlertDialog v-model:open="showDialog">
-    <AlertDialogTrigger as-child>
-      <Button variant="outline">
-        Show Dialog
-      </Button>
-    </AlertDialogTrigger>
-    <AlertDialogContent>
-      <AlertDialogHeader>
-        <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-        <AlertDialogDescription>
-          This action cannot be undone. This will permanently delete this
-          account.
-        </AlertDialogDescription>
-      </AlertDialogHeader>
-      <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
-        <AlertDialogAction class="bg-red-600 hover:bg-red-500" @click="deactivateAccount(computedMenu)">Continue</AlertDialogAction>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  </AlertDialog> -->
-
-
-  <!-- <Sheet v-model:open="isSheetOpen">
-    <SheetContent>
-      <SheetHeader>
-        <SheetTitle>Edit Menu</SheetTitle>
-        <SheetDescription>
-          Edit the Menu's information.
-        </SheetDescription>
-      </SheetHeader> -->
-      
-    <!-- </SheetContent>
-  </Sheet> -->
-
-
+    <MenuForm :menu="computedMenu" />
 </template>

--- a/resources/js/components/pos/PaymentDialog.vue
+++ b/resources/js/components/pos/PaymentDialog.vue
@@ -50,8 +50,8 @@ const paymentTypes = [
     { id: '1', label: 'Cash' },
     { id: '2', label: 'Credit' },
     { id: '3', label: 'Debit' },
-    { id: '4', label: 'GCASH' },
-    { id: '5', label: 'PAYMAYA' },
+    { id: '4', label: 'GCash' },
+    { id: '5', label: 'PayMaya' },
 ]
 
 const handlePay = () => {
@@ -99,7 +99,7 @@ const handleOpenChange = (value: boolean) => {
                                 :key="pt.id"
                                 :value="pt.id"
                             >
-                                {{ pt.label }} ({{ pt.id }})
+                                {{ pt.label }}
                             </SelectItem>
                         </SelectContent>
                     </Select>

--- a/resources/js/pages/Devices/Index.vue
+++ b/resources/js/pages/Devices/Index.vue
@@ -3,16 +3,14 @@ import { computed, ref } from 'vue'
 import { Head, Link, router, usePage } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
 import {
-    MonitorSmartphone, Wifi, WifiOff, AlertTriangle, Battery, BatteryLow,
-    BatteryMedium, RotateCcw, Plus, Eye, Download, RefreshCw, ShieldCheck,
-    ShieldAlert, Lock,
+    MonitorSmartphone, RotateCcw, Plus, Eye, Download, RefreshCw, ShieldCheck,
+    ShieldAlert,
 } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import DeviceDetailSheet from '@/components/Devices/DeviceDetailSheet.vue'
 import { type BreadcrumbItem } from '@/types'
 import type { Device } from '@/types/models'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import {
     AlertDialog,
     AlertDialogAction,

--- a/resources/js/pages/Devices/Index.vue
+++ b/resources/js/pages/Devices/Index.vue
@@ -4,7 +4,7 @@ import { Head, Link, router, usePage } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
 import {
     MonitorSmartphone, RotateCcw, Plus, Eye, Download, RefreshCw, ShieldCheck,
-    ShieldAlert,
+    ShieldAlert, AlertTriangle,
 } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import DeviceDetailSheet from '@/components/Devices/DeviceDetailSheet.vue'
@@ -106,7 +106,7 @@ function batteryBg(pct: number | null): string {
     return 'bg-woosoo-red'
 }
 
-function isSecurityExpired(device: Device): boolean {
+function isVersionMismatch(device: Device): boolean {
     if (!device.app_version) return false
     const modal = props.fleetStats?.modal_app_version
     if (!modal || !device.app_version) return false
@@ -130,9 +130,9 @@ function executeRestart() {
     router.post(route('devices.security-code.regenerate', device.id), {}, {
         preserveScroll: true,
         onSuccess: () => {
-            toast.success(`${device.name} restarted.`)
+            toast.success(`Security code regenerated for ${device.name}.`)
         },
-        onError: () => toast.error('Restart failed.'),
+        onError: () => toast.error('Regeneration failed.'),
         onFinish: () => { isRestarting.value = null },
     })
 }
@@ -198,8 +198,10 @@ function syncAll() {
                             </p>
                         </div>
                         <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-3 dark:border-white/10 dark:bg-white/[0.06]">
-                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Network</p>
-                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums text-woosoo-green">LAN ✓</p>
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Online</p>
+                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums">
+                                {{ fleetStats?.online_count ?? 0 }}/{{ activeDevices.length }} online
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -222,6 +224,9 @@ function syncAll() {
                             Add Device
                         </Link>
                     </Button>
+                    <!-- TODO: trashed devices — DeviceController needs a trashed() method + Inertia page
+                         before this link can be wired up. Route 'devices.trashed' is registered but has no
+                         controller implementation. -->
                 </div>
             </section>
 
@@ -325,19 +330,19 @@ function syncAll() {
                                         :style="{ width: `${batteryLevel(device)}%` }"
                                     />
                                 </div>
-                                <p v-if="deviceStatus(device) === 'offline' && (batteryLevel(device) ?? 100) < 5" class="mt-1 text-[10px] font-medium text-woosoo-red">
-                                    ⚠ Battery depleted
+                                <p v-if="deviceStatus(device) === 'offline' && (batteryLevel(device) ?? 100) < 5" class="mt-1 flex items-center gap-1 text-[10px] font-medium text-woosoo-red">
+                                    <AlertTriangle class="inline h-3 w-3" /> Battery depleted
                                 </p>
                             </div>
 
-                            <!-- Footer: security + actions -->
+                            <!-- Footer: version check + actions -->
                             <div class="flex items-center justify-between">
                                 <span
                                     class="inline-flex items-center gap-1 text-[10px] font-medium"
-                                    :class="isSecurityExpired(device) ? 'text-woosoo-red' : 'text-woosoo-green'"
+                                    :class="isVersionMismatch(device) ? 'text-woosoo-red' : 'text-woosoo-green'"
                                 >
-                                    <component :is="isSecurityExpired(device) ? ShieldAlert : ShieldCheck" class="h-3 w-3" />
-                                    {{ isSecurityExpired(device) ? 'Expired' : 'Sec OK' }}
+                                    <component :is="isVersionMismatch(device) ? ShieldAlert : ShieldCheck" class="h-3 w-3" />
+                                    {{ isVersionMismatch(device) ? 'Ver Mismatch' : 'Ver OK' }}
                                 </span>
                                 <div class="flex gap-1">
                                     <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openDeviceDetail(device)">
@@ -352,7 +357,7 @@ function syncAll() {
                                         @click="confirmRestart(device)"
                                     >
                                         <RotateCcw class="mr-1 h-3 w-3" :class="{ 'animate-spin': isRestarting === device.id }" />
-                                        Restart
+                                        Regen Code
                                     </Button>
                                 </div>
                             </div>
@@ -364,18 +369,18 @@ function syncAll() {
 
         <DeviceDetailSheet v-model:open="isDeviceDetailOpen" :device="selectedDevice" />
 
-        <!-- Restart confirm -->
+        <!-- Regen code confirm -->
         <AlertDialog :open="!!restartTarget" @update:open="(v) => { if (!v) restartTarget = null }">
             <AlertDialogContent>
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Restart {{ restartTarget?.name }}?</AlertDialogTitle>
+                    <AlertDialogTitle>Regenerate security code for {{ restartTarget?.name }}?</AlertDialogTitle>
                     <AlertDialogDescription>
-                        This will send a restart signal to the device. The tablet will briefly go offline.
+                        A new security code will be generated. The tablet will need to re-pair using the new code.
                     </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                     <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction @click="executeRestart">Restart</AlertDialogAction>
+                    <AlertDialogAction @click="executeRestart">Regenerate</AlertDialogAction>
                 </AlertDialogFooter>
             </AlertDialogContent>
         </AlertDialog>

--- a/resources/js/pages/Devices/Index.vue
+++ b/resources/js/pages/Devices/Index.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
- 
-import AppLayout from '@/layouts/AppLayout.vue';
-import { Head, Link, usePage } from '@inertiajs/vue3';
-import { type BreadcrumbItem } from '@/types';
-
-import { columns } from '@/components/Devices/columns';
-import DataTable from '@/components/Devices/DataTable.vue'
+import { computed, ref } from 'vue'
+import { Head, Link, router, usePage } from '@inertiajs/vue3'
+import { toast } from 'vue-sonner'
+import {
+    MonitorSmartphone, Wifi, WifiOff, AlertTriangle, Battery, BatteryLow,
+    BatteryMedium, RotateCcw, Plus, Eye, Download, RefreshCw, ShieldCheck,
+    ShieldAlert, Lock,
+} from 'lucide-vue-next'
+import AppLayout from '@/layouts/AppLayout.vue'
 import DeviceDetailSheet from '@/components/Devices/DeviceDetailSheet.vue'
-import { ref, computed, toRefs } from 'vue'
+import { type BreadcrumbItem } from '@/types'
+import type { Device } from '@/types/models'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import {
     Dialog,
     DialogContent,
@@ -16,41 +31,121 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import type { Device } from '@/types/models';
 
-const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Devices',
-        href: route('devices.index'),
-    },
-];
+interface FleetStats {
+    online_count: number
+    warning_count: number
+    offline_count: number
+    avg_battery: number | null
+    modal_app_version: string | null
+}
 
 const props = defineProps<{
-    title: string;
-    description: string;
-    devices: Device[];
-    stats?: any;
+    title: string
+    description: string
+    devices: Device[]
+    stats?: any[]
+    fleetStats?: FleetStats
 }>()
 
-const { devices, stats } = toRefs(props)
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Devices', href: route('devices.index') },
+]
+
+const page = usePage()
+const revealedSecurityCode = computed(() => String((page.props as any)?.flash?.security_code_reveal || ''))
+const showSecurityCodeReveal = ref(Boolean(revealedSecurityCode.value))
 
 const selectedDevice = ref<Device | null>(null)
 const isDeviceDetailOpen = ref(false)
-const page = usePage()
+const restartTarget = ref<Device | null>(null)
+const isRestarting = ref<number | null>(null)
+const isSyncingAll = ref(false)
 
-const revealedSecurityCode = computed(() => String((page.props as any)?.flash?.security_code_reveal || ''))
-const showSecurityCodeReveal = ref(Boolean(revealedSecurityCode.value))
-const originalDevices = computed(() => devices.value ?? [])
-const securityReadyCount = computed(() =>
-    originalDevices.value.filter((device: any) => Boolean(device.security_code_generated_at)).length
-)
+const activeDevices = computed(() => props.devices.filter((d) => !d.deleted_at))
 
-const openDeviceDetail = (device: Device) => {
+function deviceStatus(device: Device): 'online' | 'warning' | 'offline' {
+    if (device.deleted_at) return 'offline'
+    const s = (device.status ?? '').toLowerCase()
+    if (s === 'online') return 'online'
+    if (s === 'warning') return 'warning'
+    if (s === 'offline') return 'offline'
+    // Derive from heartbeat age when status field is not set
+    if (!device.last_seen_at && !device.last_heartbeat_at) return 'offline'
+    const lastSeen = new Date(device.last_heartbeat_at ?? device.last_seen_at ?? 0).getTime()
+    const diffMin = (Date.now() - lastSeen) / 60000
+    if (diffMin > 30) return 'offline'
+    if (diffMin > 5) return 'warning'
+    return 'online'
+}
+
+function lastPingLabel(device: Device): string {
+    const ts = device.last_heartbeat_at ?? device.last_seen_at
+    if (!ts) return '—'
+    const diffSec = Math.floor((Date.now() - new Date(ts).getTime()) / 1000)
+    if (diffSec < 60) return `${diffSec}s ago`
+    const diffMin = Math.floor(diffSec / 60)
+    if (diffMin < 60) return `${diffMin}m ago`
+    return `${Math.floor(diffMin / 60)}h ago`
+}
+
+function batteryLevel(device: Device): number | null {
+    const b = device.latest_heartbeat?.battery_level
+    return b != null ? Math.round(Number(b)) : null
+}
+
+function batteryColor(pct: number | null): string {
+    if (pct == null) return 'text-muted-foreground'
+    if (pct >= 60) return 'text-woosoo-green'
+    if (pct >= 15) return 'text-[#f6b56d]'
+    return 'text-woosoo-red'
+}
+
+function batteryBg(pct: number | null): string {
+    if (pct == null) return 'bg-muted'
+    if (pct >= 60) return 'bg-woosoo-green'
+    if (pct >= 15) return 'bg-[#f6b56d]'
+    return 'bg-woosoo-red'
+}
+
+function isSecurityExpired(device: Device): boolean {
+    if (!device.app_version) return false
+    const modal = props.fleetStats?.modal_app_version
+    if (!modal || !device.app_version) return false
+    return device.app_version !== modal && deviceStatus(device) !== 'online'
+}
+
+function openDeviceDetail(device: Device) {
     selectedDevice.value = device
     isDeviceDetailOpen.value = true
 }
 
+function confirmRestart(device: Device) {
+    restartTarget.value = device
+}
+
+function executeRestart() {
+    if (!restartTarget.value) return
+    const device = restartTarget.value
+    restartTarget.value = null
+    isRestarting.value = device.id
+    router.post(route('devices.security-code.regenerate', device.id), {}, {
+        preserveScroll: true,
+        onSuccess: () => {
+            toast.success(`${device.name} restarted.`)
+        },
+        onError: () => toast.error('Restart failed.'),
+        onFinish: () => { isRestarting.value = null },
+    })
+}
+
+function syncAll() {
+    isSyncingAll.value = true
+    router.reload({
+        onSuccess: () => toast.success('Fleet synced.'),
+        onFinish: () => { isSyncingAll.value = false },
+    })
+}
 </script>
 
 <template>
@@ -58,85 +153,251 @@ const openDeviceDetail = (device: Device) => {
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-5">
+            <!-- Hero header -->
             <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
-                <div class="relative flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-                    <div class="flex min-w-0 flex-1 flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-                        <div class="max-w-2xl space-y-2">
-                            <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
-                                Device management
+                <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#f6b56d]/10 via-transparent to-transparent dark:from-[#f6b56d]/6" />
+                <div class="relative flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                    <div class="space-y-2">
+                        <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+                            Tablet Management
+                        </span>
+                        <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                            Devices
+                        </h2>
+                        <!-- Fleet status summary pills -->
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span class="inline-flex items-center gap-1.5 rounded-full border border-woosoo-green/30 bg-woosoo-green/10 px-2.5 py-1 text-xs font-medium text-woosoo-green">
+                                <span class="h-1.5 w-1.5 rounded-full bg-woosoo-green" />
+                                {{ fleetStats?.online_count ?? 0 }} online
                             </span>
-                            <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
-                                Devices
-                            </h2>
-                            <p class="max-w-xl text-sm leading-6 text-muted-foreground sm:text-base">
-                                Register a new device, review the devices that are already online, and rotate security codes when a tablet needs to be re-issued.
-                            </p>
-                        </div>
-
-                        <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
-                            <Button as-child size="lg" class="w-full sm:w-auto">
-                                <Link :href="route('devices.create')">
-                                    Create Device
-                                </Link>
-                            </Button>
+                            <span v-if="(fleetStats?.warning_count ?? 0) > 0" class="inline-flex items-center gap-1.5 rounded-full border border-[#f6b56d]/30 bg-[#f6b56d]/10 px-2.5 py-1 text-xs font-medium text-[#f6b56d]">
+                                <span class="h-1.5 w-1.5 rounded-full bg-[#f6b56d]" />
+                                {{ fleetStats?.warning_count }} warning
+                            </span>
+                            <span v-if="(fleetStats?.offline_count ?? 0) > 0" class="inline-flex items-center gap-1.5 rounded-full border border-woosoo-red/30 bg-woosoo-red/10 px-2.5 py-1 text-xs font-medium text-woosoo-red">
+                                <span class="h-1.5 w-1.5 rounded-full bg-woosoo-red" />
+                                {{ fleetStats?.offline_count }} offline
+                            </span>
                         </div>
                     </div>
 
-                    <div class="grid grid-cols-2 gap-3 lg:w-[420px]">
-                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-4 dark:border-white/10 dark:bg-white/[0.06]">
-                            <p class="text-xs font-semibold tracking-[0.18em] text-muted-foreground uppercase">Total Devices</p>
-                            <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
-                                {{ stats?.total_devices ?? (devices || []).length }}
-                            </p>
-                            <p class="mt-1 text-sm text-muted-foreground">Registered devices</p>
+                    <!-- KPI strip -->
+                    <div class="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:w-auto">
+                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-3 dark:border-white/10 dark:bg-white/[0.06]">
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Devices</p>
+                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums">{{ activeDevices.length }}</p>
                         </div>
-                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-4 dark:border-white/10 dark:bg-white/[0.06]">
-                            <p class="text-xs font-semibold tracking-[0.18em] text-muted-foreground uppercase">Security Ready</p>
-                            <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
-                                {{ stats?.security_ready ?? securityReadyCount }}
+                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-3 dark:border-white/10 dark:bg-white/[0.06]">
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Avg Battery</p>
+                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums" :class="batteryColor(fleetStats?.avg_battery ?? null)">
+                                {{ fleetStats?.avg_battery != null ? `${fleetStats.avg_battery}%` : '—' }}
                             </p>
-                            <p class="mt-1 text-sm text-muted-foreground">Devices with security code</p>
+                        </div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-3 dark:border-white/10 dark:bg-white/[0.06]">
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">App Version</p>
+                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums">
+                                {{ fleetStats?.modal_app_version ?? '—' }}
+                            </p>
+                        </div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/72 px-4 py-3 dark:border-white/10 dark:bg-white/[0.06]">
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Network</p>
+                            <p class="mt-1 font-mono text-xl font-semibold tabular-nums text-woosoo-green">LAN ✓</p>
                         </div>
                     </div>
                 </div>
+
+                <!-- Action buttons -->
+                <div class="relative mt-4 flex flex-wrap gap-2">
+                    <Button variant="outline" size="sm" :disabled="isSyncingAll" @click="syncAll">
+                        <RefreshCw class="mr-1.5 h-3.5 w-3.5" :class="{ 'animate-spin': isSyncingAll }" />
+                        Sync All
+                    </Button>
+                    <Button variant="outline" size="sm" as-child>
+                        <a :href="route('devices.download-apk')">
+                            <Download class="mr-1.5 h-3.5 w-3.5" />
+                            APK Download
+                        </a>
+                    </Button>
+                    <Button size="sm" as-child>
+                        <Link :href="route('devices.create')">
+                            <Plus class="mr-1.5 h-3.5 w-3.5" />
+                            Add Device
+                        </Link>
+                    </Button>
+                </div>
             </section>
 
+            <!-- Device card grid -->
             <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
                 <div class="p-4 sm:p-6">
-                    <DataTable
-                        :data="devices"
-                        :columns="columns"
-                        :empty-action-href="route('devices.create')"
-                        empty-action-label="Create Device"
-                        @row-click="openDeviceDetail"
-                    />
-                </div>
-            </section>
-
-            <DeviceDetailSheet
-                v-model:open="isDeviceDetailOpen"
-                :device="selectedDevice"
-            />
-
-            <Dialog v-model:open="showSecurityCodeReveal">
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Security Code Created</DialogTitle>
-                        <DialogDescription>
-                            This code is shown once. Save it now for tablet registration.
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div class="rounded-md bg-muted p-4 text-center font-mono text-xl tracking-widest">
-                        {{ revealedSecurityCode }}
+                    <div v-if="activeDevices.length === 0" class="py-16 text-center text-sm text-muted-foreground">
+                        No devices registered yet.
+                        <Link :href="route('devices.create')" class="ml-1 underline">Register the first device.</Link>
                     </div>
 
-                    <DialogFooter>
-                        <Button type="button" @click="showSecurityCodeReveal = false">Close</Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+                    <div v-else class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                        <div
+                            v-for="device in activeDevices"
+                            :key="device.id"
+                            class="group relative flex flex-col gap-3 rounded-[18px] border border-black/8 bg-white/60 p-4 transition-all duration-150 hover:border-white/20 hover:shadow-sm dark:border-white/10 dark:bg-white/[0.04]"
+                            :class="{
+                                'border-woosoo-red/30 dark:border-woosoo-red/20': deviceStatus(device) === 'offline',
+                                'border-[#f6b56d]/30 dark:border-[#f6b56d]/20': deviceStatus(device) === 'warning',
+                            }"
+                        >
+                            <!-- Card header: icon + name + status -->
+                            <div class="flex items-start gap-3">
+                                <div
+                                    class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+                                    :class="{
+                                        'bg-woosoo-green/10': deviceStatus(device) === 'online',
+                                        'bg-[#f6b56d]/10': deviceStatus(device) === 'warning',
+                                        'bg-woosoo-red/10': deviceStatus(device) === 'offline',
+                                    }"
+                                >
+                                    <MonitorSmartphone
+                                        class="h-4 w-4"
+                                        :class="{
+                                            'text-woosoo-green': deviceStatus(device) === 'online',
+                                            'text-[#f6b56d]': deviceStatus(device) === 'warning',
+                                            'text-woosoo-red': deviceStatus(device) === 'offline',
+                                        }"
+                                    />
+                                </div>
+                                <div class="min-w-0 flex-1">
+                                    <p class="truncate text-sm font-semibold text-foreground">{{ device.name }}</p>
+                                    <p class="mt-0.5 truncate text-xs text-muted-foreground">
+                                        {{ device.branch?.name ?? 'No branch' }}
+                                        <span v-if="device.table?.name"> · {{ device.table.name }}</span>
+                                    </p>
+                                </div>
+                                <!-- Status pill -->
+                                <span
+                                    class="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
+                                    :class="{
+                                        'bg-woosoo-green/10 text-woosoo-green': deviceStatus(device) === 'online',
+                                        'bg-[#f6b56d]/10 text-[#f6b56d]': deviceStatus(device) === 'warning',
+                                        'bg-woosoo-red/10 text-woosoo-red': deviceStatus(device) === 'offline',
+                                    }"
+                                >
+                                    <span class="h-1 w-1 rounded-full"
+                                        :class="{
+                                            'bg-woosoo-green': deviceStatus(device) === 'online',
+                                            'bg-[#f6b56d]': deviceStatus(device) === 'warning',
+                                            'bg-woosoo-red': deviceStatus(device) === 'offline',
+                                        }"
+                                    />
+                                    {{ deviceStatus(device) }}
+                                </span>
+                            </div>
+
+                            <!-- Data grid -->
+                            <div class="grid grid-cols-2 gap-x-3 gap-y-2 rounded-lg bg-black/[0.03] p-3 dark:bg-white/[0.03]">
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Table</p>
+                                    <p class="mt-0.5 font-mono text-xs font-medium">{{ device.table?.name ?? '—' }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Last Ping</p>
+                                    <p class="mt-0.5 font-mono text-xs font-medium">{{ lastPingLabel(device) }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">App Ver</p>
+                                    <p class="mt-0.5 font-mono text-xs font-medium">{{ device.app_version ?? device.latest_heartbeat?.app_version ?? '—' }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">IP</p>
+                                    <p class="mt-0.5 font-mono text-xs font-medium">{{ device.ip_address ?? '—' }}</p>
+                                </div>
+                            </div>
+
+                            <!-- Battery bar -->
+                            <div>
+                                <div class="flex items-center justify-between">
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Battery</p>
+                                    <p class="font-mono text-xs font-medium" :class="batteryColor(batteryLevel(device))">
+                                        {{ batteryLevel(device) != null ? `${batteryLevel(device)}%` : '—' }}
+                                    </p>
+                                </div>
+                                <div class="mt-1.5 h-1.5 overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                                    <div
+                                        v-if="batteryLevel(device) != null"
+                                        class="h-full rounded-full transition-all"
+                                        :class="batteryBg(batteryLevel(device))"
+                                        :style="{ width: `${batteryLevel(device)}%` }"
+                                    />
+                                </div>
+                                <p v-if="deviceStatus(device) === 'offline' && (batteryLevel(device) ?? 100) < 5" class="mt-1 text-[10px] font-medium text-woosoo-red">
+                                    ⚠ Battery depleted
+                                </p>
+                            </div>
+
+                            <!-- Footer: security + actions -->
+                            <div class="flex items-center justify-between">
+                                <span
+                                    class="inline-flex items-center gap-1 text-[10px] font-medium"
+                                    :class="isSecurityExpired(device) ? 'text-woosoo-red' : 'text-woosoo-green'"
+                                >
+                                    <component :is="isSecurityExpired(device) ? ShieldAlert : ShieldCheck" class="h-3 w-3" />
+                                    {{ isSecurityExpired(device) ? 'Expired' : 'Sec OK' }}
+                                </span>
+                                <div class="flex gap-1">
+                                    <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openDeviceDetail(device)">
+                                        <Eye class="mr-1 h-3 w-3" />
+                                        View
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        class="h-7 px-2 text-xs"
+                                        :disabled="isRestarting === device.id"
+                                        @click="confirmRestart(device)"
+                                    >
+                                        <RotateCcw class="mr-1 h-3 w-3" :class="{ 'animate-spin': isRestarting === device.id }" />
+                                        Restart
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
+
+        <DeviceDetailSheet v-model:open="isDeviceDetailOpen" :device="selectedDevice" />
+
+        <!-- Restart confirm -->
+        <AlertDialog :open="!!restartTarget" @update:open="(v) => { if (!v) restartTarget = null }">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Restart {{ restartTarget?.name }}?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        This will send a restart signal to the device. The tablet will briefly go offline.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction @click="executeRestart">Restart</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+
+        <!-- Security code reveal -->
+        <Dialog v-model:open="showSecurityCodeReveal">
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Security Code Created</DialogTitle>
+                    <DialogDescription>
+                        This code is shown once. Save it now for tablet registration.
+                    </DialogDescription>
+                </DialogHeader>
+                <div class="rounded-md bg-muted p-4 text-center font-mono text-xl tracking-widest">
+                    {{ revealedSecurityCode }}
+                </div>
+                <DialogFooter>
+                    <Button type="button" @click="showSecurityCodeReveal = false">Close</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>
- 

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -102,6 +102,8 @@ function recallTicket(ticketId: string) {
 }
 
 onMounted(() => {
+  document.body.classList.add('kds-active')
+
   try {
     const storedDensity = window.localStorage.getItem('kds-density')
     if (storedDensity === 'comfortable' || storedDensity === 'compact') {
@@ -117,6 +119,8 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  document.body.classList.remove('kds-active')
+
   if (timer) {
     clearInterval(timer)
     timer = null
@@ -204,8 +208,7 @@ onBeforeUnmount(() => {
   --kds-weight-caption: 500;
 }
 
-html:has(.kds-viewport),
-body:has(.kds-viewport) {
+body.kds-active {
   overflow: hidden;
   margin: 0;
   width: 100%;
@@ -256,7 +259,7 @@ body:has(.kds-viewport) {
   gap: 16px;
   border-bottom: 1px solid rgb(255 255 255 / 0.08);
   background: #0f0e12;
-  padding: 8px 20px;
+  padding: 8px;
 }
 
 .kds-density-toggle {
@@ -281,7 +284,7 @@ body:has(.kds-viewport) {
   min-height: 0;
   overflow: auto;
   background: #030304;
-  padding: 14px 20px 18px;
+  padding: 14px 8px 18px;
 }
 
 .kds-grid {
@@ -300,7 +303,7 @@ body:has(.kds-viewport) {
   align-items: center;
   border-bottom: 1px solid rgb(255 255 255 / 0.08);
   background: var(--kds-bg1);
-  padding: 0 20px;
+  padding: 0 8px;
 }
 
 :deep(.kds-brand),

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3'
-import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import 'vue-sonner/style.css'
@@ -9,9 +8,8 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { ACTIVE_STATES, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
-import { useKdsBoard } from '@/components/KDS/useKdsBoard'
-import { useKdsEcho } from '@/components/KDS/useKdsEcho'
+import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { kdsMockTickets } from '@/components/KDS/kdsMockData'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 
 const props = defineProps<{
@@ -19,13 +17,19 @@ const props = defineProps<{
   initialTickets: KdsTicket[]
 }>()
 
-const board = useKdsBoard(props.initialTickets)
-const tickets = board.tickets
-useKdsEcho(board)
+function seedTickets(source: KdsTicket[]): KdsTicket[] {
+  const base = source.length > 0 ? source : kdsMockTickets
+
+  return base.map((ticket) => ({
+    ...ticket,
+    items: ticket.items.map((item) => ({ ...item, done: item.done === true })),
+  }))
+}
+
+const tickets = ref<KdsTicket[]>(seedTickets(props.initialTickets))
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
-const canvasScale = ref(1)
 let timer: ReturnType<typeof setInterval> | null = null
 
 const activeTickets = computed(() => tickets.value.filter((ticket) => ACTIVE_STATES.includes(ticket.state)))
@@ -49,14 +53,38 @@ const counts = computed<Record<KdsFilter, number>>(() => ({
   voided: tickets.value.filter((ticket) => ticket.state === 'voided').length,
 }))
 
-function updateCanvasScale() {
-  if (typeof window === 'undefined') {
+function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicket) {
+  tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
+}
+
+function toggleItem(ticketId: string, itemId: string) {
+  updateTicket(ticketId, (ticket) => {
+    if (ticket.state === 'served' || ticket.state === 'voided') {
+      return ticket
+    }
+
+    return {
+      ...ticket,
+      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
+    }
+  })
+}
+
+function advanceTicket(ticketId: string) {
+  const ticket = tickets.value.find((item) => item.id === ticketId)
+
+  if (!ticket) {
     return
   }
 
-  const safeWidth = window.innerWidth - 16
-  const safeHeight = window.innerHeight - 16
-  canvasScale.value = Math.min(safeWidth / 1280, safeHeight / 800, 1.5)
+  if (!canAdvanceTicket(ticket)) {
+    toast.warning('Complete all checklist items first.', {
+      duration: 3500,
+    })
+    return
+  }
+
+  updateTicket(ticketId, (current) => applyAdvance(current, now.value))
 }
 
 function toggleDensity() {
@@ -65,53 +93,6 @@ function toggleDensity() {
     window.localStorage.setItem('kds-density', density.value)
   } catch {
     // Storage is optional for kiosk browsers.
-  }
-}
-
-function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicket) {
-  tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
-}
-
-async function toggleItem(ticketId: string, itemId: string) {
-  const ticket = tickets.value.find((t) => t.id === ticketId)
-  if (!ticket || ticket.state === 'served' || ticket.state === 'voided') {
-    return
-  }
-
-  // Optimistic update
-  updateTicket(ticketId, (t) => ({
-    ...t,
-    items: t.items.map((it) => it.id === itemId ? { ...it, done: !it.done } : it),
-  }))
-
-  try {
-    await axios.post(`/kds/items/${itemId}/toggle`)
-  } catch {
-    // Revert optimistic update on failure
-    updateTicket(ticketId, (t) => ({
-      ...t,
-      items: t.items.map((it) => it.id === itemId ? { ...it, done: !it.done } : it),
-    }))
-    toast.error('Could not update item. Please try again.', { duration: 3000 })
-  }
-}
-
-async function advanceTicket(ticketId: string) {
-  const ticket = tickets.value.find((t) => t.id === ticketId)
-  if (!ticket) {
-    return
-  }
-
-  if (!canAdvanceTicket(ticket)) {
-    toast.warning('Complete all checklist items first.', { duration: 3500 })
-    return
-  }
-
-  try {
-    await axios.post(`/kds/orders/${ticketId}/advance`)
-  } catch (err: any) {
-    const msg = err?.response?.data?.message ?? 'Could not advance ticket. Please try again.'
-    toast.error(msg, { duration: 3500 })
   }
 }
 
@@ -133,9 +114,6 @@ onMounted(() => {
     // Storage is optional for kiosk browsers.
   }
 
-  updateCanvasScale()
-  window.addEventListener('resize', updateCanvasScale)
-  window.addEventListener('orientationchange', updateCanvasScale)
   timer = setInterval(() => {
     now.value = Date.now()
   }, 1000)
@@ -146,8 +124,6 @@ onBeforeUnmount(() => {
     clearInterval(timer)
     timer = null
   }
-  window.removeEventListener('resize', updateCanvasScale)
-  window.removeEventListener('orientationchange', updateCanvasScale)
 })
 </script>
 
@@ -155,11 +131,7 @@ onBeforeUnmount(() => {
   <Head :title="title" />
 
   <main class="kds-viewport" aria-label="Woosoo Kitchen Display">
-    <div class="kds-device-frame">
-      <section
-        class="kds-canvas"
-        :style="{ transform: `scale(${canvasScale})` }"
-      >
+    <section class="kds-shell">
         <KdsCommandBar
           :active="counts.active"
           :new-count="counts.new"
@@ -197,8 +169,7 @@ onBeforeUnmount(() => {
           </div>
           <KdsEmptyState v-else />
         </section>
-      </section>
-    </div>
+    </section>
     <Toaster position="top-center" rich-colors />
   </main>
 </template>
@@ -231,14 +202,21 @@ onBeforeUnmount(() => {
 html:has(.kds-viewport),
 body:has(.kds-viewport) {
   overflow: hidden;
+  margin: 0;
+  width: 100%;
+  height: 100%;
   background: var(--kds-bg0);
 }
 </style>
 
 <style scoped>
 .kds-viewport {
+  display: flex;
+  flex-direction: column;
+  width: 100dvw;
+  height: 100dvh;
   min-height: 100dvh;
-  width: 100vw;
+  max-height: 100dvh;
   overflow: hidden;
   background:
     radial-gradient(circle at 18% 0%, rgb(246 181 109 / 0.08), transparent 24%),
@@ -247,30 +225,23 @@ body:has(.kds-viewport) {
   font-family: var(--kds-font-s);
   letter-spacing: 0;
   padding:
-    max(8px, env(safe-area-inset-top))
-    max(8px, env(safe-area-inset-right))
-    max(8px, env(safe-area-inset-bottom))
-    max(8px, env(safe-area-inset-left));
+    env(safe-area-inset-top, 0)
+    env(safe-area-inset-right, 0)
+    env(safe-area-inset-bottom, 0)
+    env(safe-area-inset-left, 0);
   touch-action: manipulation;
+  box-sizing: border-box;
 }
 
-.kds-device-frame {
+.kds-shell {
   display: grid;
-  min-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
-  place-items: center;
-}
-
-.kds-canvas {
-  display: grid;
-  grid-template-rows: 68px 58px minmax(0, 1fr);
-  width: 1280px;
-  height: 800px;
+  grid-template-rows: minmax(68px, auto) minmax(58px, auto) minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
-  transform-origin: center;
-  border: 1px solid rgb(255 255 255 / 0.08);
-  border-radius: 16px;
   background: var(--kds-bg0);
-  box-shadow: 0 32px 120px rgb(0 0 0 / 0.62);
 }
 
 .kds-subbar {
@@ -493,7 +464,7 @@ body:has(.kds-viewport) {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  min-height: 42px;
+  min-height: 44px;
   min-width: 116px;
   border: 1px solid rgb(255 255 255 / 0.08);
   border-radius: 8px;
@@ -685,7 +656,7 @@ body:has(.kds-viewport) {
 
 :deep(.kds-item-row) {
   width: 100%;
-  min-height: 48px;
+  min-height: 44px;
   gap: 10px;
   border: 0;
   border-top: 1px solid rgb(255 255 255 / 0.045);
@@ -699,7 +670,7 @@ body:has(.kds-viewport) {
 }
 
 :deep(.density-compact .kds-item-row) {
-  min-height: 40px;
+  min-height: 44px;
   font-size: 15px;
 }
 
@@ -815,7 +786,7 @@ body:has(.kds-viewport) {
 :deep(.kds-empty) {
   display: grid;
   height: 100%;
-  min-height: 540px;
+  min-height: 0;
   place-items: center;
   align-content: center;
   gap: 10px;
@@ -837,12 +808,6 @@ body:has(.kds-viewport) {
 
 :deep(.kds-empty span) {
   font-size: 16px;
-}
-
-@media (max-width: 900px), (max-height: 620px) {
-  .kds-viewport {
-    overflow: auto;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -9,7 +9,6 @@ import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
 import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
-import { kdsMockTickets } from '@/components/KDS/kdsMockData'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 
 const props = defineProps<{
@@ -18,9 +17,7 @@ const props = defineProps<{
 }>()
 
 function seedTickets(source: KdsTicket[]): KdsTicket[] {
-  const base = source.length > 0 ? source : kdsMockTickets
-
-  return base.map((ticket) => ({
+  return source.map((ticket) => ({
     ...ticket,
     items: ticket.items.map((item) => ({ ...item, done: item.done === true })),
   }))

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3'
+import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import 'vue-sonner/style.css'
@@ -8,7 +9,7 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { ACTIVE_STATES, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
 import { useKdsBoard } from '@/components/KDS/useKdsBoard'
 import { useKdsEcho } from '@/components/KDS/useKdsEcho'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
@@ -71,34 +72,47 @@ function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicke
   tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
 }
 
-function toggleItem(ticketId: string, itemId: string) {
-  updateTicket(ticketId, (ticket) => {
-    if (ticket.state === 'served' || ticket.state === 'voided') {
-      return ticket
-    }
+async function toggleItem(ticketId: string, itemId: string) {
+  const ticket = tickets.value.find((t) => t.id === ticketId)
+  if (!ticket || ticket.state === 'served' || ticket.state === 'voided') {
+    return
+  }
 
-    return {
-      ...ticket,
-      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
-    }
-  })
+  // Optimistic update
+  updateTicket(ticketId, (t) => ({
+    ...t,
+    items: t.items.map((it) => it.id === itemId ? { ...it, done: !it.done } : it),
+  }))
+
+  try {
+    await axios.post(`/kds/items/${itemId}/toggle`)
+  } catch {
+    // Revert optimistic update on failure
+    updateTicket(ticketId, (t) => ({
+      ...t,
+      items: t.items.map((it) => it.id === itemId ? { ...it, done: !it.done } : it),
+    }))
+    toast.error('Could not update item. Please try again.', { duration: 3000 })
+  }
 }
 
-function advanceTicket(ticketId: string) {
-  const ticket = tickets.value.find((item) => item.id === ticketId)
-
+async function advanceTicket(ticketId: string) {
+  const ticket = tickets.value.find((t) => t.id === ticketId)
   if (!ticket) {
     return
   }
 
   if (!canAdvanceTicket(ticket)) {
-    toast.warning('Complete all checklist items first.', {
-      duration: 3500,
-    })
+    toast.warning('Complete all checklist items first.', { duration: 3500 })
     return
   }
 
-  updateTicket(ticketId, (current) => applyAdvance(current, now.value))
+  try {
+    await axios.post(`/kds/orders/${ticketId}/advance`)
+  } catch (err: any) {
+    const msg = err?.response?.data?.message ?? 'Could not advance ticket. Please try again.'
+    toast.error(msg, { duration: 3500 })
+  }
 }
 
 function recallTicket(ticketId: string) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -8,8 +8,11 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { postKdsAdvance, postKdsToggleItem } from '@/components/KDS/kdsApi'
+import { ACTIVE_STATES, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
+import { useKdsBoard } from '@/components/KDS/useKdsBoard'
+import { useKdsEcho } from '@/components/KDS/useKdsEcho'
 
 const props = defineProps<{
   title: string
@@ -19,14 +22,20 @@ const props = defineProps<{
 function seedTickets(source: KdsTicket[]): KdsTicket[] {
   return source.map((ticket) => ({
     ...ticket,
+    state: ticket.state === 'ready' ? 'preparing' : ticket.state,
     items: ticket.items.map((item) => ({ ...item, done: item.done === true })),
   }))
 }
 
-const tickets = ref<KdsTicket[]>(seedTickets(props.initialTickets))
+const board = useKdsBoard(seedTickets(props.initialTickets))
+useKdsEcho(board)
+
+const tickets = board.tickets
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
+const pendingAdvance = ref<Set<string>>(new Set())
+const pendingToggle = ref<Set<string>>(new Set())
 let timer: ReturnType<typeof setInterval> | null = null
 
 const activeTickets = computed(() => tickets.value.filter((ticket) => ACTIVE_STATES.includes(ticket.state)))
@@ -44,30 +53,35 @@ const counts = computed<Record<KdsFilter, number>>(() => ({
   active: activeTickets.value.length,
   overdue: filterTickets(tickets.value, 'overdue', now.value).length,
   new: tickets.value.filter((ticket) => ticket.state === 'new').length,
-  preparing: tickets.value.filter((ticket) => ticket.state === 'preparing').length,
-  ready: tickets.value.filter((ticket) => ticket.state === 'ready').length,
+  preparing: tickets.value.filter((ticket) => ticket.state === 'preparing' || ticket.state === 'ready').length,
+  ready: 0,
   served: tickets.value.filter((ticket) => ticket.state === 'served').length,
   voided: tickets.value.filter((ticket) => ticket.state === 'voided').length,
 }))
 
-function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicket) {
-  tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
+async function toggleItem(ticketId: string, itemId: string) {
+  const ticket = tickets.value.find((item) => item.id === ticketId)
+
+  if (!ticket || ticket.state === 'served' || ticket.state === 'voided') {
+    return
+  }
+
+  if (pendingToggle.value.has(itemId)) {
+    return
+  }
+
+  pendingToggle.value.add(itemId)
+
+  try {
+    await postKdsToggleItem(itemId)
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Unable to update item.')
+  } finally {
+    pendingToggle.value.delete(itemId)
+  }
 }
 
-function toggleItem(ticketId: string, itemId: string) {
-  updateTicket(ticketId, (ticket) => {
-    if (ticket.state === 'served' || ticket.state === 'voided') {
-      return ticket
-    }
-
-    return {
-      ...ticket,
-      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
-    }
-  })
-}
-
-function advanceTicket(ticketId: string) {
+async function advanceTicket(ticketId: string) {
   const ticket = tickets.value.find((item) => item.id === ticketId)
 
   if (!ticket) {
@@ -81,7 +95,19 @@ function advanceTicket(ticketId: string) {
     return
   }
 
-  updateTicket(ticketId, (current) => applyAdvance(current, now.value))
+  if (pendingAdvance.value.has(ticketId)) {
+    return
+  }
+
+  pendingAdvance.value.add(ticketId)
+
+  try {
+    await postKdsAdvance(ticketId)
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Unable to advance order.')
+  } finally {
+    pendingAdvance.value.delete(ticketId)
+  }
 }
 
 function toggleDensity() {
@@ -91,14 +117,6 @@ function toggleDensity() {
   } catch {
     // Storage is optional for kiosk browsers.
   }
-}
-
-function recallTicket(ticketId: string) {
-  updateTicket(ticketId, (ticket) => applyRecall(ticket, now.value))
-  selectedFilter.value = 'active'
-  toast.success('Ticket recalled to the line.', {
-    duration: 3000,
-  })
 }
 
 onMounted(() => {
@@ -137,7 +155,6 @@ onBeforeUnmount(() => {
           :active="counts.active"
           :new-count="counts.new"
           :preparing="counts.preparing"
-          :ready="counts.ready"
           :overdue="counts.overdue"
           :clock="clockLabel"
           :date-label="dateLabel"
@@ -164,7 +181,6 @@ onBeforeUnmount(() => {
               :now="now"
               :density="density"
               @advance="advanceTicket"
-              @recall="recallTicket"
               @toggle-item="toggleItem"
             />
           </div>
@@ -357,7 +373,7 @@ body.kds-active {
 
 :deep(.kds-metrics) {
   display: grid;
-  grid-template-columns: repeat(5, minmax(80px, 1fr));
+  grid-template-columns: repeat(4, minmax(80px, 1fr));
   height: 100%;
 }
 

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -197,6 +197,14 @@ onBeforeUnmount(() => {
   --kds-font-d: Raleway, ui-sans-serif, system-ui, sans-serif;
   --kds-font-s: Kanit, ui-sans-serif, system-ui, sans-serif;
   --kds-font-m: "JetBrains Mono", "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  /* Weight scale — see .interface-design/system.md. Capped at 700 to de-shout. */
+  --kds-weight-display: 700;
+  --kds-weight-hero: 700;
+  --kds-weight-cta: 700;
+  --kds-weight-label: 600;
+  --kds-weight-body: 500;
+  --kds-weight-data: 600;
+  --kds-weight-caption: 500;
 }
 
 html:has(.kds-viewport),
@@ -262,7 +270,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg1);
   font-family: var(--kds-font-s);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: var(--kds-weight-label);
   padding: 0 16px;
   text-transform: uppercase;
 }
@@ -334,14 +342,14 @@ body:has(.kds-viewport) {
 :deep(.kds-brand-name) {
   font-family: var(--kds-font-d);
   font-size: 16px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-display);
   line-height: 1;
 }
 
 :deep(.kds-brand-sub) {
   color: var(--kds-accent);
   font-size: 11px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   letter-spacing: 0.14em;
   line-height: 1.15;
   text-transform: uppercase;
@@ -364,13 +372,15 @@ body:has(.kds-viewport) {
 :deep(.kds-metric strong) {
   font-family: var(--kds-font-m);
   font-size: 24px;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--kds-weight-data);
   line-height: 1;
 }
 
 :deep(.kds-metric span) {
   color: var(--kds-fg3);
   font-size: 9px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -402,7 +412,7 @@ body:has(.kds-viewport) {
   gap: 7px;
   border-radius: 999px;
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   padding: 0 13px;
   text-transform: uppercase;
 }
@@ -434,6 +444,8 @@ body:has(.kds-viewport) {
 :deep(.kds-clock strong) {
   display: block;
   font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--kds-weight-data);
   line-height: 1;
 }
 
@@ -441,7 +453,7 @@ body:has(.kds-viewport) {
   display: block;
   color: var(--kds-fg3);
   font-size: 9px;
-  font-weight: 800;
+  font-weight: var(--kds-weight-caption);
   letter-spacing: 0.14em;
   margin-top: 3px;
   text-transform: uppercase;
@@ -472,7 +484,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg1);
   font-family: var(--kds-font-s);
   font-size: 13px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   padding: 0 14px;
   text-transform: uppercase;
 }
@@ -487,6 +499,8 @@ body:has(.kds-viewport) {
   color: var(--kds-fg2);
   font-family: var(--kds-font-m);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--kds-weight-data);
 }
 
 :deep(.kds-filter-chip.is-active) {
@@ -565,7 +579,7 @@ body:has(.kds-viewport) {
 :deep(.kds-status-block > span) {
   color: var(--kds-fg3);
   font-size: 10px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -574,7 +588,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg0);
   font-family: var(--kds-font-s);
   font-size: 32px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-hero);
   line-height: 1;
 }
 
@@ -582,6 +596,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg2);
   font-family: var(--kds-font-m);
   font-size: 11px;
+  font-weight: var(--kds-weight-caption);
   margin-top: 7px;
 }
 
@@ -616,7 +631,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg1);
   font-family: var(--kds-font-s);
   font-size: 12px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-label);
   letter-spacing: 0.12em;
   padding: 4px 10px;
   text-transform: uppercase;
@@ -637,7 +652,7 @@ body:has(.kds-viewport) {
   border-bottom: 1px solid rgb(255 255 255 / 0.06);
   color: var(--kds-void);
   font-size: 13px;
-  font-weight: 700;
+  font-weight: var(--kds-weight-body);
   margin: 0;
   padding: 10px 16px;
 }
@@ -664,7 +679,7 @@ body:has(.kds-viewport) {
   color: var(--kds-fg0);
   font-family: var(--kds-font-s);
   font-size: 16px;
-  font-weight: 800;
+  font-weight: var(--kds-weight-body);
   padding: 0 16px;
   text-align: left;
 }
@@ -701,6 +716,8 @@ body:has(.kds-viewport) {
 :deep(.kds-item-qty) {
   color: var(--kds-accent);
   font-family: var(--kds-font-m);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--kds-weight-data);
   min-width: 34px;
 }
 
@@ -762,7 +779,7 @@ body:has(.kds-viewport) {
   color: #17100b;
   font-family: var(--kds-font-s);
   font-size: 14px;
-  font-weight: 900;
+  font-weight: var(--kds-weight-cta);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -804,10 +821,12 @@ body:has(.kds-viewport) {
   color: var(--kds-fg0);
   font-family: var(--kds-font-d);
   font-size: 34px;
+  font-weight: var(--kds-weight-display);
 }
 
 :deep(.kds-empty span) {
   font-size: 16px;
+  font-weight: var(--kds-weight-body);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -8,18 +8,19 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, elapsedFor, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
-import { kdsMockTickets } from '@/components/KDS/kdsMockData'
+import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { useKdsBoard } from '@/components/KDS/useKdsBoard'
+import { useKdsEcho } from '@/components/KDS/useKdsEcho'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 
-defineProps<{
+const props = defineProps<{
   title: string
+  initialTickets: KdsTicket[]
 }>()
 
-const tickets = ref<KdsTicket[]>(kdsMockTickets.map((ticket) => ({
-  ...ticket,
-  items: ticket.items.map((item) => ({ ...item })),
-})))
+const board = useKdsBoard(props.initialTickets)
+const tickets = board.tickets
+useKdsEcho(board)
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3'
+import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import 'vue-sonner/style.css'
@@ -9,6 +10,7 @@ import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
 import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { useKdsBoard } from '@/components/KDS/useKdsBoard'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 
 const props = defineProps<{
@@ -23,7 +25,8 @@ function seedTickets(source: KdsTicket[]): KdsTicket[] {
   }))
 }
 
-const tickets = ref<KdsTicket[]>(seedTickets(props.initialTickets))
+const board = useKdsBoard(seedTickets(props.initialTickets))
+const tickets = board.tickets
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
@@ -54,20 +57,34 @@ function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicke
   tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
 }
 
-function toggleItem(ticketId: string, itemId: string) {
-  updateTicket(ticketId, (ticket) => {
-    if (ticket.state === 'served' || ticket.state === 'voided') {
-      return ticket
-    }
+async function toggleItem(ticketId: string, itemId: string) {
+  const ticket = tickets.value.find((t) => t.id === ticketId)
 
-    return {
-      ...ticket,
-      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
-    }
-  })
+  if (!ticket || ticket.state === 'served' || ticket.state === 'voided') {
+    return
+  }
+
+  const prevDone = ticket.items.find((item) => item.id === itemId)?.done ?? false
+
+  // Optimistic flip; reconcile to the server's authoritative state on success.
+  updateTicket(ticketId, (current) => ({
+    ...current,
+    items: current.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
+  }))
+
+  try {
+    const { data } = await axios.post(route('kds.toggle-item', itemId))
+    board.applyItemToggle({ order_id: ticketId, item_id: itemId, done: data.done, done_at: data.done_at })
+  } catch (error) {
+    updateTicket(ticketId, (current) => ({
+      ...current,
+      items: current.items.map((item) => item.id === itemId ? { ...item, done: prevDone } : item),
+    }))
+    toast.error((error as any)?.response?.data?.message ?? 'Could not update item.', { duration: 3500 })
+  }
 }
 
-function advanceTicket(ticketId: string) {
+async function advanceTicket(ticketId: string) {
   const ticket = tickets.value.find((item) => item.id === ticketId)
 
   if (!ticket) {
@@ -81,7 +98,16 @@ function advanceTicket(ticketId: string) {
     return
   }
 
+  // Snapshot for rollback, then advance optimistically (client nextStateFor mirrors server nextStatus).
+  const snapshot = ticket
   updateTicket(ticketId, (current) => applyAdvance(current, now.value))
+
+  try {
+    await axios.post(route('kds.advance', ticketId))
+  } catch (error) {
+    updateTicket(ticketId, () => snapshot)
+    toast.error((error as any)?.response?.data?.message ?? 'Could not advance ticket.', { duration: 3500 })
+  }
 }
 
 function toggleDensity() {
@@ -94,6 +120,8 @@ function toggleDensity() {
 }
 
 function recallTicket(ticketId: string) {
+  // Wave 3: wire to POST /kds/orders/{order}/recall (route + enum edge + contract not yet built).
+  // Until then recall is local-only and does not persist.
   updateTicket(ticketId, (ticket) => applyRecall(ticket, now.value))
   selectedFilter.value = 'active'
   toast.success('Ticket recalled to the line.', {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -1,0 +1,842 @@
+<script setup lang="ts">
+import { Head } from '@inertiajs/vue3'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import 'vue-sonner/style.css'
+import { Toaster } from '@/components/ui/sonner'
+import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
+import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
+import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
+import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
+import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, elapsedFor, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { kdsMockTickets } from '@/components/KDS/kdsMockData'
+import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
+
+defineProps<{
+  title: string
+}>()
+
+const tickets = ref<KdsTicket[]>(kdsMockTickets.map((ticket) => ({
+  ...ticket,
+  items: ticket.items.map((item) => ({ ...item })),
+})))
+const selectedFilter = ref<KdsFilter>('active')
+const density = ref<KdsDensity>('comfortable')
+const now = ref(Date.now())
+const canvasScale = ref(1)
+let timer: ReturnType<typeof setInterval> | null = null
+
+const activeTickets = computed(() => tickets.value.filter((ticket) => ACTIVE_STATES.includes(ticket.state)))
+const visibleTickets = computed(() => sortTickets(filterTickets(tickets.value, selectedFilter.value, now.value), now.value))
+const clockLabel = computed(() => new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+}).format(now.value))
+const dateLabel = computed(() => new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  month: 'short',
+  day: 'numeric',
+}).format(now.value))
+const counts = computed<Record<KdsFilter, number>>(() => ({
+  active: activeTickets.value.length,
+  overdue: filterTickets(tickets.value, 'overdue', now.value).length,
+  new: tickets.value.filter((ticket) => ticket.state === 'new').length,
+  preparing: tickets.value.filter((ticket) => ticket.state === 'preparing').length,
+  ready: tickets.value.filter((ticket) => ticket.state === 'ready').length,
+  served: tickets.value.filter((ticket) => ticket.state === 'served').length,
+  voided: tickets.value.filter((ticket) => ticket.state === 'voided').length,
+}))
+
+function updateCanvasScale() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const safeWidth = window.innerWidth - 16
+  const safeHeight = window.innerHeight - 16
+  canvasScale.value = Math.min(safeWidth / 1280, safeHeight / 800, 1.5)
+}
+
+function toggleDensity() {
+  density.value = density.value === 'comfortable' ? 'compact' : 'comfortable'
+  try {
+    window.localStorage.setItem('kds-density', density.value)
+  } catch {
+    // Storage is optional for kiosk browsers.
+  }
+}
+
+function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicket) {
+  tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
+}
+
+function toggleItem(ticketId: string, itemId: string) {
+  updateTicket(ticketId, (ticket) => {
+    if (ticket.state === 'served' || ticket.state === 'voided') {
+      return ticket
+    }
+
+    return {
+      ...ticket,
+      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
+    }
+  })
+}
+
+function advanceTicket(ticketId: string) {
+  const ticket = tickets.value.find((item) => item.id === ticketId)
+
+  if (!ticket) {
+    return
+  }
+
+  if (!canAdvanceTicket(ticket)) {
+    toast.warning('Complete all checklist items first.', {
+      duration: 3500,
+    })
+    return
+  }
+
+  updateTicket(ticketId, (current) => applyAdvance(current, now.value))
+}
+
+function recallTicket(ticketId: string) {
+  updateTicket(ticketId, (ticket) => applyRecall(ticket, now.value))
+  selectedFilter.value = 'active'
+  toast.success('Ticket recalled to the line.', {
+    duration: 3000,
+  })
+}
+
+onMounted(() => {
+  try {
+    const storedDensity = window.localStorage.getItem('kds-density')
+    if (storedDensity === 'comfortable' || storedDensity === 'compact') {
+      density.value = storedDensity
+    }
+  } catch {
+    // Storage is optional for kiosk browsers.
+  }
+
+  updateCanvasScale()
+  window.addEventListener('resize', updateCanvasScale)
+  window.addEventListener('orientationchange', updateCanvasScale)
+  timer = setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (timer) {
+    clearInterval(timer)
+    timer = null
+  }
+  window.removeEventListener('resize', updateCanvasScale)
+  window.removeEventListener('orientationchange', updateCanvasScale)
+})
+</script>
+
+<template>
+  <Head :title="title" />
+
+  <main class="kds-viewport" aria-label="Woosoo Kitchen Display">
+    <div class="kds-device-frame">
+      <section
+        class="kds-canvas"
+        :style="{ transform: `scale(${canvasScale})` }"
+      >
+        <KdsCommandBar
+          :active="counts.active"
+          :new-count="counts.new"
+          :preparing="counts.preparing"
+          :ready="counts.ready"
+          :overdue="counts.overdue"
+          :clock="clockLabel"
+          :date-label="dateLabel"
+        />
+
+        <div class="kds-subbar">
+          <KdsFilterChips v-model="selectedFilter" :counts="counts" />
+          <button
+            type="button"
+            class="kds-density-toggle"
+            :aria-pressed="density === 'compact'"
+            @click="toggleDensity"
+          >
+            {{ density === 'comfortable' ? 'Comfortable' : 'Compact' }}
+          </button>
+        </div>
+
+        <section class="kds-grid-wrap" aria-label="Ticket queue">
+          <div v-if="visibleTickets.length" class="kds-grid" :class="`density-${density}`">
+            <KdsTicketCard
+              v-for="ticket in visibleTickets"
+              :key="ticket.id"
+              :ticket="ticket"
+              :now="now"
+              :density="density"
+              @advance="advanceTicket"
+              @recall="recallTicket"
+              @toggle-item="toggleItem"
+            />
+          </div>
+          <KdsEmptyState v-else />
+        </section>
+      </section>
+    </div>
+    <Toaster position="top-center" rich-colors />
+  </main>
+</template>
+
+<style>
+:root {
+  --kds-bg0: #050506;
+  --kds-bg1: #0d0c10;
+  --kds-bg2: #151318;
+  --kds-bg3: #1d1a21;
+  --kds-bg4: #25212a;
+  --kds-fg0: #f4efe7;
+  --kds-fg1: #ddd4c7;
+  --kds-fg2: #a89d8e;
+  --kds-fg3: #70675e;
+  --kds-accent: #f6b56d;
+  --kds-new: #85a9d8;
+  --kds-preparing: #de8a48;
+  --kds-ready: #6fc778;
+  --kds-served: #96918e;
+  --kds-warning: #d8a440;
+  --kds-overdue: #d65540;
+  --kds-refill: #5cb6b0;
+  --kds-void: #a892ad;
+  --kds-font-d: Raleway, ui-sans-serif, system-ui, sans-serif;
+  --kds-font-s: Kanit, ui-sans-serif, system-ui, sans-serif;
+  --kds-font-m: "JetBrains Mono", "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+html:has(.kds-viewport),
+body:has(.kds-viewport) {
+  overflow: hidden;
+  background: var(--kds-bg0);
+}
+</style>
+
+<style scoped>
+.kds-viewport {
+  min-height: 100dvh;
+  width: 100vw;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 0%, rgb(246 181 109 / 0.08), transparent 24%),
+    linear-gradient(180deg, #0c0b0f 0%, #040405 100%);
+  color: var(--kds-fg0);
+  font-family: var(--kds-font-s);
+  letter-spacing: 0;
+  padding:
+    max(8px, env(safe-area-inset-top))
+    max(8px, env(safe-area-inset-right))
+    max(8px, env(safe-area-inset-bottom))
+    max(8px, env(safe-area-inset-left));
+  touch-action: manipulation;
+}
+
+.kds-device-frame {
+  display: grid;
+  min-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)));
+  place-items: center;
+}
+
+.kds-canvas {
+  display: grid;
+  grid-template-rows: 68px 58px minmax(0, 1fr);
+  width: 1280px;
+  height: 800px;
+  overflow: hidden;
+  transform-origin: center;
+  border: 1px solid rgb(255 255 255 / 0.08);
+  border-radius: 16px;
+  background: var(--kds-bg0);
+  box-shadow: 0 32px 120px rgb(0 0 0 / 0.62);
+}
+
+.kds-subbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  background: #0f0e12;
+  padding: 8px 20px;
+}
+
+.kds-density-toggle {
+  min-height: 44px;
+  border: 1px solid rgb(255 255 255 / 0.1);
+  border-radius: 8px;
+  background: var(--kds-bg2);
+  color: var(--kds-fg1);
+  font-family: var(--kds-font-s);
+  font-size: 12px;
+  font-weight: 800;
+  padding: 0 16px;
+  text-transform: uppercase;
+}
+
+.kds-density-toggle:focus-visible {
+  outline: 3px solid rgb(246 181 109 / 0.45);
+  outline-offset: 2px;
+}
+
+.kds-grid-wrap {
+  min-height: 0;
+  overflow: auto;
+  background: #030304;
+  padding: 14px 20px 18px;
+}
+
+.kds-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.kds-grid.density-compact {
+  gap: 10px;
+}
+
+:deep(.kds-command) {
+  display: grid;
+  grid-template-columns: 280px 1fr 310px;
+  align-items: center;
+  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  background: var(--kds-bg1);
+  padding: 0 20px;
+}
+
+:deep(.kds-brand),
+:deep(.kds-status-clock),
+:deep(.kds-online),
+:deep(.kds-rush),
+:deep(.kds-clock),
+:deep(.kds-filters),
+:deep(.kds-ticket-type-row),
+:deep(.kds-ticket-footer),
+:deep(.kds-status-block),
+:deep(.kds-item-row) {
+  display: flex;
+  align-items: center;
+}
+
+:deep(.kds-brand) {
+  gap: 10px;
+}
+
+:deep(.kds-brand-mark) {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  background: var(--kds-accent);
+  color: #14100c;
+}
+
+:deep(.kds-brand-mark svg) {
+  width: 20px;
+  height: 20px;
+}
+
+:deep(.kds-brand-name) {
+  font-family: var(--kds-font-d);
+  font-size: 16px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+:deep(.kds-brand-sub) {
+  color: var(--kds-accent);
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  line-height: 1.15;
+  text-transform: uppercase;
+}
+
+:deep(.kds-metrics) {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(80px, 1fr));
+  height: 100%;
+}
+
+:deep(.kds-metric) {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  border-left: 1px solid rgb(255 255 255 / 0.08);
+  gap: 4px;
+}
+
+:deep(.kds-metric strong) {
+  font-family: var(--kds-font-m);
+  font-size: 24px;
+  line-height: 1;
+}
+
+:deep(.kds-metric span) {
+  color: var(--kds-fg3);
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+:deep(.kds-metric .is-new) {
+  color: var(--kds-new);
+}
+
+:deep(.kds-metric .is-preparing) {
+  color: var(--kds-preparing);
+}
+
+:deep(.kds-metric .is-ready) {
+  color: var(--kds-ready);
+}
+
+:deep(.kds-metric .is-overdue) {
+  color: var(--kds-overdue);
+}
+
+:deep(.kds-status-clock) {
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+:deep(.kds-online),
+:deep(.kds-rush) {
+  min-height: 30px;
+  gap: 7px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 900;
+  padding: 0 13px;
+  text-transform: uppercase;
+}
+
+:deep(.kds-online) {
+  border: 1px solid rgb(82 190 102 / 0.35);
+  background: rgb(82 190 102 / 0.16);
+  color: #7fdb88;
+}
+
+:deep(.kds-rush) {
+  border: 1px solid rgb(214 85 64 / 0.35);
+  background: rgb(214 85 64 / 0.14);
+  color: var(--kds-overdue);
+}
+
+:deep(.kds-online svg),
+:deep(.kds-rush svg),
+:deep(.kds-clock svg) {
+  width: 16px;
+  height: 16px;
+}
+
+:deep(.kds-clock) {
+  gap: 8px;
+  font-family: var(--kds-font-m);
+}
+
+:deep(.kds-clock strong) {
+  display: block;
+  font-size: 22px;
+  line-height: 1;
+}
+
+:deep(.kds-clock span) {
+  display: block;
+  color: var(--kds-fg3);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  margin-top: 3px;
+  text-transform: uppercase;
+}
+
+:deep(.kds-filters) {
+  gap: 8px;
+  min-width: 0;
+}
+
+:deep(.kds-filter-divider) {
+  width: 1px;
+  height: 34px;
+  background: rgb(255 255 255 / 0.08);
+  margin: 0 6px;
+}
+
+:deep(.kds-filter-chip) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 42px;
+  min-width: 116px;
+  border: 1px solid rgb(255 255 255 / 0.08);
+  border-radius: 8px;
+  background: var(--kds-bg2);
+  color: var(--kds-fg1);
+  font-family: var(--kds-font-s);
+  font-size: 13px;
+  font-weight: 900;
+  padding: 0 14px;
+  text-transform: uppercase;
+}
+
+:deep(.kds-filter-chip strong) {
+  display: grid;
+  place-items: center;
+  min-width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.06);
+  color: var(--kds-fg2);
+  font-family: var(--kds-font-m);
+  font-size: 12px;
+}
+
+:deep(.kds-filter-chip.is-active) {
+  border-color: rgb(133 169 216 / 0.45);
+  background: rgb(30 57 88 / 0.45);
+  color: var(--kds-fg0);
+}
+
+:deep(.kds-filter-chip:focus-visible) {
+  outline: 3px solid rgb(246 181 109 / 0.45);
+  outline-offset: 2px;
+}
+
+:deep(.kds-ticket) {
+  display: flex;
+  min-height: 312px;
+  overflow: hidden;
+  flex-direction: column;
+  border: 1px solid rgb(255 255 255 / 0.08);
+  border-left-width: 4px;
+  border-radius: 10px;
+  background: var(--kds-bg2);
+  box-shadow: 0 18px 44px rgb(0 0 0 / 0.32);
+}
+
+:deep(.kds-ticket.density-compact) {
+  min-height: 248px;
+}
+
+:deep(.kds-ticket.state-new) {
+  border-left-color: var(--kds-new);
+}
+
+:deep(.kds-ticket.state-preparing) {
+  border-left-color: var(--kds-preparing);
+}
+
+:deep(.kds-ticket.state-ready) {
+  border-left-color: var(--kds-ready);
+}
+
+:deep(.kds-ticket.state-served) {
+  border-left-color: var(--kds-served);
+}
+
+:deep(.kds-ticket.state-voided) {
+  border-left-color: var(--kds-void);
+  opacity: 0.72;
+}
+
+:deep(.kds-ticket.urgency-over:not(.is-terminal)) {
+  border-color: rgb(214 85 64 / 0.45);
+  border-left-color: var(--kds-overdue);
+  box-shadow: 0 0 0 1px rgb(214 85 64 / 0.16), 0 24px 56px rgb(214 85 64 / 0.13);
+}
+
+:deep(.kds-ticket-header) {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 14px 16px 10px;
+}
+
+:deep(.kds-ticket-pane) {
+  display: grid;
+  align-content: start;
+  min-height: 72px;
+}
+
+:deep(.kds-ticket-pane.is-right) {
+  text-align: right;
+}
+
+:deep(.kds-ticket-pane span),
+:deep(.kds-items-head),
+:deep(.kds-status-block > span) {
+  color: var(--kds-fg3);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+:deep(.kds-ticket-pane strong) {
+  color: var(--kds-fg0);
+  font-family: var(--kds-font-s);
+  font-size: 32px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+:deep(.kds-ticket-pane small) {
+  color: var(--kds-fg2);
+  font-family: var(--kds-font-m);
+  font-size: 11px;
+  margin-top: 7px;
+}
+
+:deep(.kds-timer) {
+  font-family: var(--kds-font-m) !important;
+  font-variant-numeric: tabular-nums;
+}
+
+:deep(.urgency-warn .kds-timer) {
+  color: var(--kds-warning);
+}
+
+:deep(.urgency-over .kds-timer) {
+  color: var(--kds-overdue);
+}
+
+:deep(.is-struck) {
+  text-decoration: line-through;
+  text-decoration-thickness: 3px;
+}
+
+:deep(.kds-ticket-type-row) {
+  gap: 8px;
+  padding: 0 16px 10px;
+}
+
+:deep(.kds-pill),
+:deep(.kds-recalled),
+:deep(.kds-status-badge) {
+  border-color: rgb(255 255 255 / 0.1);
+  background: rgb(255 255 255 / 0.03);
+  color: var(--kds-fg1);
+  font-family: var(--kds-font-s);
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+:deep(.kds-pill.is-refill) {
+  border-color: rgb(92 182 176 / 0.32);
+  background: rgb(92 182 176 / 0.18);
+  color: #77d4cf;
+}
+
+:deep(.kds-recalled) {
+  color: var(--kds-accent);
+}
+
+:deep(.kds-void-reason) {
+  border-top: 1px solid rgb(255 255 255 / 0.06);
+  border-bottom: 1px solid rgb(255 255 255 / 0.06);
+  color: var(--kds-void);
+  font-size: 13px;
+  font-weight: 700;
+  margin: 0;
+  padding: 10px 16px;
+}
+
+:deep(.kds-items) {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+:deep(.kds-items-head) {
+  justify-content: space-between;
+  padding: 0 16px 8px;
+}
+
+:deep(.kds-item-row) {
+  width: 100%;
+  min-height: 48px;
+  gap: 10px;
+  border: 0;
+  border-top: 1px solid rgb(255 255 255 / 0.045);
+  background: transparent;
+  color: var(--kds-fg0);
+  font-family: var(--kds-font-s);
+  font-size: 16px;
+  font-weight: 800;
+  padding: 0 16px;
+  text-align: left;
+}
+
+:deep(.density-compact .kds-item-row) {
+  min-height: 40px;
+  font-size: 15px;
+}
+
+:deep(.kds-item-row:not(:disabled):active) {
+  background: rgb(246 181 109 / 0.08);
+}
+
+:deep(.kds-item-row:focus-visible) {
+  outline: 3px solid rgb(246 181 109 / 0.45);
+  outline-offset: -3px;
+}
+
+:deep(.kds-item-row.is-done) {
+  color: rgb(244 239 231 / 0.62);
+}
+
+:deep(.kds-item-row.is-disabled) {
+  cursor: not-allowed;
+}
+
+:deep(.kds-item-check) {
+  width: 24px;
+  height: 24px;
+  border-color: rgb(255 255 255 / 0.22);
+  border-radius: 6px;
+}
+
+:deep(.kds-item-qty) {
+  color: var(--kds-accent);
+  font-family: var(--kds-font-m);
+  min-width: 34px;
+}
+
+:deep(.kds-item-name) {
+  min-width: 0;
+}
+
+:deep(.kds-safety) {
+  color: var(--kds-warning);
+}
+
+:deep(.kds-ticket-footer) {
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid rgb(255 255 255 / 0.06);
+  padding: 12px 16px 14px;
+}
+
+:deep(.kds-status-block) {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+:deep(.kds-status-badge) {
+  gap: 6px;
+  letter-spacing: 0.08em;
+}
+
+:deep(.kds-status-badge.state-new) {
+  border-color: rgb(133 169 216 / 0.35);
+  background: rgb(133 169 216 / 0.12);
+  color: var(--kds-new);
+}
+
+:deep(.kds-status-badge.state-preparing) {
+  border-color: rgb(222 138 72 / 0.35);
+  background: rgb(222 138 72 / 0.12);
+  color: var(--kds-preparing);
+}
+
+:deep(.kds-status-badge.state-ready) {
+  border-color: rgb(111 199 120 / 0.35);
+  background: rgb(111 199 120 / 0.12);
+  color: var(--kds-ready);
+}
+
+:deep(.kds-status-badge.state-served) {
+  color: var(--kds-served);
+}
+
+:deep(.kds-status-badge.state-voided) {
+  color: var(--kds-void);
+}
+
+:deep(.kds-card-action) {
+  min-width: 190px;
+  min-height: 56px;
+  color: #17100b;
+  font-family: var(--kds-font-s);
+  font-size: 14px;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+:deep(.kds-card-action:disabled),
+:deep(.kds-card-action[aria-disabled="true"]) {
+  opacity: 0.45;
+}
+
+:deep(.kds-card-action.is-recall) {
+  border-color: rgb(246 181 109 / 0.28);
+  background: rgb(246 181 109 / 0.08);
+  color: var(--kds-accent);
+}
+
+:deep(.kds-card-action:focus-visible) {
+  outline: 3px solid rgb(246 181 109 / 0.45);
+  outline-offset: 2px;
+}
+
+:deep(.kds-empty) {
+  display: grid;
+  height: 100%;
+  min-height: 540px;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  color: var(--kds-fg2);
+  text-align: center;
+}
+
+:deep(.kds-empty svg) {
+  width: 46px;
+  height: 46px;
+  color: var(--kds-ready);
+}
+
+:deep(.kds-empty strong) {
+  color: var(--kds-fg0);
+  font-family: var(--kds-font-d);
+  font-size: 34px;
+}
+
+:deep(.kds-empty span) {
+  font-size: 16px;
+}
+
+@media (max-width: 900px), (max-height: 620px) {
+  .kds-viewport {
+    overflow: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  :deep(*) {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}
+</style>

--- a/resources/js/pages/POS/Index.vue
+++ b/resources/js/pages/POS/Index.vue
@@ -12,7 +12,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { MonitorSmartphone, Circle, ReceiptText } from 'lucide-vue-next'
+import { MonitorSmartphone, Circle, ReceiptText, RefreshCw } from 'lucide-vue-next'
 import EditOrderDialog from '@/components/pos/EditOrderDialog.vue'
 import PaymentDialog from '@/components/pos/PaymentDialog.vue'
 import PosTableCard from '@/components/pos/PosTableCard.vue'
@@ -31,8 +31,6 @@ import {
     Skeleton,
 } from '@/components/ui/skeleton'
 
-// Interfaces imported from @/types/pos
-
 const props = defineProps<{
     title: string
     description: string
@@ -43,6 +41,9 @@ const props = defineProps<{
         date_time_opened: string
         date_time_closed: string | null
     } | null
+    posConnected?: boolean
+    posStatus?: 'connected' | 'not_configured' | 'auth_failed' | 'unreachable'
+    posMessage?: string
 }>()
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -53,19 +54,34 @@ const breadcrumbs: BreadcrumbItem[] = [
 ]
 
 const pageTitle = computed(() => props.title || 'POS')
+
+const posBannerTitle = computed(() => {
+    switch (props.posStatus) {
+        case 'not_configured':
+            return 'POS password not configured'
+        case 'auth_failed':
+            return 'POS credentials rejected'
+        case 'unreachable':
+            return 'POS not reachable'
+        default:
+            return 'POS not connected'
+    }
+})
 const terminals = computed<PosTerminal[]>(() => (Array.isArray(props.terminals) ? props.terminals : []))
-const currentSession = computed(() => props.currentSession ?? null)
 
 const selectedTerminalId = ref<string | null>(terminals.value[0]?.id ?? null)
-const tables = ref<PosTable[]>(Array.isArray(props.tables) ? props.tables : [])
+const terminalTables = ref<PosTable[]>(Array.isArray(props.tables) ? props.tables : [])
 const tablesLoading = ref(false)
 const tablesError = ref<string | null>(null)
+const loadingTerminalId = ref<string | null>(null)
+let tablesLoadSeq = 0
 
 const showOrdersModal = ref(false)
 const selectedTable = ref<PosTable | null>(null)
 const selectedOrders = ref<PosOrder[]>([])
 const ordersLoading = ref(false)
 const ordersError = ref<string | null>(null)
+const addOrderError = ref<string | null>(null)
 const actionLoading = ref(false)
 
 const form = useForm({
@@ -91,14 +107,14 @@ const selectedTerminal = computed(() =>
     terminals.value.find((terminal) => String(terminal.id) === String(selectedTerminalId.value)) ?? null
 )
 
-const occupiedTables = computed(() => tables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
+const occupiedTables = computed(() => terminalTables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
 
 const currentSessionStatus = computed(() => {
-    if (!currentSession.value) {
+    if (!props.currentSession) {
         return 'No Session'
     }
 
-    return currentSession.value.date_time_closed ? 'Closed' : 'Open'
+    return props.currentSession.date_time_closed ? 'Closed' : 'Open'
 })
 
 const readJsonPayload = async (response: Response): Promise<any> => {
@@ -172,7 +188,9 @@ const fetchWithCsrf = async (url: string, options: RequestInit): Promise<Respons
 }
 
 const loadTablesForTerminal = async (terminalId: string) => {
+    const seq = ++tablesLoadSeq
     selectedTerminalId.value = terminalId
+    loadingTerminalId.value = terminalId
     tablesLoading.value = true
     tablesError.value = null
 
@@ -184,17 +202,24 @@ const loadTablesForTerminal = async (terminalId: string) => {
             },
         })
 
+        if (seq !== tablesLoadSeq) return
+
         const payload = await readJsonPayload(response)
 
         if (!response.ok || !payload?.success) {
             throw new Error(payload?.message || 'Failed to load tables for selected terminal.')
         }
 
-        tables.value = Array.isArray(payload.tables) ? payload.tables : []
+        terminalTables.value = Array.isArray(payload.tables) ? payload.tables : []
     } catch (error: any) {
-        tablesError.value = error?.message || 'Unable to load tables from Krypton.'
+        if (seq === tablesLoadSeq) {
+            tablesError.value = error?.message || 'Unable to load tables from Krypton.'
+        }
     } finally {
-        tablesLoading.value = false
+        if (seq === tablesLoadSeq) {
+            tablesLoading.value = false
+            loadingTerminalId.value = null
+        }
     }
 }
 
@@ -206,6 +231,7 @@ const openTableOrders = async (table: PosTable) => {
     selectedTable.value = table
     selectedOrders.value = []
     ordersError.value = null
+    addOrderError.value = null
     ordersLoading.value = true
     showOrdersModal.value = true
 
@@ -251,7 +277,7 @@ const addOrderForTable = () => {
             loadTablesForTerminal(selectedTerminalId.value!)
         },
         onError: (errors) => {
-            ordersError.value = errors.message || 'Unable to add order from POS.'
+            addOrderError.value = errors.message || 'Unable to add order from POS.'
         },
     })
 }
@@ -375,6 +401,12 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-5">
+            <div v-if="posConnected === false" class="rounded-[18px] border border-destructive/40 bg-destructive/10 px-5 py-4 text-sm text-destructive">
+                <p class="font-semibold">{{ posBannerTitle }}</p>
+                <p class="mt-1">{{ posMessage }}</p>
+                <a :href="route('pos-connection.index')" class="mt-2 inline-block underline underline-offset-2 hover:opacity-80">Go to Configuration → POS Connection</a>
+            </div>
+
             <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
                 <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                     <div class="max-w-3xl space-y-3">
@@ -411,8 +443,8 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 </div>
                 <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
                     <p class="text-xs uppercase tracking-wide text-muted-foreground">Current Session</p>
-                    <p class="mt-1 text-lg font-semibold">#{{ currentSession?.id || '—' }} • {{ currentSessionStatus }}</p>
-                    <p class="text-xs text-muted-foreground">Opened: {{ formatDateTime(currentSession?.date_time_opened) }}</p>
+                    <p class="mt-1 text-lg font-semibold">#{{ props.currentSession?.id || '—' }} • {{ currentSessionStatus }}</p>
+                    <p class="text-xs text-muted-foreground">Opened: {{ formatDateTime(props.currentSession?.date_time_opened) }}</p>
                 </div>
             </section>
 
@@ -427,8 +459,9 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                             v-for="terminal in terminals"
                             :key="terminal.id"
                             type="button"
-                            class="group rounded-[22px] border border-black/8 bg-gradient-to-b from-slate-900/95 to-slate-950 p-4 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-woosoo-accent/70 hover:shadow-woosoo-accent/20 dark:border-white/10"
+                            class="group rounded-[22px] border border-black/8 bg-gradient-to-b from-slate-900/95 to-slate-950 p-4 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-woosoo-accent/70 hover:shadow-woosoo-accent/20 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10"
                             :class="String(selectedTerminalId) === String(terminal.id) ? 'ring-2 ring-woosoo-accent/70' : ''"
+                            :disabled="tablesLoading && loadingTerminalId === String(terminal.id)"
                             @click="loadTablesForTerminal(String(terminal.id))"
                         >
                             <div class="mb-3 flex items-center justify-between">
@@ -441,9 +474,15 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
 
                             <div class="mx-auto mb-4 flex h-44 w-full max-w-[220px] items-center justify-center rounded-[1.7rem] border-[10px] border-slate-700 bg-slate-800 shadow-inner">
                                 <div class="flex h-full w-full flex-col items-center justify-center rounded-[1.2rem] bg-slate-900 text-center text-white/90">
-                                    <MonitorSmartphone class="mb-2 h-10 w-10 text-woosoo-accent" />
-                                    <p class="px-2 text-sm font-semibold leading-tight">{{ terminal.name }}</p>
-                                    <p class="mt-1 text-[11px] text-white/50">{{ terminal.type }}</p>
+                                    <template v-if="tablesLoading && loadingTerminalId === String(terminal.id)">
+                                        <RefreshCw class="mb-2 h-10 w-10 animate-spin text-woosoo-accent" />
+                                        <p class="px-2 text-[11px] text-white/50">Loading tables…</p>
+                                    </template>
+                                    <template v-else>
+                                        <MonitorSmartphone class="mb-2 h-10 w-10 text-woosoo-accent" />
+                                        <p class="px-2 text-sm font-semibold leading-tight">{{ terminal.name }}</p>
+                                        <p class="mt-1 text-[11px] text-white/50">{{ terminal.type }}</p>
+                                    </template>
                                 </div>
                             </div>
 
@@ -469,7 +508,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                             </p>
                         </div>
                         <div class="text-right text-xs text-muted-foreground">
-                            <p>Registered Tables: <span class="font-semibold text-foreground">{{ tables.length }}</span></p>
+                            <p>Registered Tables: <span class="font-semibold text-foreground">{{ terminalTables.length }}</span></p>
                             <p>Occupied Tables: <span class="font-semibold text-destructive">{{ occupiedTables }}</span></p>
                         </div>
                     </div>
@@ -488,9 +527,13 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                         {{ tablesError }}
                     </div>
 
+                    <div v-else-if="terminalTables.length === 0" class="rounded-xl border border-black/8 bg-muted/30 px-4 py-8 text-center text-sm text-muted-foreground dark:border-white/10">
+                        No tables found for this terminal.
+                    </div>
+
                     <div v-else class="grid grid-cols-2 gap-4 md:grid-cols-4 xl:grid-cols-6">
                         <PosTableCard
-                            v-for="table in tables"
+                            v-for="table in terminalTables"
                             :key="table.id"
                             :table="table"
                             :selected="selectedTable?.id === table.id"
@@ -515,29 +558,37 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 <div class="max-h-[62vh] overflow-auto px-6 py-4">
                     <div class="mb-4 rounded-xl border border-black/8 bg-muted/30 p-4 dark:border-white/10">
                         <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Add Order by Table</p>
-                        <div class="flex flex-wrap items-end gap-3">
-                            <div>
-                                <label class="mb-1 block text-xs text-muted-foreground">Guest Count</label>
-                                <input
-                                    v-model.number="form.guest_count"
-                                    type="number"
-                                    min="1"
-                                    class="w-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                >
-                            </div>
-                            <div>
-                                <label class="mb-1 block text-xs text-muted-foreground">Reference</label>
-                                <input
-                                    v-model="form.reference"
-                                    type="text"
-                                    class="w-56 rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                    placeholder="Optional"
-                                >
-                            </div>
-                            <Button :disabled="form.processing" @click="addOrderForTable">
-                                Add Order
-                            </Button>
+                        <div v-if="props.currentSession?.date_time_closed" class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                            Session closed — orders cannot be added.
                         </div>
+                        <template v-else>
+                            <div class="flex flex-wrap items-end gap-3">
+                                <div>
+                                    <label class="mb-1 block text-xs text-muted-foreground">Guest Count</label>
+                                    <input
+                                        v-model.number="form.guest_count"
+                                        type="number"
+                                        min="1"
+                                        class="w-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                    >
+                                </div>
+                                <div>
+                                    <label class="mb-1 block text-xs text-muted-foreground">Reference</label>
+                                    <input
+                                        v-model="form.reference"
+                                        type="text"
+                                        class="w-56 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                        placeholder="Optional"
+                                    >
+                                </div>
+                                <Button :disabled="form.processing" @click="addOrderForTable">
+                                    Add Order
+                                </Button>
+                            </div>
+                            <div v-if="addOrderError" class="mt-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                                {{ addOrderError }}
+                            </div>
+                        </template>
                     </div>
 
                     <div v-if="ordersLoading" class="space-y-3 py-4">
@@ -573,7 +624,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                                 <th class="px-2 py-3 text-right">Guests</th>
                                 <th class="px-2 py-3 text-right">Total</th>
                                 <th class="px-2 py-3 text-right">Paid</th>
-                                <th class="px-2 py-3 text-right">Resetable Txn#</th>
+                                <th class="px-2 py-3 text-right">Resettable Txn#</th>
                                 <th class="px-2 py-3 text-right">Actions</th>
                             </tr>
                         </thead>
@@ -599,37 +650,37 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                         </tbody>
                     </table>
                 </div>
-
-                <EditOrderDialog
-                    :open="editDialogOpen"
-                    :order="selectedOrderForEdit"
-                    @update:open="editDialogOpen = $event"
-                    @save="handleEditSave"
-                />
-
-                <PaymentDialog
-                    :open="paymentDialogOpen"
-                    :order="selectedOrderForPay"
-                    @update:open="paymentDialogOpen = $event"
-                    @pay="handlePay"
-                />
-
-                <AlertDialog :open="voidDialogOpen" @update:open="voidDialogOpen = $event">
-                    <AlertDialogContent>
-                        <AlertDialogHeader>
-                            <AlertDialogTitle>Void Order #{{ selectedOrderForVoid?.id }}</AlertDialogTitle>
-                            <AlertDialogDescription>
-                                Are you sure you want to void this order? This action cannot be undone.
-                            </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                            <AlertDialogCancel @click="voidDialogOpen = false">Cancel</AlertDialogCancel>
-                            <AlertDialogAction @click="handleVoidConfirm">Void Order</AlertDialogAction>
-                        </AlertDialogFooter>
-                    </AlertDialogContent>
-                </AlertDialog>
             </DialogContent>
         </Dialog>
         </div>
+
+        <EditOrderDialog
+            :open="editDialogOpen"
+            :order="selectedOrderForEdit"
+            @update:open="editDialogOpen = $event"
+            @save="handleEditSave"
+        />
+
+        <PaymentDialog
+            :open="paymentDialogOpen"
+            :order="selectedOrderForPay"
+            @update:open="paymentDialogOpen = $event"
+            @pay="handlePay"
+        />
+
+        <AlertDialog :open="voidDialogOpen" @update:open="voidDialogOpen = $event">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Void Order #{{ selectedOrderForVoid?.id }}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        Are you sure you want to void this order? This action cannot be undone.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel @click="voidDialogOpen = false">Cancel</AlertDialogCancel>
+                    <AlertDialogAction @click="handleVoidConfirm">Void Order</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
     </AppLayout>
 </template>

--- a/resources/js/pages/Packages/Index.vue
+++ b/resources/js/pages/Packages/Index.vue
@@ -1,9 +1,8 @@
-<!-- Audit Fix (2026-04-06): admin UI for package CRUD and modifier mapping management. -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
-import { Pencil, Trash2, Package, Plus, RotateCcw } from 'lucide-vue-next'
+import { Pencil, Trash2, Package, RotateCcw } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import type { BreadcrumbItem } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -15,436 +14,435 @@ import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
 import { Select, SelectContent, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
 } from '@/components/ui/table'
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 
 interface PackageModifierVm {
-  id?: number
-  krypton_menu_id: number
-  sort_order: number
+    id?: number
+    krypton_menu_id: number
+    sort_order: number
 }
 
 interface PackageVm {
-  id: number
-  name: string
-  description?: string | null
-  krypton_menu_id: number
-  is_active: boolean
-  sort_order: number
-  modifiers: PackageModifierVm[]
+    id: number
+    name: string
+    description?: string | null
+    krypton_menu_id: number
+    is_active: boolean
+    sort_order: number
+    modifiers: PackageModifierVm[]
 }
 
 interface MenuOption {
-  id: number
-  name: string
-  receipt_name?: string | null
-  is_modifier_only: boolean
+    id: number
+    name: string
+    receipt_name?: string | null
+    is_modifier_only: boolean
 }
 
 interface PackagesPageProps {
-  title: string
-  description: string
-  packages: PackageVm[]
-  menuOptions: MenuOption[]
-  modifierDescriptions: Record<number, string>
+    title: string
+    description: string
+    packages: PackageVm[]
+    menuOptions: MenuOption[]
+    modifierDescriptions: Record<number, string>
 }
 
 const props = defineProps<PackagesPageProps>()
 
 const breadcrumbs: BreadcrumbItem[] = [
-  {
-    title: 'Packages',
-    href: route('packages.index'),
-  },
+    { title: 'Krypton Modifiers', href: route('packages.index') },
 ]
 
 const editingId = ref<number | null>(null)
 const pendingDelete = ref<PackageVm | null>(null)
 
 const form = useForm({
-  name: '',
-  description: '',
-  krypton_menu_id: 0,
-  is_active: true,
-  sort_order: 0,
-  modifier_ids: [] as number[],
-  modifier_descriptions: {} as Record<number, string>,
+    name: '',
+    description: '',
+    krypton_menu_id: 0,
+    is_active: true,
+    sort_order: 0,
+    modifier_ids: [] as number[],
+    modifier_descriptions: {} as Record<number, string>,
 })
 
 const modifierSearch = ref('')
 
 const orderedPackages = computed(() => {
-  return [...(props.packages ?? [])].sort((a, b) => a.sort_order - b.sort_order)
+    return [...(props.packages ?? [])].sort((a, b) => a.sort_order - b.sort_order)
 })
 
-function modifiersToCsv(modifiers: PackageModifierVm[]): string {
-  return [...modifiers]
-    .sort((a, b) => a.sort_order - b.sort_order)
-    .map((m) => String(m.krypton_menu_id))
-    .join(',')
+function modifierNames(modifiers: PackageModifierVm[]): string {
+    const byId = new Map((props.menuOptions ?? []).map((m) => [m.id, m.name]))
+    const names = [...modifiers]
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((m) => byId.get(m.krypton_menu_id) ?? `#${m.krypton_menu_id}`)
+    if (names.length === 0) return '—'
+    const joined = names.join(', ')
+    return joined.length > 60 ? joined.slice(0, 57) + '…' : joined
 }
 
 const packageMenuOptions = computed(() => {
-  return props.menuOptions ?? []
+    return props.menuOptions ?? []
 })
 
 const filteredModifierOptions = computed(() => {
-  const needle = modifierSearch.value.trim().toLowerCase()
-  if (!needle) {
-    return props.menuOptions ?? []
-  }
-
-  return (props.menuOptions ?? []).filter((item) => {
-    return item.name.toLowerCase().includes(needle)
-      || String(item.id).includes(needle)
-      || (item.receipt_name ?? '').toLowerCase().includes(needle)
-  })
+    const needle = modifierSearch.value.trim().toLowerCase()
+    if (!needle) {
+        return props.menuOptions ?? []
+    }
+    return (props.menuOptions ?? []).filter((item) => {
+        return item.name.toLowerCase().includes(needle)
+            || String(item.id).includes(needle)
+            || (item.receipt_name ?? '').toLowerCase().includes(needle)
+    })
 })
 
 const selectedModifierPreview = computed(() => {
-  const picked = new Set(form.modifier_ids)
-  return (props.menuOptions ?? []).filter((item) => picked.has(item.id)).slice(0, 8)
+    const picked = new Set(form.modifier_ids)
+    return (props.menuOptions ?? []).filter((item) => picked.has(item.id)).slice(0, 8)
 })
 
 const selectedModifiers = computed(() => {
-  const byId = new Map((props.menuOptions ?? []).map((item) => [item.id, item]))
-  return form.modifier_ids
-    .map((id) => byId.get(id) ?? { id, name: `Menu #${id}`, receipt_name: null, is_modifier_only: false } as MenuOption)
+    const byId = new Map((props.menuOptions ?? []).map((item) => [item.id, item]))
+    return form.modifier_ids
+        .map((id) => byId.get(id) ?? { id, name: `Menu #${id}`, receipt_name: null, is_modifier_only: false } as MenuOption)
 })
 
 function isModifierSelected(menuId: number): boolean {
-  return form.modifier_ids.includes(menuId)
+    return form.modifier_ids.includes(menuId)
 }
 
 function toggleModifier(menuId: number, checked: boolean): void {
-  if (checked && !form.modifier_ids.includes(menuId)) {
-    form.modifier_ids = [...form.modifier_ids, menuId]
-    return
-  }
-
-  if (!checked && form.modifier_ids.includes(menuId)) {
-    form.modifier_ids = form.modifier_ids.filter((id) => id !== menuId)
-  }
+    if (checked && !form.modifier_ids.includes(menuId)) {
+        form.modifier_ids = [...form.modifier_ids, menuId]
+        return
+    }
+    if (!checked && form.modifier_ids.includes(menuId)) {
+        form.modifier_ids = form.modifier_ids.filter((id) => id !== menuId)
+    }
 }
 
 function resetForm() {
-  editingId.value = null
-  form.reset()
-  form.clearErrors()
-  form.description = ''
-  form.is_active = true
-  form.krypton_menu_id = 0
-  form.sort_order = 0
-  form.modifier_ids = []
-  form.modifier_descriptions = {}
-  modifierSearch.value = ''
+    editingId.value = null
+    form.reset()
+    form.clearErrors()
+    form.description = ''
+    form.is_active = true
+    form.krypton_menu_id = 0
+    form.sort_order = 0
+    form.modifier_ids = []
+    form.modifier_descriptions = {}
+    modifierSearch.value = ''
 }
 
 function editPackage(item: PackageVm) {
-  editingId.value = item.id
-  form.name = item.name
-  form.description = item.description ?? ''
-  form.krypton_menu_id = item.krypton_menu_id
-  form.is_active = item.is_active
-  form.sort_order = item.sort_order
-  form.modifier_ids = [...(item.modifiers ?? [])]
-    .sort((a, b) => a.sort_order - b.sort_order)
-    .map((modifier) => modifier.krypton_menu_id)
-  const descriptions: Record<number, string> = {}
-  for (const menuId of form.modifier_ids) {
-    descriptions[menuId] = props.modifierDescriptions?.[menuId] ?? ''
-  }
-  form.modifier_descriptions = descriptions
-  window.scrollTo({ top: 0, behavior: 'smooth' })
+    editingId.value = item.id
+    form.name = item.name
+    form.description = item.description ?? ''
+    form.krypton_menu_id = item.krypton_menu_id
+    form.is_active = item.is_active
+    form.sort_order = item.sort_order
+    form.modifier_ids = [...(item.modifiers ?? [])]
+        .sort((a, b) => a.sort_order - b.sort_order)
+        .map((modifier) => modifier.krypton_menu_id)
+    const descriptions: Record<number, string> = {}
+    for (const menuId of form.modifier_ids) {
+        descriptions[menuId] = props.modifierDescriptions?.[menuId] ?? ''
+    }
+    form.modifier_descriptions = descriptions
+    window.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
 function submit() {
-  const orderedModifierIds = [...form.modifier_ids]
-    .map((id) => Number(id))
-    .filter((id) => Number.isFinite(id) && id > 0)
+    const orderedModifierIds = [...form.modifier_ids]
+        .map((id) => Number(id))
+        .filter((id) => Number.isFinite(id) && id > 0)
 
-  const payload = {
-    name: form.name,
-    description: form.description,
-    krypton_menu_id: Number(form.krypton_menu_id),
-    is_active: Boolean(form.is_active),
-    sort_order: Number(form.sort_order),
-    modifiers: orderedModifierIds.map((id, index) => ({
-      krypton_menu_id: id,
-      sort_order: index,
-      description: form.modifier_descriptions[id] ?? null,
-    })),
-  }
+    const payload = {
+        name: form.name,
+        description: form.description,
+        krypton_menu_id: Number(form.krypton_menu_id),
+        is_active: Boolean(form.is_active),
+        sort_order: Number(form.sort_order),
+        modifiers: orderedModifierIds.map((id, index) => ({
+            krypton_menu_id: id,
+            sort_order: index,
+            description: form.modifier_descriptions[id] ?? null,
+        })),
+    }
 
-  if (editingId.value) {
-    form.transform(() => payload).put(route('packages.update', editingId.value), {
-      preserveScroll: true,
-      onSuccess: () => {
-        toast.success('Package updated.')
-        resetForm()
-      },
-      onError: () => toast.error('Failed to update package.'),
+    if (editingId.value) {
+        form.transform(() => payload).put(route('packages.update', editingId.value), {
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success('Package updated.')
+                resetForm()
+            },
+            onError: () => toast.error('Failed to update package.'),
+        })
+        return
+    }
+
+    form.transform(() => payload).post(route('packages.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            toast.success('Package created.')
+            resetForm()
+        },
+        onError: () => toast.error('Failed to create package.'),
     })
-    return
-  }
-
-  form.transform(() => payload).post(route('packages.store'), {
-    preserveScroll: true,
-    onSuccess: () => {
-      toast.success('Package created.')
-      resetForm()
-    },
-    onError: () => toast.error('Failed to create package.'),
-  })
 }
 
 function confirmDelete(item: PackageVm) {
-  pendingDelete.value = item
+    pendingDelete.value = item
 }
 
 function executeDelete() {
-  if (!pendingDelete.value) return
-  const item = pendingDelete.value
-  pendingDelete.value = null
-
-  router.delete(route('packages.destroy', item.id), {
-    preserveScroll: true,
-    onSuccess: () => toast.success(`Package "${item.name}" deleted.`),
-    onError: () => toast.error('Failed to delete package.'),
-  })
+    if (!pendingDelete.value) return
+    const item = pendingDelete.value
+    pendingDelete.value = null
+    router.delete(route('packages.destroy', item.id), {
+        preserveScroll: true,
+        onSuccess: () => toast.success(`Package "${item.name}" deleted.`),
+        onError: () => toast.error('Failed to delete package.'),
+    })
 }
 </script>
 
 <template>
-  <AppLayout :breadcrumbs="breadcrumbs">
-    <Head :title="title" />
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head :title="title" />
 
-    <div class="space-y-6 p-6">
-      <!-- Create / Edit form -->
-      <Card>
-        <CardHeader>
-          <CardTitle class="flex items-center gap-2">
-            <component :is="editingId ? Pencil : Plus" class="h-4 w-4" />
-            {{ editingId ? 'Edit Package' : 'New Package' }}
-          </CardTitle>
-          <CardDescription>
-            {{ editingId ? 'Update package details and linked menu items.' : 'Add a new menu package and map its modifier items.' }}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form class="grid gap-4 md:grid-cols-2" @submit.prevent="submit">
-            <div class="space-y-2">
-              <Label for="package_name">Package Name</Label>
-              <Input id="package_name" v-model="form.name" placeholder="Set Meal A" required />
-              <p v-if="form.errors.name" class="text-sm text-destructive">{{ form.errors.name }}</p>
-            </div>
-
-            <div class="space-y-2 md:col-span-2">
-              <Label for="package_description">Description</Label>
-              <Textarea
-                id="package_description"
-                v-model="form.description"
-                rows="3"
-                placeholder="A short, guest-facing description of what this package includes."
-              />
-              <p class="text-xs text-muted-foreground">Shown to guests. Describe what makes this package worth choosing.</p>
-              <p v-if="form.errors.description" class="text-sm text-destructive">{{ form.errors.description }}</p>
-            </div>
-
-            <div class="space-y-2">
-              <Label for="krypton_menu_id">Package Menu</Label>
-              <Select v-model="form.krypton_menu_id">
-                <SelectTrigger id="krypton_menu_id">
-                  <SelectValue placeholder="Select package menu" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectLabel>Available Menus</SelectLabel>
-                  <SelectItem v-for="menu in packageMenuOptions" :key="menu.id" :value="menu.id">
-                    {{ menu.name }} (ID: {{ menu.id }})
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p class="text-xs text-muted-foreground">Choose the real menu entry linked to this package.</p>
-              <p v-if="form.errors.krypton_menu_id" class="text-sm text-destructive">{{ form.errors.krypton_menu_id }}</p>
-            </div>
-
-            <div class="space-y-2">
-              <Label for="sort_order">Display Order</Label>
-              <Input id="sort_order" v-model.number="form.sort_order" type="number" min="0" />
-              <p class="text-xs text-muted-foreground">Lower numbers appear first.</p>
-              <p v-if="form.errors.sort_order" class="text-sm text-destructive">{{ form.errors.sort_order }}</p>
-            </div>
-
-            <div class="space-y-2">
-              <div class="flex items-center justify-between gap-2">
-                <Label for="modifier_filter">Modifier Menus</Label>
-                <Badge variant="secondary">{{ form.modifier_ids.length }} selected</Badge>
-              </div>
-              <Input id="modifier_filter" v-model="modifierSearch" placeholder="Search menu by name, receipt code, or ID" />
-              <div class="max-h-44 overflow-y-auto rounded-md border p-2 space-y-2">
-                <div v-for="menu in filteredModifierOptions" :key="menu.id" class="flex items-start gap-2 rounded-sm px-1 py-1 hover:bg-muted/60">
-                  <Checkbox
-                    :id="`modifier-${menu.id}`"
-                    :model-value="isModifierSelected(menu.id)"
-                    @update:model-value="(value: boolean | 'indeterminate') => toggleModifier(menu.id, value === true)"
-                  />
-                  <Label :for="`modifier-${menu.id}`" class="cursor-pointer leading-tight">
-                    <span class="font-medium">{{ menu.name }}</span>
-                    <span class="ml-1 text-xs text-muted-foreground">(ID: {{ menu.id }})</span>
-                    <span v-if="menu.receipt_name" class="ml-1 text-xs text-muted-foreground">{{ menu.receipt_name }}</span>
-                  </Label>
-                </div>
-                <p v-if="filteredModifierOptions.length === 0" class="py-6 text-center text-xs text-muted-foreground">
-                  No menu items matched your search.
-                </p>
-              </div>
-              <div v-if="selectedModifierPreview.length > 0" class="flex flex-wrap gap-1">
-                <Badge v-for="menu in selectedModifierPreview" :key="`picked-${menu.id}`" variant="outline">
-                  {{ menu.name }}
-                </Badge>
-              </div>
-            </div>
-
-            <div v-if="selectedModifiers.length > 0" class="space-y-3 md:col-span-2">
-              <div class="flex items-center justify-between gap-2">
-                <Label>Modifier Descriptions</Label>
-                <Badge variant="secondary">{{ selectedModifiers.length }} item{{ selectedModifiers.length === 1 ? '' : 's' }}</Badge>
-              </div>
-              <p class="text-xs text-muted-foreground">
-                Descriptions are shared across all packages that include this item.
-              </p>
-              <div class="space-y-3 rounded-md border p-3">
-                <div v-for="menu in selectedModifiers" :key="`desc-${menu.id}`" class="space-y-1">
-                  <Label :for="`modifier-desc-${menu.id}`" class="leading-tight">
-                    <span class="font-medium">{{ menu.name }}</span>
-                    <span class="ml-1 text-xs text-muted-foreground">(ID: {{ menu.id }})</span>
-                    <span v-if="menu.receipt_name" class="ml-1 text-xs text-muted-foreground">{{ menu.receipt_name }}</span>
-                  </Label>
-                  <Textarea
-                    :id="`modifier-desc-${menu.id}`"
-                    v-model="form.modifier_descriptions[menu.id]"
-                    rows="2"
-                    placeholder="Describe this modifier for guests."
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div class="md:col-span-2 flex items-center gap-3">
-              <Switch id="is_active" :model-value="form.is_active" @update:model-value="(v) => form.is_active = Boolean(v)" />
-              <Label for="is_active">Active — visible to ordering devices</Label>
-            </div>
-
-            <div class="md:col-span-2 flex gap-2">
-              <Button type="submit" :disabled="form.processing">
-                {{ form.processing ? 'Saving…' : (editingId ? 'Update Package' : 'Create Package') }}
-              </Button>
-              <Button type="button" variant="outline" :disabled="form.processing" @click="resetForm">
-                <RotateCcw class="mr-2 h-4 w-4" />
-                Reset
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-
-      <!-- Package list -->
-      <Card>
-        <CardHeader>
-          <CardTitle class="flex items-center gap-2">
-            <Package class="h-4 w-4" />
-            Configured Packages
-          </CardTitle>
-          <CardDescription>{{ orderedPackages.length }} package{{ orderedPackages.length === 1 ? '' : 's' }} configured.</CardDescription>
-        </CardHeader>
-        <CardContent class="p-0">
-          <div class="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Menu ID</TableHead>
-                  <TableHead>Modifiers</TableHead>
-                  <TableHead>Order</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead class="text-right">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow v-for="item in orderedPackages" :key="item.id">
-                  <TableCell class="font-medium">{{ item.name }}</TableCell>
-                  <TableCell class="font-mono text-sm">{{ item.krypton_menu_id }}</TableCell>
-                  <TableCell class="text-sm text-muted-foreground">{{ modifiersToCsv(item.modifiers ?? []) || '—' }}</TableCell>
-                  <TableCell>{{ item.sort_order }}</TableCell>
-                  <TableCell>
-                    <Badge :variant="item.is_active ? 'default' : 'secondary'">
-                      {{ item.is_active ? 'Active' : 'Inactive' }}
-                    </Badge>
-                  </TableCell>
-                  <TableCell class="text-right">
-                    <div class="flex justify-end gap-2">
-                      <Button size="sm" variant="outline" @click="editPackage(item)">
-                        <Pencil class="mr-1 h-3 w-3" />
-                        Edit
-                      </Button>
-                      <Button size="sm" variant="destructive" @click="confirmDelete(item)">
-                        <Trash2 class="mr-1 h-3 w-3" />
-                        Delete
-                      </Button>
+        <div class="space-y-5">
+            <!-- Create / Edit form section -->
+            <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#f6b56d]/10 via-transparent to-transparent dark:from-[#f6b56d]/6" />
+                <div class="relative space-y-5">
+                    <!-- Section header -->
+                    <div>
+                        <a :href="route('package-configs.index')" class="mb-2 inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
+                            ← Dining Tiers
+                        </a>
+                        <div class="mt-1">
+                            <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+                                Krypton Modifiers
+                            </span>
+                        </div>
+                        <h2 class="mt-2 font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                            {{ editingId ? 'Edit Package' : 'New Package' }}
+                        </h2>
+                        <p class="mt-1 text-sm text-muted-foreground">
+                            {{ editingId ? 'Update package details and linked menu items.' : 'Add a new menu package and map its modifier items.' }}
+                        </p>
                     </div>
-                  </TableCell>
-                </TableRow>
-                <TableRow v-if="orderedPackages.length === 0">
-                  <TableCell colspan="6" class="py-12 text-center text-sm text-muted-foreground">
-                    No packages configured yet. Use the form above to add the first one.
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
 
-    <!-- Delete confirmation dialog -->
-    <AlertDialog :open="!!pendingDelete" @update:open="(v) => { if (!v) pendingDelete = null }">
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete package?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This will permanently remove <strong>{{ pendingDelete?.name }}</strong> and unlink its modifier mappings.
-            Ordering sessions currently using this package will be unaffected.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel @click="pendingDelete = null">Cancel</AlertDialogCancel>
-          <AlertDialogAction class="bg-destructive hover:bg-destructive/90" @click="executeDelete">
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  </AppLayout>
+                    <!-- Form -->
+                    <form class="grid gap-4 md:grid-cols-2" @submit.prevent="submit">
+                        <div class="space-y-2">
+                            <Label for="package_name">Package Name</Label>
+                            <Input id="package_name" v-model="form.name" placeholder="Set Meal A" required />
+                            <p v-if="form.errors.name" class="text-sm text-destructive">{{ form.errors.name }}</p>
+                        </div>
+
+                        <div class="space-y-2 md:col-span-2">
+                            <Label for="package_description">Description</Label>
+                            <Textarea
+                                id="package_description"
+                                v-model="form.description"
+                                rows="3"
+                                placeholder="A short, guest-facing description of what this package includes."
+                            />
+                            <p class="text-xs text-muted-foreground">Shown to guests. Describe what makes this package worth choosing.</p>
+                            <p v-if="form.errors.description" class="text-sm text-destructive">{{ form.errors.description }}</p>
+                        </div>
+
+                        <div class="space-y-2">
+                            <Label for="krypton_menu_id">Package Menu</Label>
+                            <Select v-model="form.krypton_menu_id">
+                                <SelectTrigger id="krypton_menu_id">
+                                    <SelectValue placeholder="Select package menu" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectLabel>Available Menus</SelectLabel>
+                                    <SelectItem v-for="menu in packageMenuOptions" :key="menu.id" :value="menu.id">
+                                        {{ menu.name }} (ID: {{ menu.id }})
+                                    </SelectItem>
+                                </SelectContent>
+                            </Select>
+                            <p class="text-xs text-muted-foreground">Choose the real menu entry linked to this package.</p>
+                            <p v-if="form.errors.krypton_menu_id" class="text-sm text-destructive">{{ form.errors.krypton_menu_id }}</p>
+                        </div>
+
+                        <div class="space-y-2">
+                            <Label for="sort_order">Display Order</Label>
+                            <Input id="sort_order" v-model.number="form.sort_order" type="number" min="0" />
+                            <p class="text-xs text-muted-foreground">Lower numbers appear first.</p>
+                            <p v-if="form.errors.sort_order" class="text-sm text-destructive">{{ form.errors.sort_order }}</p>
+                        </div>
+
+                        <div class="space-y-2">
+                            <div class="flex items-center justify-between gap-2">
+                                <Label for="modifier_filter">Modifier Menus</Label>
+                                <Badge variant="secondary">{{ form.modifier_ids.length }} selected</Badge>
+                            </div>
+                            <Input id="modifier_filter" v-model="modifierSearch" placeholder="Search menu by name, receipt code, or ID" />
+                            <div class="max-h-44 space-y-2 overflow-y-auto rounded-md border p-2">
+                                <div v-for="menu in filteredModifierOptions" :key="menu.id" class="flex items-start gap-2 rounded-sm px-1 py-1 hover:bg-muted/60">
+                                    <Checkbox
+                                        :id="`modifier-${menu.id}`"
+                                        :model-value="isModifierSelected(menu.id)"
+                                        @update:model-value="(value: boolean | 'indeterminate') => toggleModifier(menu.id, value === true)"
+                                    />
+                                    <Label :for="`modifier-${menu.id}`" class="cursor-pointer leading-tight">
+                                        <span class="font-medium">{{ menu.name }}</span>
+                                        <span class="ml-1 text-xs text-muted-foreground">(ID: {{ menu.id }})</span>
+                                        <span v-if="menu.receipt_name" class="ml-1 text-xs text-muted-foreground">{{ menu.receipt_name }}</span>
+                                    </Label>
+                                </div>
+                                <p v-if="filteredModifierOptions.length === 0" class="py-6 text-center text-xs text-muted-foreground">
+                                    No menu items matched your search.
+                                </p>
+                            </div>
+                            <div v-if="selectedModifierPreview.length > 0" class="flex flex-wrap gap-1">
+                                <Badge v-for="menu in selectedModifierPreview" :key="`picked-${menu.id}`" variant="outline">
+                                    {{ menu.name }}
+                                </Badge>
+                            </div>
+                        </div>
+
+                        <div v-if="selectedModifiers.length > 0" class="space-y-3 md:col-span-2">
+                            <div class="flex items-center justify-between gap-2">
+                                <Label>Modifier Descriptions</Label>
+                                <Badge variant="secondary">{{ selectedModifiers.length }} item{{ selectedModifiers.length === 1 ? '' : 's' }}</Badge>
+                            </div>
+                            <p class="text-xs text-muted-foreground">
+                                Descriptions are shared across all packages that include this item.
+                            </p>
+                            <div class="space-y-3 rounded-md border p-3">
+                                <div v-for="menu in selectedModifiers" :key="`desc-${menu.id}`" class="space-y-1">
+                                    <Label :for="`modifier-desc-${menu.id}`" class="leading-tight">
+                                        <span class="font-medium">{{ menu.name }}</span>
+                                        <span class="ml-1 text-xs text-muted-foreground">(ID: {{ menu.id }})</span>
+                                        <span v-if="menu.receipt_name" class="ml-1 text-xs text-muted-foreground">{{ menu.receipt_name }}</span>
+                                    </Label>
+                                    <Textarea
+                                        :id="`modifier-desc-${menu.id}`"
+                                        v-model="form.modifier_descriptions[menu.id]"
+                                        rows="2"
+                                        placeholder="Describe this modifier for guests."
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="flex items-center gap-3 md:col-span-2">
+                            <Switch id="is_active" :model-value="form.is_active" @update:model-value="(v) => form.is_active = Boolean(v)" />
+                            <Label for="is_active">Active — visible to ordering devices</Label>
+                        </div>
+
+                        <div class="flex gap-2 md:col-span-2">
+                            <Button type="submit" :disabled="form.processing">
+                                {{ form.processing ? 'Saving…' : (editingId ? 'Update Package' : 'Create Package') }}
+                            </Button>
+                            <Button type="button" variant="outline" :disabled="form.processing" @click="resetForm">
+                                <RotateCcw class="mr-2 h-4 w-4" />
+                                Reset
+                            </Button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+
+            <!-- Package list section -->
+            <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
+                <div class="flex items-center gap-2 border-b border-black/8 px-5 py-4 dark:border-white/10">
+                    <Package class="h-4 w-4 text-muted-foreground" />
+                    <div>
+                        <p class="text-sm font-semibold text-foreground">Configured Packages</p>
+                        <p class="text-xs text-muted-foreground">{{ orderedPackages.length }} package{{ orderedPackages.length === 1 ? '' : 's' }} configured.</p>
+                    </div>
+                </div>
+                <div class="overflow-x-auto">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead>Menu ID</TableHead>
+                                <TableHead>Modifiers</TableHead>
+                                <TableHead>Order</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead class="text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            <TableRow v-for="item in orderedPackages" :key="item.id">
+                                <TableCell class="font-medium">{{ item.name }}</TableCell>
+                                <TableCell class="font-mono text-sm">{{ item.krypton_menu_id }}</TableCell>
+                                <TableCell class="text-sm text-muted-foreground">{{ modifierNames(item.modifiers ?? []) }}</TableCell>
+                                <TableCell>{{ item.sort_order }}</TableCell>
+                                <TableCell>
+                                    <Badge :variant="item.is_active ? 'default' : 'secondary'">
+                                        {{ item.is_active ? 'Active' : 'Inactive' }}
+                                    </Badge>
+                                </TableCell>
+                                <TableCell class="text-right">
+                                    <div class="flex justify-end gap-2">
+                                        <Button size="sm" variant="outline" @click="editPackage(item)">
+                                            <Pencil class="mr-1 h-3 w-3" />
+                                            Edit
+                                        </Button>
+                                        <Button size="sm" variant="destructive" @click="confirmDelete(item)">
+                                            <Trash2 class="mr-1 h-3 w-3" />
+                                            Delete
+                                        </Button>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                            <TableRow v-if="orderedPackages.length === 0">
+                                <TableCell colspan="6" class="py-12 text-center text-sm text-muted-foreground">
+                                    No packages configured yet. Use the form above to add the first one.
+                                </TableCell>
+                            </TableRow>
+                        </TableBody>
+                    </Table>
+                </div>
+            </section>
+        </div>
+
+        <!-- Delete confirmation dialog -->
+        <AlertDialog :open="!!pendingDelete" @update:open="(v) => { if (!v) pendingDelete = null }">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete package?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        This will permanently remove <strong>{{ pendingDelete?.name }}</strong> and unlink its modifier mappings.
+                        Ordering sessions currently using this package will be unaffected.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel @click="pendingDelete = null">Cancel</AlertDialogCancel>
+                    <AlertDialogAction class="bg-destructive hover:bg-destructive/90" @click="executeDelete">
+                        Delete
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    </AppLayout>
 </template>

--- a/resources/js/pages/package-configs/IndexPackageConfigs.vue
+++ b/resources/js/pages/package-configs/IndexPackageConfigs.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
-import { Plus, Pencil, Trash2, Package2 } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, Eye, Check } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import type { BreadcrumbItem } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -10,235 +10,343 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table'
-import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel,
-  AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
-  AlertDialogHeader, AlertDialogTitle,
+    AlertDialog, AlertDialogAction, AlertDialogCancel,
+    AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
+    AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import {
-  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+    Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 
-interface PackageConfigVm {
-  id: number
-  name: string
-  description: string | null
-  base_price: string
-  is_active: boolean
-  sort_order: number
+interface AllowedMenu {
+    id: number
+    krypton_menu_id: number
+    name: string
+    menu_type: string | null
+    sort_order: number
+    is_active: boolean
 }
 
-defineProps<{ packages: PackageConfigVm[] }>()
+interface PackageConfigVm {
+    id: number
+    name: string
+    description: string | null
+    base_price: string
+    is_active: boolean
+    sort_order: number
+    menus: AllowedMenu[]
+}
+
+const props = defineProps<{ packages: PackageConfigVm[] }>()
 
 const breadcrumbs: BreadcrumbItem[] = [
-  { title: 'Package Configs', href: route('package-configs.index') },
+    { title: 'Packages', href: route('package-configs.index') },
 ]
+
+const orderedPackages = computed(() =>
+    [...props.packages].sort((a, b) => a.sort_order - b.sort_order),
+)
+
+const activeCount = computed(() => props.packages.filter((p) => p.is_active).length)
+const allPublished = computed(() => props.packages.length > 0 && props.packages.every((p) => p.is_active))
+
+function tierLabel(index: number): string {
+    return ['ENTRY TIER', 'MID TIER', 'PREMIUM TIER'][index] ?? `TIER ${index + 1}`
+}
+
+function menusByType(pkg: PackageConfigVm, type: string) {
+    return pkg.menus.filter((m) => (m.menu_type ?? 'meat') === type && m.is_active)
+}
+
+function isBestSeller(index: number): boolean {
+    return index === Math.floor(orderedPackages.value.length / 2)
+}
 
 // ─── Create ────────────────────────────────────────────────────────────────
 const showCreate = ref(false)
-const createForm = useForm({
-  name: '', description: '', base_price: '', is_active: true, sort_order: 0,
-})
+const createForm = useForm({ name: '', description: '', base_price: '', is_active: true, sort_order: 0 })
 
 function submitCreate() {
-  createForm.post(route('package-configs.store'), {
-    onSuccess: () => {
-      showCreate.value = false
-      createForm.reset()
-      toast.success('Package created.')
-    },
-  })
+    createForm.post(route('package-configs.store'), {
+        onSuccess: () => {
+            showCreate.value = false
+            createForm.reset()
+            toast.success('Package created.')
+        },
+    })
 }
 
 // ─── Edit ──────────────────────────────────────────────────────────────────
 const editingId = ref<number | null>(null)
-const editForm = useForm({
-  name: '', description: '', base_price: '', is_active: true, sort_order: 0,
-})
+const editForm = useForm({ name: '', description: '', base_price: '', is_active: true, sort_order: 0 })
 
 function openEdit(pkg: PackageConfigVm) {
-  editingId.value   = pkg.id
-  editForm.name        = pkg.name
-  editForm.description = pkg.description ?? ''
-  editForm.base_price  = pkg.base_price
-  editForm.is_active   = pkg.is_active
-  editForm.sort_order  = pkg.sort_order
+    editingId.value   = pkg.id
+    editForm.name        = pkg.name
+    editForm.description = pkg.description ?? ''
+    editForm.base_price  = pkg.base_price
+    editForm.is_active   = pkg.is_active
+    editForm.sort_order  = pkg.sort_order
 }
 
 function submitEdit() {
-  if (!editingId.value) return
-  editForm.put(route('package-configs.update', editingId.value), {
-    onSuccess: () => {
-      editingId.value = null
-      toast.success('Package updated.')
-    },
-  })
+    if (!editingId.value) return
+    editForm.put(route('package-configs.update', editingId.value), {
+        onSuccess: () => {
+            editingId.value = null
+            toast.success('Package updated.')
+        },
+    })
 }
 
 // ─── Delete ────────────────────────────────────────────────────────────────
 const deleteTarget = ref<PackageConfigVm | null>(null)
 
 function confirmDelete() {
-  if (!deleteTarget.value) return
-  router.delete(route('package-configs.destroy', deleteTarget.value.id), {
-    onSuccess: () => {
-      deleteTarget.value = null
-      toast.success('Package deleted.')
-    },
-  })
+    if (!deleteTarget.value) return
+    router.delete(route('package-configs.destroy', deleteTarget.value.id), {
+        onSuccess: () => {
+            deleteTarget.value = null
+            toast.success('Package deleted.')
+        },
+    })
 }
 </script>
 
 <template>
-  <AppLayout :breadcrumbs="breadcrumbs">
-    <Head title="Package Configs" />
+    <Head title="Packages" />
 
-    <div class="flex flex-col gap-6 p-4 md:p-6">
-      <!-- Header -->
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <Package2 class="h-5 w-5 text-muted-foreground" />
-          <h1 class="text-xl font-semibold">Package Configs</h1>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="space-y-5">
+            <!-- Hero header -->
+            <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#f6b56d]/10 via-transparent to-transparent dark:from-[#f6b56d]/6" />
+                <div class="relative flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div class="space-y-2">
+                        <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+                            Dining Tiers
+                        </span>
+                        <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                            Packages
+                        </h2>
+                        <p class="text-sm text-muted-foreground">
+                            {{ activeCount }} active package{{ activeCount !== 1 ? 's' : '' }} ·
+                            {{ allPublished ? 'All published' : 'Some inactive' }}
+                        </p>
+                    </div>
+                    <div class="flex gap-2">
+                        <Button variant="outline" size="sm" as-child>
+                            <a :href="route('packages.index')">Krypton Modifiers</a>
+                        </Button>
+                        <Button size="sm" @click="showCreate = true">
+                            <Plus class="mr-1.5 h-3.5 w-3.5" />
+                            New Package
+                        </Button>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Tier cards grid -->
+            <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
+                <div class="p-4 sm:p-6">
+                    <div v-if="orderedPackages.length === 0" class="py-16 text-center text-sm text-muted-foreground">
+                        No packages configured yet.
+                        <button class="ml-1 underline" @click="showCreate = true">Add the first one.</button>
+                    </div>
+
+                    <div v-else class="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+                        <div
+                            v-for="(pkg, index) in orderedPackages"
+                            :key="pkg.id"
+                            class="relative flex flex-col gap-4 rounded-[18px] border bg-white/60 p-5 transition-all duration-150 dark:bg-white/[0.04]"
+                            :class="isBestSeller(index)
+                                ? 'border-[#f6b56d]/60 shadow-md shadow-[#f6b56d]/10 dark:border-[#f6b56d]/40'
+                                : 'border-black/8 dark:border-white/10'"
+                        >
+                            <!-- Best seller ribbon -->
+                            <div v-if="isBestSeller(index)" class="absolute right-0 top-0 overflow-hidden rounded-tr-[18px]">
+                                <div class="translate-x-2 -translate-y-px rotate-45 origin-bottom-left bg-[#f6b56d] px-6 py-0.5 text-[9px] font-bold tracking-widest text-black uppercase">
+                                    BEST SELLER
+                                </div>
+                            </div>
+
+                            <!-- Tier label + name -->
+                            <div>
+                                <p class="text-[10px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+                                    {{ tierLabel(index) }}
+                                </p>
+                                <h3 class="mt-1 text-lg font-semibold text-foreground">{{ pkg.name }}</h3>
+                                <p v-if="pkg.description" class="mt-1 text-sm text-muted-foreground">{{ pkg.description }}</p>
+                            </div>
+
+                            <!-- Price -->
+                            <div class="flex items-baseline gap-1">
+                                <span class="font-mono text-3xl font-bold text-[#f6b56d]">₱{{ pkg.base_price }}</span>
+                                <span class="text-sm text-muted-foreground">/ pax</span>
+                            </div>
+
+                            <!-- Meats section -->
+                            <div v-if="menusByType(pkg, 'meat').length > 0">
+                                <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                                    Meats · {{ menusByType(pkg, 'meat').length }} cuts
+                                </p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="m in menusByType(pkg, 'meat')"
+                                        :key="m.id"
+                                        class="flex items-center gap-2 text-sm text-foreground"
+                                    >
+                                        <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-[#f6b56d]" />
+                                        {{ m.name }}
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Add-ons/sides section -->
+                            <div v-if="menusByType(pkg, 'side').length > 0 || menusByType(pkg, 'dessert').length > 0">
+                                <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Add-ons Included</p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="m in [...menusByType(pkg, 'side'), ...menusByType(pkg, 'dessert')]"
+                                        :key="m.id"
+                                        class="flex items-center gap-2 text-sm text-foreground"
+                                    >
+                                        <Check class="h-3.5 w-3.5 shrink-0 text-woosoo-green" />
+                                        {{ m.name }}
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- All items fallback (if no menu_type separation) -->
+                            <div v-if="menusByType(pkg, 'meat').length === 0 && pkg.menus.length > 0">
+                                <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                                    Included · {{ pkg.menus.length }} items
+                                </p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="m in pkg.menus.slice(0, 8)"
+                                        :key="m.id"
+                                        class="flex items-center gap-2 text-sm text-foreground"
+                                    >
+                                        <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-[#f6b56d]" />
+                                        {{ m.name }}
+                                    </li>
+                                    <li v-if="pkg.menus.length > 8" class="text-xs text-muted-foreground">
+                                        + {{ pkg.menus.length - 8 }} more
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <!-- Empty menus state -->
+                            <div v-if="pkg.menus.length === 0" class="rounded-lg border border-dashed border-border/60 py-4 text-center text-xs text-muted-foreground">
+                                No menu items configured
+                            </div>
+
+                            <!-- Status badge -->
+                            <div class="flex items-center justify-between border-t border-black/5 pt-3 dark:border-white/8">
+                                <Badge :variant="pkg.is_active ? 'default' : 'secondary'" class="text-[10px]">
+                                    {{ pkg.is_active ? 'Published' : 'Inactive' }}
+                                </Badge>
+                                <div class="flex gap-1">
+                                    <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openEdit(pkg)">
+                                        <Pencil class="mr-1 h-3 w-3" /> Edit
+                                    </Button>
+                                    <Button variant="ghost" size="sm" class="h-7 px-2 text-xs text-destructive hover:text-destructive" @click="deleteTarget = pkg">
+                                        <Trash2 class="mr-1 h-3 w-3" /> Delete
+                                    </Button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
-        <Button size="sm" @click="showCreate = true">
-          <Plus class="mr-1 h-4 w-4" /> New Package
-        </Button>
-      </div>
 
-      <!-- Table -->
-      <Card>
-        <CardContent class="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Price</TableHead>
-                <TableHead>Order</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead class="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow v-for="pkg in packages" :key="pkg.id">
-                <TableCell>
-                  <div class="font-medium">{{ pkg.name }}</div>
-                  <div v-if="pkg.description" class="text-xs text-muted-foreground truncate max-w-xs">{{ pkg.description }}</div>
-                </TableCell>
-                <TableCell>₱{{ pkg.base_price }}</TableCell>
-                <TableCell>{{ pkg.sort_order }}</TableCell>
-                <TableCell>
-                  <Badge :variant="pkg.is_active ? 'default' : 'secondary'">
-                    {{ pkg.is_active ? 'Active' : 'Inactive' }}
-                  </Badge>
-                </TableCell>
-                <TableCell class="text-right">
-                  <div class="flex justify-end gap-1">
-                    <Button variant="ghost" size="icon" @click="openEdit(pkg)">
-                      <Pencil class="h-4 w-4" />
-                    </Button>
-                    <Button variant="ghost" size="icon" class="text-destructive" @click="deleteTarget = pkg">
-                      <Trash2 class="h-4 w-4" />
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-              <TableRow v-if="!packages.length">
-                <TableCell colspan="5" class="text-center text-muted-foreground py-8">
-                  No package configs yet.
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-    </div>
+        <!-- Create dialog -->
+        <Dialog :open="showCreate" @update:open="showCreate = $event">
+            <DialogContent>
+                <DialogHeader><DialogTitle>New Package</DialogTitle></DialogHeader>
+                <form class="flex flex-col gap-4" @submit.prevent="submitCreate">
+                    <div class="grid gap-1.5">
+                        <Label>Name</Label>
+                        <Input v-model="createForm.name" required />
+                        <p v-if="createForm.errors.name" class="text-xs text-destructive">{{ createForm.errors.name }}</p>
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Description</Label>
+                        <Input v-model="createForm.description" />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Price (₱)</Label>
+                        <Input v-model="createForm.base_price" type="number" step="0.01" min="0" required />
+                        <p v-if="createForm.errors.base_price" class="text-xs text-destructive">{{ createForm.errors.base_price }}</p>
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Sort Order</Label>
+                        <Input v-model.number="createForm.sort_order" type="number" min="0" />
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Switch v-model:checked="createForm.is_active" />
+                        <Label>Active / Published</Label>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" type="button" @click="showCreate = false">Cancel</Button>
+                        <Button type="submit" :disabled="createForm.processing">Create</Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
 
-    <!-- Create dialog -->
-    <Dialog :open="showCreate" @update:open="showCreate = $event">
-      <DialogContent>
-        <DialogHeader><DialogTitle>New Package</DialogTitle></DialogHeader>
-        <form class="flex flex-col gap-4" @submit.prevent="submitCreate">
-          <div class="grid gap-1.5">
-            <Label>Name</Label>
-            <Input v-model="createForm.name" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Description</Label>
-            <Input v-model="createForm.description" />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Price (₱)</Label>
-            <Input v-model="createForm.base_price" type="number" step="0.01" min="0" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Sort Order</Label>
-            <Input v-model.number="createForm.sort_order" type="number" min="0" />
-          </div>
-          <div class="flex items-center gap-3">
-            <Switch v-model:checked="createForm.is_active" />
-            <Label>Active</Label>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" type="button" @click="showCreate = false">Cancel</Button>
-            <Button type="submit" :disabled="createForm.processing">Create</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <!-- Edit dialog -->
+        <Dialog :open="editingId !== null" @update:open="(val) => { if (!val) editingId = null }">
+            <DialogContent>
+                <DialogHeader><DialogTitle>Edit Package</DialogTitle></DialogHeader>
+                <form class="flex flex-col gap-4" @submit.prevent="submitEdit">
+                    <div class="grid gap-1.5">
+                        <Label>Name</Label>
+                        <Input v-model="editForm.name" required />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Description</Label>
+                        <Input v-model="editForm.description" />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Price (₱)</Label>
+                        <Input v-model="editForm.base_price" type="number" step="0.01" min="0" required />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Sort Order</Label>
+                        <Input v-model.number="editForm.sort_order" type="number" min="0" />
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Switch v-model:checked="editForm.is_active" />
+                        <Label>Active / Published</Label>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" type="button" @click="editingId = null">Cancel</Button>
+                        <Button type="submit" :disabled="editForm.processing">Save</Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
 
-    <!-- Edit dialog -->
-    <Dialog :open="editingId !== null" @update:open="(val) => { if (!val) editingId = null }">
-      <DialogContent>
-        <DialogHeader><DialogTitle>Edit Package</DialogTitle></DialogHeader>
-        <form class="flex flex-col gap-4" @submit.prevent="submitEdit">
-          <div class="grid gap-1.5">
-            <Label>Name</Label>
-            <Input v-model="editForm.name" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Description</Label>
-            <Input v-model="editForm.description" />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Price (₱)</Label>
-            <Input v-model="editForm.base_price" type="number" step="0.01" min="0" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Sort Order</Label>
-            <Input v-model.number="editForm.sort_order" type="number" min="0" />
-          </div>
-          <div class="flex items-center gap-3">
-            <Switch v-model:checked="editForm.is_active" />
-            <Label>Active</Label>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" type="button" @click="editingId = null">Cancel</Button>
-            <Button type="submit" :disabled="editForm.processing">Save</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-
-    <!-- Delete confirmation -->
-    <AlertDialog :open="deleteTarget !== null" @update:open="(val) => { if (!val) deleteTarget = null }">
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete package?</AlertDialogTitle>
-          <AlertDialogDescription>
-            "{{ deleteTarget?.name }}" and all its allowed-menu rules will be removed permanently.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction class="bg-destructive text-destructive-foreground" @click="confirmDelete">
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  </AppLayout>
+        <!-- Delete confirmation -->
+        <AlertDialog :open="deleteTarget !== null" @update:open="(val) => { if (!val) deleteTarget = null }">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete package?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        "{{ deleteTarget?.name }}" and all its allowed-menu rules will be removed permanently.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction class="bg-destructive text-destructive-foreground" @click="confirmDelete">
+                        Delete
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    </AppLayout>
 </template>

--- a/resources/js/pages/package-configs/IndexPackageConfigs.vue
+++ b/resources/js/pages/package-configs/IndexPackageConfigs.vue
@@ -16,7 +16,7 @@ import {
     AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import {
-    Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+    Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 
 interface AllowedMenu {
@@ -41,7 +41,7 @@ interface PackageConfigVm {
 const props = defineProps<{ packages: PackageConfigVm[] }>()
 
 const breadcrumbs: BreadcrumbItem[] = [
-    { title: 'Packages', href: route('package-configs.index') },
+    { title: 'Dining Tiers', href: route('package-configs.index') },
 ]
 
 const orderedPackages = computed(() =>
@@ -59,8 +59,23 @@ function menusByType(pkg: PackageConfigVm, type: string) {
     return pkg.menus.filter((m) => (m.menu_type ?? 'meat') === type && m.is_active)
 }
 
-function isBestSeller(index: number): boolean {
-    return index === Math.floor(orderedPackages.value.length / 2)
+function formatPrice(value: string): string {
+    const n = parseFloat(String(value))
+    if (!Number.isFinite(n)) return value
+    return n.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+// ─── Manage Menus ──────────────────────────────────────────────────────────
+const manageMenusPkg = ref<PackageConfigVm | null>(null)
+
+function openManageMenus(pkg: PackageConfigVm) {
+    manageMenusPkg.value = pkg
+}
+
+function switchToEdit() {
+    const pkg = manageMenusPkg.value
+    manageMenusPkg.value = null
+    if (pkg) openEdit(pkg)
 }
 
 // ─── Create ────────────────────────────────────────────────────────────────
@@ -115,7 +130,7 @@ function confirmDelete() {
 </script>
 
 <template>
-    <Head title="Packages" />
+    <Head title="Dining Tiers" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-5">
@@ -132,7 +147,7 @@ function confirmDelete() {
                         </h2>
                         <p class="text-sm text-muted-foreground">
                             {{ activeCount }} active package{{ activeCount !== 1 ? 's' : '' }} ·
-                            {{ allPublished ? 'All published' : 'Some inactive' }}
+                            {{ packages.length === 0 ? '' : allPublished ? 'All published' : 'Some inactive' }}
                         </p>
                     </div>
                     <div class="flex gap-2">
@@ -159,18 +174,8 @@ function confirmDelete() {
                         <div
                             v-for="(pkg, index) in orderedPackages"
                             :key="pkg.id"
-                            class="relative flex flex-col gap-4 rounded-[18px] border bg-white/60 p-5 transition-all duration-150 dark:bg-white/[0.04]"
-                            :class="isBestSeller(index)
-                                ? 'border-[#f6b56d]/60 shadow-md shadow-[#f6b56d]/10 dark:border-[#f6b56d]/40'
-                                : 'border-black/8 dark:border-white/10'"
+                            class="relative flex flex-col gap-4 rounded-[18px] border border-black/8 bg-white/60 p-5 transition-all duration-150 dark:border-white/10 dark:bg-white/[0.04]"
                         >
-                            <!-- Best seller ribbon -->
-                            <div v-if="isBestSeller(index)" class="absolute right-0 top-0 overflow-hidden rounded-tr-[18px]">
-                                <div class="translate-x-2 -translate-y-px rotate-45 origin-bottom-left bg-[#f6b56d] px-6 py-0.5 text-[9px] font-bold tracking-widest text-black uppercase">
-                                    BEST SELLER
-                                </div>
-                            </div>
-
                             <!-- Tier label + name -->
                             <div>
                                 <p class="text-[10px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
@@ -182,7 +187,7 @@ function confirmDelete() {
 
                             <!-- Price -->
                             <div class="flex items-baseline gap-1">
-                                <span class="font-mono text-3xl font-bold text-[#f6b56d]">₱{{ pkg.base_price }}</span>
+                                <span class="font-mono text-3xl font-bold text-[#f6b56d]">₱{{ formatPrice(pkg.base_price) }}</span>
                                 <span class="text-sm text-muted-foreground">/ pax</span>
                             </div>
 
@@ -218,6 +223,21 @@ function confirmDelete() {
                                 </ul>
                             </div>
 
+                            <!-- Beverages section -->
+                            <div v-if="menusByType(pkg, 'beverage').length > 0">
+                                <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Beverages</p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="m in menusByType(pkg, 'beverage')"
+                                        :key="m.id"
+                                        class="flex items-center gap-2 text-sm text-foreground"
+                                    >
+                                        <Check class="h-3.5 w-3.5 shrink-0 text-woosoo-green" />
+                                        {{ m.name }}
+                                    </li>
+                                </ul>
+                            </div>
+
                             <!-- All items fallback (if no menu_type separation) -->
                             <div v-if="menusByType(pkg, 'meat').length === 0 && pkg.menus.length > 0">
                                 <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
@@ -243,12 +263,15 @@ function confirmDelete() {
                                 No menu items configured
                             </div>
 
-                            <!-- Status badge -->
+                            <!-- Status badge + actions -->
                             <div class="flex items-center justify-between border-t border-black/5 pt-3 dark:border-white/8">
                                 <Badge :variant="pkg.is_active ? 'default' : 'secondary'" class="text-[10px]">
                                     {{ pkg.is_active ? 'Published' : 'Inactive' }}
                                 </Badge>
                                 <div class="flex gap-1">
+                                    <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openManageMenus(pkg)">
+                                        Manage Menus
+                                    </Button>
                                     <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openEdit(pkg)">
                                         <Pencil class="mr-1 h-3 w-3" /> Edit
                                     </Button>
@@ -262,6 +285,58 @@ function confirmDelete() {
                 </div>
             </section>
         </div>
+
+        <!-- Manage Menus dialog -->
+        <Dialog :open="manageMenusPkg !== null" @update:open="(val) => { if (!val) manageMenusPkg = null }">
+            <DialogContent class="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Menus — {{ manageMenusPkg?.name }}</DialogTitle>
+                    <DialogDescription>
+                        Menu items are synced from the POS configuration. To add or remove items, update the package in the POS system, then sync.
+                    </DialogDescription>
+                </DialogHeader>
+                <div v-if="manageMenusPkg" class="max-h-72 space-y-3 overflow-y-auto py-1">
+                    <div v-if="manageMenusPkg.menus.length === 0" class="py-4 text-center text-sm text-muted-foreground">
+                        No menu items attached to this package.
+                    </div>
+                    <template v-else>
+                        <div v-if="menusByType(manageMenusPkg, 'meat').length > 0">
+                            <p class="mb-1 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Meats</p>
+                            <ul class="space-y-1">
+                                <li v-for="m in menusByType(manageMenusPkg, 'meat')" :key="m.id" class="flex items-center gap-2 text-sm">
+                                    <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-[#f6b56d]" />
+                                    {{ m.name }}
+                                    <Badge variant="secondary" class="ml-auto text-[9px]">{{ m.menu_type ?? 'meat' }}</Badge>
+                                </li>
+                            </ul>
+                        </div>
+                        <div v-if="menusByType(manageMenusPkg, 'side').length > 0 || menusByType(manageMenusPkg, 'dessert').length > 0">
+                            <p class="mb-1 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Add-ons</p>
+                            <ul class="space-y-1">
+                                <li v-for="m in [...menusByType(manageMenusPkg, 'side'), ...menusByType(manageMenusPkg, 'dessert')]" :key="m.id" class="flex items-center gap-2 text-sm">
+                                    <Check class="h-3 w-3 shrink-0 text-woosoo-green" />
+                                    {{ m.name }}
+                                    <Badge variant="secondary" class="ml-auto text-[9px]">{{ m.menu_type }}</Badge>
+                                </li>
+                            </ul>
+                        </div>
+                        <div v-if="menusByType(manageMenusPkg, 'beverage').length > 0">
+                            <p class="mb-1 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Beverages</p>
+                            <ul class="space-y-1">
+                                <li v-for="m in menusByType(manageMenusPkg, 'beverage')" :key="m.id" class="flex items-center gap-2 text-sm">
+                                    <Check class="h-3 w-3 shrink-0 text-woosoo-green" />
+                                    {{ m.name }}
+                                </li>
+                            </ul>
+                        </div>
+                    </template>
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" @click="manageMenusPkg = null">Close</Button>
+                    <Button variant="ghost" @click="switchToEdit">Edit Tier Details</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
 
         <!-- Create dialog -->
         <Dialog :open="showCreate" @update:open="showCreate = $event">

--- a/resources/js/pages/package-configs/IndexPackageConfigs.vue
+++ b/resources/js/pages/package-configs/IndexPackageConfigs.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
-import { Plus, Pencil, Trash2, Eye, Check } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, Check } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import type { BreadcrumbItem } from '@/types'
 import { Button } from '@/components/ui/button'

--- a/resources/js/pages/tablet-categories/IndexTabletCategories.vue
+++ b/resources/js/pages/tablet-categories/IndexTabletCategories.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from 'vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
-import { Plus, Pencil, Trash2, GripVertical, Star, X, Search } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, GripVertical, Star, X, Search, RefreshCw } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import type { BreadcrumbItem } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -58,6 +58,7 @@ const selectedCategory = computed(() =>
 
 // ─── Category Drag Reorder ─────────────────────────────────────────────────
 const dragOverId = ref<number | null>(null)
+const isReordering = ref(false)
 let draggingId: number | null = null
 
 function onDragStart(id: number) { draggingId = id }
@@ -79,12 +80,14 @@ function onDrop(targetId: number) {
     const [moved] = ordered.splice(fromIdx, 1)
     ordered.splice(toIdx, 0, moved)
     dragOverId.value = null
+    isReordering.value = true
     router.put(route('tablet-categories.reorder'), {
         ids: ordered.map((c) => c.id),
     }, {
         preserveScroll: true,
         onSuccess: () => toast.success('Order saved.'),
         onError: () => toast.error('Failed to save order.'),
+        onFinish: () => { isReordering.value = false },
     })
 }
 
@@ -248,13 +251,14 @@ function submitAttach() {
 
             <!-- Two-pane layout -->
             <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
-                <div class="flex min-h-[480px] divide-x divide-black/8 dark:divide-white/10">
+                <div class="flex min-h-[480px] flex-col lg:flex-row divide-y lg:divide-y-0 lg:divide-x divide-black/8 dark:divide-white/10">
                     <!-- Left pane: category list -->
-                    <div class="w-72 shrink-0 flex flex-col">
+                    <div class="w-full lg:w-72 lg:shrink-0 flex flex-col">
                         <div class="border-b border-black/8 px-4 py-3 dark:border-white/10">
-                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                            <p class="flex items-center text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
                                 Categories
-                                <Badge variant="secondary" class="ml-1 text-[9px]">{{ categories.length }} active</Badge>
+                                <Badge variant="secondary" class="ml-1 text-[9px]">{{ categories.filter(c => c.is_active).length }} active</Badge>
+                                <RefreshCw v-if="isReordering" class="ml-1.5 h-3 w-3 animate-spin" />
                             </p>
                         </div>
                         <div class="flex-1 overflow-y-auto py-1">

--- a/resources/js/pages/tablet-categories/IndexTabletCategories.vue
+++ b/resources/js/pages/tablet-categories/IndexTabletCategories.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
-import { Plus, Pencil, Trash2, LayoutList } from 'lucide-vue-next'
+import { Plus, Pencil, Trash2, GripVertical, Star, X, Search } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import type { BreadcrumbItem } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -10,222 +10,512 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
-} from '@/components/ui/table'
-import {
-  AlertDialog, AlertDialogAction, AlertDialogCancel,
-  AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
-  AlertDialogHeader, AlertDialogTitle,
+    AlertDialog, AlertDialogAction, AlertDialogCancel,
+    AlertDialogContent, AlertDialogDescription, AlertDialogFooter,
+    AlertDialogHeader, AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
 import {
-  Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
+    Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog'
 
-interface CategoryVm {
-  id: number
-  name: string
-  slug: string
-  sort_order: number
-  is_active: boolean
+interface CategoryMenu {
+    id: number
+    krypton_menu_id: number
+    name: string
+    is_featured: boolean
+    sort_order: number
 }
 
-defineProps<{ categories: CategoryVm[] }>()
+interface CategoryVm {
+    id: number
+    name: string
+    slug: string
+    sort_order: number
+    is_active: boolean
+    menu_count: number
+    menus: CategoryMenu[]
+}
+
+interface UnattachedMenu {
+    id: number
+    name: string
+}
+
+const props = defineProps<{
+    categories: CategoryVm[]
+    unattachedMenus?: UnattachedMenu[]
+}>()
 
 const breadcrumbs: BreadcrumbItem[] = [
-  { title: 'Tablet Categories', href: route('tablet-categories.index') },
+    { title: 'Tablet Categories', href: route('tablet-categories.index') },
 ]
 
-// ─── Create ──────────────────────────────────────────────────────────────────
+const selectedId = ref<number | null>(props.categories[0]?.id ?? null)
+const selectedCategory = computed(() =>
+    props.categories.find((c) => c.id === selectedId.value) ?? null,
+)
+
+// ─── Category Drag Reorder ─────────────────────────────────────────────────
+const dragOverId = ref<number | null>(null)
+let draggingId: number | null = null
+
+function onDragStart(id: number) { draggingId = id }
+function onDragEnd() {
+    draggingId = null
+    dragOverId.value = null
+}
+function onDragOver(e: DragEvent, id: number) {
+    e.preventDefault()
+    dragOverId.value = id
+}
+
+function onDrop(targetId: number) {
+    if (!draggingId || draggingId === targetId) return
+    const ordered = [...props.categories].sort((a, b) => a.sort_order - b.sort_order)
+    const fromIdx = ordered.findIndex((c) => c.id === draggingId)
+    const toIdx   = ordered.findIndex((c) => c.id === targetId)
+    if (fromIdx === -1 || toIdx === -1) return
+    const [moved] = ordered.splice(fromIdx, 1)
+    ordered.splice(toIdx, 0, moved)
+    dragOverId.value = null
+    router.put(route('tablet-categories.reorder'), {
+        ids: ordered.map((c) => c.id),
+    }, {
+        preserveScroll: true,
+        onSuccess: () => toast.success('Order saved.'),
+        onError: () => toast.error('Failed to save order.'),
+    })
+}
+
+// ─── Create category ──────────────────────────────────────────────────────
 const showCreate = ref(false)
 const createForm = useForm({ name: '', slug: '', sort_order: 0, is_active: true })
 
 function submitCreate() {
-  createForm.post(route('tablet-categories.store'), {
-    onSuccess: () => {
-      showCreate.value = false
-      createForm.reset()
-      toast.success('Category created.')
-    },
-  })
+    createForm.post(route('tablet-categories.store'), {
+        onSuccess: () => {
+            showCreate.value = false
+            createForm.reset()
+            toast.success('Category created.')
+        },
+    })
 }
 
-// ─── Edit ─────────────────────────────────────────────────────────────────────
+// ─── Edit category ────────────────────────────────────────────────────────
 const editingId = ref<number | null>(null)
 const editForm = useForm({ name: '', slug: '', sort_order: 0, is_active: true })
 
 function openEdit(cat: CategoryVm) {
-  editingId.value = cat.id
-  editForm.name       = cat.name
-  editForm.slug       = cat.slug
-  editForm.sort_order = cat.sort_order
-  editForm.is_active  = cat.is_active
+    editingId.value    = cat.id
+    editForm.name       = cat.name
+    editForm.slug       = cat.slug
+    editForm.sort_order = cat.sort_order
+    editForm.is_active  = cat.is_active
 }
 
 function submitEdit() {
-  if (!editingId.value) return
-  editForm.put(route('tablet-categories.update', editingId.value), {
-    onSuccess: () => {
-      editingId.value = null
-      toast.success('Category updated.')
-    },
-  })
+    if (!editingId.value) return
+    editForm.put(route('tablet-categories.update', editingId.value), {
+        onSuccess: () => {
+            editingId.value = null
+            toast.success('Category updated.')
+        },
+    })
 }
 
-// ─── Delete ───────────────────────────────────────────────────────────────────
+// ─── Delete category ──────────────────────────────────────────────────────
 const deleteTarget = ref<CategoryVm | null>(null)
 
-function confirmDelete() {
-  if (!deleteTarget.value) return
-  router.delete(route('tablet-categories.destroy', deleteTarget.value.id), {
-    onSuccess: () => {
-      deleteTarget.value = null
-      toast.success('Category deleted.')
-    },
-  })
+function executeDelete() {
+    if (!deleteTarget.value) return
+    const id = deleteTarget.value.id
+    router.delete(route('tablet-categories.destroy', id), {
+        preserveScroll: true,
+        onSuccess: () => {
+            if (selectedId.value === id) {
+                selectedId.value = props.categories.find((c) => c.id !== id)?.id ?? null
+            }
+            deleteTarget.value = null
+            toast.success('Category deleted.')
+        },
+    })
+}
+
+// ─── Toggle category active ───────────────────────────────────────────────
+function toggleActive(cat: CategoryVm) {
+    router.put(route('tablet-categories.update', cat.id), {
+        name: cat.name,
+        slug: cat.slug,
+        sort_order: cat.sort_order,
+        is_active: !cat.is_active,
+    }, {
+        preserveScroll: true,
+        onSuccess: () => toast.success(`${cat.name} ${!cat.is_active ? 'activated' : 'deactivated'}.`),
+    })
+}
+
+// ─── Detach menu ──────────────────────────────────────────────────────────
+const detachTarget = ref<{ catId: number; menuId: number; name: string } | null>(null)
+
+function confirmDetach(cat: CategoryVm, menu: CategoryMenu) {
+    detachTarget.value = { catId: cat.id, menuId: menu.krypton_menu_id, name: menu.name }
+}
+
+function executeDetach() {
+    if (!detachTarget.value) return
+    const { catId, menuId } = detachTarget.value
+    detachTarget.value = null
+    router.delete(route('tablet-categories.menus.detach', { tabletCategory: catId, menuId }), {
+        preserveScroll: true,
+        onSuccess: () => toast.success('Menu detached.'),
+        onError: () => toast.error('Failed to detach menu.'),
+    })
+}
+
+// ─── Toggle featured ─────────────────────────────────────────────────────
+function toggleFeatured(cat: CategoryVm, menu: CategoryMenu) {
+    router.post(route('tablet-categories.menus.featured', { tabletCategory: cat.id, menuId: menu.krypton_menu_id }), {}, {
+        preserveScroll: true,
+        onSuccess: () => toast.success(`${menu.name} ${!menu.is_featured ? 'featured' : 'unfeatured'}.`),
+    })
+}
+
+// ─── Attach menus ─────────────────────────────────────────────────────────
+const showAttach = ref(false)
+const attachSearch = ref('')
+const selectedAttachIds = ref<number[]>([])
+
+const filteredUnattached = computed(() => {
+    const needle = attachSearch.value.trim().toLowerCase()
+    return (props.unattachedMenus ?? []).filter((m) =>
+        !needle || m.name.toLowerCase().includes(needle),
+    )
+})
+
+function toggleAttachSelection(id: number) {
+    const idx = selectedAttachIds.value.indexOf(id)
+    if (idx === -1) {
+        selectedAttachIds.value.push(id)
+    } else {
+        selectedAttachIds.value.splice(idx, 1)
+    }
+}
+
+function submitAttach() {
+    if (!selectedCategory.value || selectedAttachIds.value.length === 0) return
+    router.post(
+        route('tablet-categories.menus.attach', selectedCategory.value.id),
+        { menu_ids: selectedAttachIds.value },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                showAttach.value = false
+                selectedAttachIds.value = []
+                attachSearch.value = ''
+                toast.success('Menu(s) attached.')
+            },
+            onError: () => toast.error('Failed to attach menus.'),
+        },
+    )
 }
 </script>
 
 <template>
-  <AppLayout :breadcrumbs="breadcrumbs">
     <Head title="Tablet Categories" />
 
-    <div class="flex flex-col gap-6 p-4 md:p-6">
-      <!-- Header -->
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <LayoutList class="h-5 w-5 text-muted-foreground" />
-          <h1 class="text-xl font-semibold">Tablet Categories</h1>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="space-y-5">
+            <!-- Hero header -->
+            <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#f6b56d]/10 via-transparent to-transparent dark:from-[#f6b56d]/6" />
+                <div class="relative flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                    <div class="space-y-2">
+                        <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
+                            Menu Sync
+                        </span>
+                        <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+                            Tablet Categories
+                        </h2>
+                        <p class="text-sm text-muted-foreground">Drag to reorder · changes reflect on tablets immediately</p>
+                    </div>
+                    <Button size="sm" @click="showCreate = true">
+                        <Plus class="mr-1.5 h-3.5 w-3.5" />
+                        New Category
+                    </Button>
+                </div>
+            </section>
+
+            <!-- Two-pane layout -->
+            <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
+                <div class="flex min-h-[480px] divide-x divide-black/8 dark:divide-white/10">
+                    <!-- Left pane: category list -->
+                    <div class="w-72 shrink-0 flex flex-col">
+                        <div class="border-b border-black/8 px-4 py-3 dark:border-white/10">
+                            <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                                Categories
+                                <Badge variant="secondary" class="ml-1 text-[9px]">{{ categories.length }} active</Badge>
+                            </p>
+                        </div>
+                        <div class="flex-1 overflow-y-auto py-1">
+                            <div
+                                v-for="(cat, index) in [...categories].sort((a, b) => a.sort_order - b.sort_order)"
+                                :key="cat.id"
+                                class="flex cursor-pointer items-center gap-2 px-3 py-2.5 transition-colors"
+                                :class="{
+                                    'bg-[#2a1e0c] text-[#F6B56D]': selectedId === cat.id,
+                                    'hover:bg-black/4 dark:hover:bg-white/4': selectedId !== cat.id,
+                                    'border-t-2 border-[#f6b56d]/60': dragOverId === cat.id,
+                                }"
+                                draggable="true"
+                                @click="selectedId = cat.id"
+                                @dragstart="onDragStart(cat.id)"
+                                @dragend="onDragEnd"
+                                @dragover="onDragOver($event, cat.id)"
+                                @drop="onDrop(cat.id)"
+                            >
+                                <GripVertical class="h-3.5 w-3.5 shrink-0 cursor-grab text-muted-foreground/40" />
+                                <span class="w-4 shrink-0 font-mono text-[10px] text-muted-foreground">#{{ index + 1 }}</span>
+                                <span class="min-w-0 flex-1 truncate text-sm font-medium">{{ cat.name }}</span>
+                                <span class="font-mono text-[10px] text-muted-foreground">{{ cat.menu_count }}</span>
+                                <button
+                                    class="shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase transition-colors"
+                                    :class="cat.is_active
+                                        ? 'bg-woosoo-green/10 text-woosoo-green hover:bg-woosoo-green/20'
+                                        : 'bg-muted text-muted-foreground hover:bg-muted/80'"
+                                    @click.stop="toggleActive(cat)"
+                                >
+                                    {{ cat.is_active ? 'Active' : 'Off' }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Right pane: category detail -->
+                    <div class="flex min-w-0 flex-1 flex-col">
+                        <div v-if="!selectedCategory" class="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+                            Select a category to manage its menus.
+                        </div>
+
+                        <template v-else>
+                            <!-- Right pane header -->
+                            <div class="flex items-center justify-between border-b border-black/8 px-5 py-3 dark:border-white/10">
+                                <div class="flex items-center gap-2">
+                                    <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                                        :class="selectedCategory.is_active
+                                            ? 'bg-woosoo-green/10 text-woosoo-green'
+                                            : 'bg-muted text-muted-foreground'"
+                                    >
+                                        <span class="h-1.5 w-1.5 rounded-full"
+                                            :class="selectedCategory.is_active ? 'bg-woosoo-green' : 'bg-muted-foreground/40'"
+                                        />
+                                        {{ selectedCategory.is_active ? 'Active' : 'Off' }}
+                                    </span>
+                                    <h3 class="font-semibold text-foreground">{{ selectedCategory.name }}</h3>
+                                </div>
+                                <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openEdit(selectedCategory)">
+                                    <Pencil class="mr-1 h-3 w-3" /> Edit
+                                </Button>
+                            </div>
+
+                            <!-- Fields strip -->
+                            <div class="grid grid-cols-3 gap-4 border-b border-black/8 px-5 py-3 dark:border-white/10">
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Slug</p>
+                                    <p class="mt-0.5 font-mono text-xs">{{ selectedCategory.slug }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Sort Order</p>
+                                    <p class="mt-0.5 font-mono text-xs">#{{ selectedCategory.sort_order }}</p>
+                                </div>
+                                <div>
+                                    <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Menu Items</p>
+                                    <p class="mt-0.5 font-mono text-xs">{{ selectedCategory.menu_count }}</p>
+                                </div>
+                            </div>
+
+                            <!-- Attached menus label -->
+                            <div class="flex items-center justify-between px-5 py-3">
+                                <p class="text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Attached Menus</p>
+                            </div>
+
+                            <!-- Menu list -->
+                            <div class="flex-1 overflow-y-auto">
+                                <div v-if="selectedCategory.menus.length === 0" class="px-5 py-8 text-center text-sm text-muted-foreground">
+                                    No items attached. Use "+ Attach Menu" below.
+                                </div>
+                                <div v-else>
+                                    <div
+                                        v-for="menu in selectedCategory.menus"
+                                        :key="menu.id"
+                                        class="flex items-center gap-3 border-b border-black/5 px-5 py-2.5 last:border-b-0 dark:border-white/5"
+                                    >
+                                        <span class="min-w-0 flex-1 truncate text-sm text-foreground">{{ menu.name }}</span>
+                                        <button
+                                            class="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase transition-colors"
+                                            :class="menu.is_featured
+                                                ? 'bg-[#f6b56d]/20 text-[#f6b56d] hover:bg-[#f6b56d]/30'
+                                                : 'bg-muted text-muted-foreground hover:bg-muted/80'"
+                                            @click="toggleFeatured(selectedCategory, menu)"
+                                        >
+                                            <Star class="inline-block h-2.5 w-2.5" :fill="menu.is_featured ? 'currentColor' : 'none'" />
+                                            {{ menu.is_featured ? 'Featured' : 'Feature' }}
+                                        </button>
+                                        <button
+                                            class="shrink-0 text-muted-foreground/60 transition-colors hover:text-destructive"
+                                            @click="confirmDetach(selectedCategory, menu)"
+                                        >
+                                            <X class="h-3.5 w-3.5" />
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Footer: attach + delete -->
+                            <div class="flex items-center justify-between border-t border-black/8 px-5 py-3 dark:border-white/10">
+                                <Button variant="outline" size="sm" @click="showAttach = true">
+                                    <Plus class="mr-1.5 h-3.5 w-3.5" />
+                                    Attach Menu
+                                </Button>
+                                <Button variant="ghost" size="sm" class="h-7 px-2 text-xs text-destructive hover:text-destructive" @click="deleteTarget = selectedCategory">
+                                    <Trash2 class="mr-1 h-3 w-3" />
+                                    Delete Category
+                                </Button>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </section>
         </div>
-        <Button size="sm" @click="showCreate = true">
-          <Plus class="mr-1 h-4 w-4" /> New Category
-        </Button>
-      </div>
 
-      <!-- Table -->
-      <Card>
-        <CardContent class="p-0">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Slug</TableHead>
-                <TableHead>Order</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead class="text-right">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow v-for="cat in categories" :key="cat.id">
-                <TableCell class="font-medium">{{ cat.name }}</TableCell>
-                <TableCell class="text-muted-foreground text-sm">{{ cat.slug }}</TableCell>
-                <TableCell>{{ cat.sort_order }}</TableCell>
-                <TableCell>
-                  <Badge :variant="cat.is_active ? 'default' : 'secondary'">
-                    {{ cat.is_active ? 'Active' : 'Inactive' }}
-                  </Badge>
-                </TableCell>
-                <TableCell class="text-right">
-                  <div class="flex justify-end gap-1">
-                    <Button variant="ghost" size="icon" @click="openEdit(cat)">
-                      <Pencil class="h-4 w-4" />
+        <!-- Create dialog -->
+        <Dialog :open="showCreate" @update:open="showCreate = $event">
+            <DialogContent>
+                <DialogHeader><DialogTitle>New Category</DialogTitle></DialogHeader>
+                <form class="flex flex-col gap-4" @submit.prevent="submitCreate">
+                    <div class="grid gap-1.5">
+                        <Label>Name</Label>
+                        <Input v-model="createForm.name" required />
+                        <p v-if="createForm.errors.name" class="text-xs text-destructive">{{ createForm.errors.name }}</p>
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Slug <span class="text-muted-foreground">(optional)</span></Label>
+                        <Input v-model="createForm.slug" placeholder="auto-generated from name" />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Sort Order</Label>
+                        <Input v-model.number="createForm.sort_order" type="number" min="0" />
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Switch v-model:checked="createForm.is_active" />
+                        <Label>Active</Label>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" type="button" @click="showCreate = false">Cancel</Button>
+                        <Button type="submit" :disabled="createForm.processing">Create</Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+
+        <!-- Edit dialog -->
+        <Dialog :open="editingId !== null" @update:open="(val) => { if (!val) editingId = null }">
+            <DialogContent>
+                <DialogHeader><DialogTitle>Edit Category</DialogTitle></DialogHeader>
+                <form class="flex flex-col gap-4" @submit.prevent="submitEdit">
+                    <div class="grid gap-1.5">
+                        <Label>Name</Label>
+                        <Input v-model="editForm.name" required />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Slug</Label>
+                        <Input v-model="editForm.slug" />
+                    </div>
+                    <div class="grid gap-1.5">
+                        <Label>Sort Order</Label>
+                        <Input v-model.number="editForm.sort_order" type="number" min="0" />
+                    </div>
+                    <div class="flex items-center gap-3">
+                        <Switch v-model:checked="editForm.is_active" />
+                        <Label>Active</Label>
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" type="button" @click="editingId = null">Cancel</Button>
+                        <Button type="submit" :disabled="editForm.processing">Save</Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+
+        <!-- Attach menus dialog -->
+        <Dialog :open="showAttach" @update:open="(val) => { if (!val) { showAttach = false; selectedAttachIds = []; attachSearch = '' } }">
+            <DialogContent class="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Attach Menu Items</DialogTitle>
+                </DialogHeader>
+                <div class="flex flex-col gap-3">
+                    <div class="relative">
+                        <Search class="absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" />
+                        <Input v-model="attachSearch" placeholder="Search menus…" class="pl-8" />
+                    </div>
+                    <div class="max-h-64 overflow-y-auto rounded-md border">
+                        <div
+                            v-for="m in filteredUnattached"
+                            :key="m.id"
+                            class="flex cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-muted/50"
+                            :class="{ 'bg-[#f6b56d]/10': selectedAttachIds.includes(m.id) }"
+                            @click="toggleAttachSelection(m.id)"
+                        >
+                            <div class="h-3.5 w-3.5 shrink-0 rounded border"
+                                :class="selectedAttachIds.includes(m.id) ? 'border-[#f6b56d] bg-[#f6b56d]' : 'border-border'"
+                            />
+                            <span class="text-sm">{{ m.name }}</span>
+                        </div>
+                        <p v-if="filteredUnattached.length === 0" class="py-6 text-center text-xs text-muted-foreground">
+                            No unattached menus found.
+                        </p>
+                    </div>
+                    <p class="text-xs text-muted-foreground">{{ selectedAttachIds.length }} selected</p>
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" @click="showAttach = false">Cancel</Button>
+                    <Button :disabled="selectedAttachIds.length === 0" @click="submitAttach">
+                        Attach {{ selectedAttachIds.length > 0 ? `(${selectedAttachIds.length})` : '' }}
                     </Button>
-                    <Button variant="ghost" size="icon" class="text-destructive" @click="deleteTarget = cat">
-                      <Trash2 class="h-4 w-4" />
-                    </Button>
-                  </div>
-                </TableCell>
-              </TableRow>
-              <TableRow v-if="!categories.length">
-                <TableCell colspan="5" class="text-center text-muted-foreground py-8">
-                  No categories yet. Falling back to built-in defaults.
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </CardContent>
-      </Card>
-    </div>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
 
-    <!-- Create dialog -->
-    <Dialog :open="showCreate" @update:open="showCreate = $event">
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>New Category</DialogTitle>
-        </DialogHeader>
-        <form class="flex flex-col gap-4" @submit.prevent="submitCreate">
-          <div class="grid gap-1.5">
-            <Label for="c-name">Name</Label>
-            <Input id="c-name" v-model="createForm.name" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label for="c-slug">Slug <span class="text-muted-foreground text-xs">(auto-generated if empty)</span></Label>
-            <Input id="c-slug" v-model="createForm.slug" placeholder="e.g. grilled-meats" />
-          </div>
-          <div class="grid gap-1.5">
-            <Label for="c-order">Sort Order</Label>
-            <Input id="c-order" v-model.number="createForm.sort_order" type="number" min="0" />
-          </div>
-          <div class="flex items-center gap-3">
-            <Switch id="c-active" v-model:checked="createForm.is_active" />
-            <Label for="c-active">Active</Label>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" type="button" @click="showCreate = false">Cancel</Button>
-            <Button type="submit" :disabled="createForm.processing">Create</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <!-- Detach confirmation -->
+        <AlertDialog :open="detachTarget !== null" @update:open="(val) => { if (!val) detachTarget = null }">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Detach menu?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        "{{ detachTarget?.name }}" will be removed from this category.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction @click="executeDetach">Detach</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
 
-    <!-- Edit dialog -->
-    <Dialog :open="editingId !== null" @update:open="(val) => { if (!val) editingId = null }">
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Edit Category</DialogTitle>
-        </DialogHeader>
-        <form class="flex flex-col gap-4" @submit.prevent="submitEdit">
-          <div class="grid gap-1.5">
-            <Label>Name</Label>
-            <Input v-model="editForm.name" required />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Slug</Label>
-            <Input v-model="editForm.slug" />
-          </div>
-          <div class="grid gap-1.5">
-            <Label>Sort Order</Label>
-            <Input v-model.number="editForm.sort_order" type="number" min="0" />
-          </div>
-          <div class="flex items-center gap-3">
-            <Switch v-model:checked="editForm.is_active" />
-            <Label>Active</Label>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" type="button" @click="editingId = null">Cancel</Button>
-            <Button type="submit" :disabled="editForm.processing">Save Changes</Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
-
-    <!-- Delete confirmation -->
-    <AlertDialog :open="deleteTarget !== null" @update:open="(val) => { if (!val) deleteTarget = null }">
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete category?</AlertDialogTitle>
-          <AlertDialogDescription>
-            "{{ deleteTarget?.name }}" and all its menu assignments will be removed. This cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction class="bg-destructive text-destructive-foreground" @click="confirmDelete">
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  </AppLayout>
+        <!-- Delete category confirmation -->
+        <AlertDialog :open="deleteTarget !== null" @update:open="(val) => { if (!val) deleteTarget = null }">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete category?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        "{{ deleteTarget?.name }}" and all its menu attachments will be removed permanently.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction class="bg-destructive text-destructive-foreground" @click="executeDelete">Delete</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    </AppLayout>
 </template>

--- a/resources/js/types/models.d.ts
+++ b/resources/js/types/models.d.ts
@@ -53,22 +53,35 @@ export interface TableOrder {
     order?: Order;
 }
 
+export interface DeviceHeartbeat {
+    device_id: number;
+    battery_level: number | null;
+    recorded_at: string;
+    app_version: string | null;
+    wifi_signal_dbm: number | null;
+    ping_ms: number | null;
+}
+
 export interface Device {
-  id: number;
+    id: number;
     name: string;
-        table_id: number | null;
-        branch_id: number;
+    table_id: number | null;
+    branch_id: number;
     is_active: boolean;
-        device_uuid?: string;
+    status?: string;
+    device_uuid?: string;
     ip_address?: string;
-        last_ip_address?: string;
-        last_seen_at?: string;
-        type?: string;
-        security_code_generated_at?: string;
+    last_ip_address?: string;
+    last_seen_at?: string;
+    last_heartbeat_at?: string;
+    app_version?: string;
+    type?: string;
+    security_code_generated_at?: string;
     deleted_at?: string;
     port?: number;
     branch?: Branch;
     table?: Table;
+    latest_heartbeat?: DeviceHeartbeat | null;
 }
 
 export interface DeviceOrder {

--- a/resources/views/devices/certificate.blade.php
+++ b/resources/views/devices/certificate.blade.php
@@ -320,8 +320,8 @@
         <div class="unavail-title">Certificate Not Found</div>
         <div class="unavail-desc">
           The CA certificate file is not present on this server.
-          Contact your system administrator to place the certificate at
-          <code>docker/certs/fullchain.pem</code> or <code>storage/app/public/certificates/woosoo-ca.der</code>.
+          Contact your system administrator — the platform CA must be present at
+          <code>docker/certs/rootCA.crt</code> (mounted into the app container from the platform repo).
         </div>
       </div>
     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ use App\Models\Krypton\Menu;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\PersonalAccessToken;
@@ -375,7 +376,9 @@ Route::middleware([RequestId::class, 'api'])->group(function () {
         try {
             $rows = DB::connection('pos')->select('CALL get_menus_by_course(?)', [$course]);
         } catch (Throwable $e) {
-            return ApiResponse::error('Stored procedure call failed: '.$e->getMessage(), null, 500);
+            Log::error('[debug/pos] stored procedure failed', ['error' => $e->getMessage(), 'course' => $course]);
+
+            return ApiResponse::error('POS stored procedure failed. Check Laravel log.', null, 500);
         }
 
         $ids = collect($rows)->pluck('id')->unique()->values()->all();

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,8 +99,15 @@ Route::middleware([
     'auth:device',
     UpdateDeviceLastSeen::class,
 ])->get('/order/{orderId}/dispatch', function (Request $request, int $orderId) {
-    $order = DeviceOrder::where(['order_id' => $orderId])->first();
+    $order = DeviceOrder::where('order_id', $orderId)->first();
+
+    if (! $order) {
+        return response()->json(['message' => 'Order not found.'], 404);
+    }
+
     PrintOrder::dispatch($order);
+
+    return response()->json(['status' => 'dispatched']);
 });
 
 // Device-only refill/printed endpoints moved under auth:device group below

--- a/routes/web.php
+++ b/routes/web.php
@@ -272,7 +272,16 @@ Route::middleware(['auth'])->group(function () {
 
                 return response()->json(['success' => false, 'message' => 'Device order not found'], 404);
             } catch (Throwable $e) {
-                return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+                // Log the real cause for ops; never leak the raw exception to the client.
+                \Illuminate\Support\Facades\Log::error('[pos.fill-order] update failed', [
+                    'order_id' => $orderId,
+                    'exception' => $e->getMessage(),
+                ]);
+
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Could not update the order. Please try again.',
+                ], 500);
             }
         })->name('pos.fill-order');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,8 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware(['can:admin'])->group(function () {
         // Orders
         Route::get('/kds', [KdsController::class, 'index'])->name('kds.display');
+        Route::post('/kds/orders/{order}/advance', [KdsController::class, 'advance'])->name('kds.advance');
+        Route::post('/kds/items/{item}/toggle', [KdsController::class, 'toggleItem'])->name('kds.toggle-item');
 
         Route::get('/orders', [OrderController::class, 'index'])->name('orders.index');
         Route::get('/orders/{id}', [OrderController::class, 'show'])->name('orders.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,5 @@
 <?php
 
-use App\Enums\OrderStatus;
-use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderVoided;
 use App\Http\Controllers\Admin\AccessibilityController;
 use App\Http\Controllers\Admin\BranchController;
 use App\Http\Controllers\Admin\DashboardController;
@@ -25,7 +22,6 @@ use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\ServiceRequestController;
 use App\Http\Controllers\Admin\TabletCategoryController;
 use App\Http\Controllers\Admin\UserController;
-use App\Models\DeviceOrder;
 use App\Services\LocalBranchResolver;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -234,57 +230,7 @@ Route::middleware(['auth'])->group(function () {
             Route::post('/restart', [ReverbController::class, 'restart'])->name('restart');
         });
 
-        // Update device_orders directly (admin only)
-        Route::post('/pos/fill-order', function (Request $request) {
-            $user = $request->user();
-            if (! $user || ! ($user->is_admin ?? false)) {
-                return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
-            }
-
-            $data = $request->validate([
-                'order_id' => ['required'],
-                'date_time_closed' => ['nullable', 'date'],
-                'is_open' => ['nullable', 'in:0,1'],
-                'is_voided' => ['nullable', 'in:0,1'],
-                'session_id' => ['nullable', 'integer'],
-            ]);
-
-            $orderId = $data['order_id'];
-            $isVoided = ($data['is_voided'] ?? 0) == 1;
-
-            try {
-                // Update local device_orders table directly
-                $deviceOrder = DeviceOrder::where('order_id', $orderId)->first();
-                if ($deviceOrder) {
-                    $newStatus = $isVoided
-                        ? OrderStatus::VOIDED
-                        : OrderStatus::COMPLETED;
-                    $deviceOrder->update(['status' => $newStatus]);
-
-                    // Dispatch appropriate event
-                    if ($isVoided) {
-                        OrderVoided::dispatch($deviceOrder);
-                    } else {
-                        OrderCompleted::dispatch($deviceOrder);
-                    }
-
-                    return response()->json(['success' => true, 'order' => $deviceOrder]);
-                }
-
-                return response()->json(['success' => false, 'message' => 'Device order not found'], 404);
-            } catch (Throwable $e) {
-                // Log the real cause for ops; never leak the raw exception to the client.
-                \Illuminate\Support\Facades\Log::error('[pos.fill-order] update failed', [
-                    'order_id' => $orderId,
-                    'exception' => $e->getMessage(),
-                ]);
-
-                return response()->json([
-                    'success' => false,
-                    'message' => 'Could not update the order. Please try again.',
-                ], 500);
-            }
-        })->name('pos.fill-order');
+        Route::post('/pos/fill-order', [PosController::class, 'fillOrder'])->name('pos.fill-order');
 
         // Reports
         Route::prefix('reports')->name('reports.')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,6 +104,7 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/package-configs/{packageConfig}/menus', [PackageConfigController::class, 'syncAllowedMenus'])->name('package-configs.sync-menus');
         // Tablet Categories
         Route::get('/tablet-categories', [TabletCategoryController::class, 'index'])->name('tablet-categories.index');
+        Route::put('/tablet-categories/reorder', [TabletCategoryController::class, 'reorder'])->name('tablet-categories.reorder');
         Route::post('/tablet-categories', [TabletCategoryController::class, 'store'])->name('tablet-categories.store');
         Route::put('/tablet-categories/{tabletCategory}', [TabletCategoryController::class, 'update'])->name('tablet-categories.update');
         Route::delete('/tablet-categories/{tabletCategory}', [TabletCategoryController::class, 'destroy'])->name('tablet-categories.destroy');
@@ -202,7 +203,6 @@ Route::middleware(['auth'])->group(function () {
             ->where('channel', 'release|debug')
             ->name('devices.download-apk');
 
-        Route::resource('/devices', DeviceController::class);
         Route::prefix('devices')->name('devices.')->group(function () {
             Route::get('trashed', [DeviceController::class, 'trashed'])->name('trashed');
             Route::patch('{id}/restore', [DeviceController::class, 'restore'])->name('restore');
@@ -210,6 +210,7 @@ Route::middleware(['auth'])->group(function () {
             Route::post('/{device}/token', [DeviceController::class, 'createToken'])->name('create.token');
             Route::post('/{device}/security-code', [DeviceController::class, 'regenerateSecurityCode'])->name('security-code.regenerate');
         });
+        Route::resource('/devices', DeviceController::class);
 
         Route::get('/accessibility', [AccessibilityController::class, 'index'])->name('accessibility.index');
         Route::get('/accessibility/{role}/permissions', [AccessibilityController::class, 'updatePermissions'])->name('accessibility.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,12 @@ Route::middleware(['auth'])->group(function () {
     // Admin-only routes
     Route::middleware(['can:admin'])->group(function () {
         // Orders
+        Route::get('/kds', function () {
+            return Inertia::render('KDS/Display', [
+                'title' => 'Kitchen Display',
+            ]);
+        })->name('kds.display');
+
         Route::get('/orders', [OrderController::class, 'index'])->name('orders.index');
         Route::get('/orders/{id}', [OrderController::class, 'show'])->name('orders.show');
         Route::delete('/orders/{id}', [OrderController::class, 'destroy'])->name('orders.destroy');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,37 +1,36 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Auth;
-use Inertia\Inertia;
-
-
-use App\Http\Controllers\Admin\{
-    DashboardController,
-    OrderController,
-    PosController,
-    MenuController,
-    UserController,
-    Device\DeviceController,
-    ManualController,
-    AccessibilityController,
-    RoleController,
-    PermissionController,
-    PackageController,
-    PackageConfigController,
-    TabletCategoryController,
-    MediaLibraryController,
-    BranchController,
-    ReverbController,
-    MonitoringController,
-    PosConnectionController
-};
-use App\Http\Controllers\Admin\ServiceRequestController;
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
+use App\Http\Controllers\Admin\AccessibilityController;
+use App\Http\Controllers\Admin\BranchController;
+use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\Device\DeviceController;
 use App\Http\Controllers\Admin\EventLogController;
-
-use App\Http\Controllers\Admin\Reports\{
-    SalesController,
-    ReportController,
-};
+use App\Http\Controllers\Admin\KdsController;
+use App\Http\Controllers\Admin\ManualController;
+use App\Http\Controllers\Admin\MediaLibraryController;
+use App\Http\Controllers\Admin\MenuController;
+use App\Http\Controllers\Admin\MonitoringController;
+use App\Http\Controllers\Admin\OrderController;
+use App\Http\Controllers\Admin\PackageConfigController;
+use App\Http\Controllers\Admin\PackageController;
+use App\Http\Controllers\Admin\PermissionController;
+use App\Http\Controllers\Admin\PosConnectionController;
+use App\Http\Controllers\Admin\PosController;
+use App\Http\Controllers\Admin\Reports\ReportController;
+use App\Http\Controllers\Admin\ReverbController;
+use App\Http\Controllers\Admin\RoleController;
+use App\Http\Controllers\Admin\ServiceRequestController;
+use App\Http\Controllers\Admin\TabletCategoryController;
+use App\Http\Controllers\Admin\UserController;
+use App\Models\DeviceOrder;
+use App\Services\LocalBranchResolver;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 
 // Handle CORS preflight — return 204 No Content with no body
 Route::options('/{any}', function () {
@@ -58,11 +57,7 @@ Route::middleware(['auth'])->group(function () {
     // Admin-only routes
     Route::middleware(['can:admin'])->group(function () {
         // Orders
-        Route::get('/kds', function () {
-            return Inertia::render('KDS/Display', [
-                'title' => 'Kitchen Display',
-            ]);
-        })->name('kds.display');
+        Route::get('/kds', [KdsController::class, 'index'])->name('kds.display');
 
         Route::get('/orders', [OrderController::class, 'index'])->name('orders.index');
         Route::get('/orders/{id}', [OrderController::class, 'show'])->name('orders.show');
@@ -78,14 +73,14 @@ Route::middleware(['auth'])->group(function () {
         Route::put('/pos/orders/{orderId}', [PosController::class, 'editOrder'])->name('pos.orders.edit');
         Route::post('/pos/orders/{orderId}/void', [PosController::class, 'voidOrder'])->name('pos.orders.void');
         Route::post('/pos/orders/{orderId}/pay', [PosController::class, 'payOrder'])->name('pos.orders.pay');
-        
+
         // Bulk operations with rate limiting (60 requests/min to prevent abuse)
         Route::middleware(['throttle:60,1'])->group(function () {
             Route::post('/orders/bulk-complete', [OrderController::class, 'bulkComplete'])->name('orders.bulk-complete');
             Route::post('/orders/bulk-void', [OrderController::class, 'bulkVoid'])->name('orders.bulk-void');
             Route::post('/orders/status/bulk', [OrderController::class, 'bulkStatus'])->name('orders.bulk-status');
         });
-        
+
         // Admin: update single order status
         Route::post('/orders/{id}/status', [OrderController::class, 'updateStatus'])->name('orders.update-status');
         // Device order API for strict verification
@@ -136,7 +131,7 @@ Route::middleware(['auth'])->group(function () {
         ];
 
         Route::get('/admin/api/settings', function () use ($settingsDefaults) {
-            $branch = app(\App\Services\LocalBranchResolver::class)->resolve();
+            $branch = app(LocalBranchResolver::class)->resolve();
 
             if (! $branch) {
                 return response()->json(['message' => 'No active branch configured.'], 422);
@@ -145,8 +140,8 @@ Route::middleware(['auth'])->group(function () {
             return response()->json(array_merge($settingsDefaults, $branch->settings ?? []));
         })->name('admin.settings.get');
 
-        Route::put('/admin/api/settings', function (\Illuminate\Http\Request $request) use ($settingsDefaults) {
-            $branch = app(\App\Services\LocalBranchResolver::class)->resolve();
+        Route::put('/admin/api/settings', function (Request $request) {
+            $branch = app(LocalBranchResolver::class)->resolve();
 
             if (! $branch) {
                 return response()->json(['message' => 'No active branch configured.'], 422);
@@ -237,7 +232,7 @@ Route::middleware(['auth'])->group(function () {
         });
 
         // Update device_orders directly (admin only)
-        Route::post('/pos/fill-order', function (\Illuminate\Http\Request $request) {
+        Route::post('/pos/fill-order', function (Request $request) {
             $user = $request->user();
             if (! $user || ! ($user->is_admin ?? false)) {
                 return response()->json(['success' => false, 'message' => 'Unauthorized'], 403);
@@ -256,25 +251,25 @@ Route::middleware(['auth'])->group(function () {
 
             try {
                 // Update local device_orders table directly
-                $deviceOrder = \App\Models\DeviceOrder::where('order_id', $orderId)->first();
+                $deviceOrder = DeviceOrder::where('order_id', $orderId)->first();
                 if ($deviceOrder) {
-                    $newStatus = $isVoided 
-                        ? \App\Enums\OrderStatus::VOIDED 
-                        : \App\Enums\OrderStatus::COMPLETED;
+                    $newStatus = $isVoided
+                        ? OrderStatus::VOIDED
+                        : OrderStatus::COMPLETED;
                     $deviceOrder->update(['status' => $newStatus]);
 
                     // Dispatch appropriate event
                     if ($isVoided) {
-                        \App\Events\Order\OrderVoided::dispatch($deviceOrder);
+                        OrderVoided::dispatch($deviceOrder);
                     } else {
-                        \App\Events\Order\OrderCompleted::dispatch($deviceOrder);
+                        OrderCompleted::dispatch($deviceOrder);
                     }
 
                     return response()->json(['success' => true, 'order' => $deviceOrder]);
                 }
 
                 return response()->json(['success' => false, 'message' => 'Device order not found'], 404);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
             }
         })->name('pos.fill-order');

--- a/scripts/deployment/apply-woosoo-config.sh
+++ b/scripts/deployment/apply-woosoo-config.sh
@@ -69,11 +69,18 @@ case "$WOOSOO_ENV" in
     ;;
 esac
 # SESSION_SECURE_COOKIE is derived from WOOSOO_SCHEME, not from WOOSOO_ENV.
-if [[ "${WOOSOO_SCHEME}" == "https" ]]; then
-  _SESSION_SECURE_COOKIE="true"
-else
-  _SESSION_SECURE_COOKIE="false"
-fi
+case "$WOOSOO_SCHEME" in
+  https)
+    _SESSION_SECURE_COOKIE="true"
+    ;;
+  http)
+    _SESSION_SECURE_COOKIE="false"
+    ;;
+  *)
+    echo "ERROR: WOOSOO_SCHEME='${WOOSOO_SCHEME}' is not valid. Allowed values: http | https" >&2
+    exit 1
+    ;;
+esac
 
 WOOSOO_APPLY_STATIC_IP="${WOOSOO_APPLY_STATIC_IP:-true}"
 WOOSOO_RESTART_DOCKER="${WOOSOO_RESTART_DOCKER:-true}"
@@ -113,10 +120,17 @@ escape_ere() {
 set_env() {
   local key="$1"
   local value="$2"
+  local mode="${3:-quoted}"
   local file=".env"
   local rendered escaped_key
 
-  rendered="$(quote_env_value "$value")"
+  # Boolean-like flags (e.g. APP_DEBUG, SESSION_SECURE_COOKIE) must be written as
+  # bare true/false literals; Laravel treats the quoted string "false" as truthy.
+  if [[ "$mode" == "raw" ]]; then
+    rendered="$value"
+  else
+    rendered="$(quote_env_value "$value")"
+  fi
   escaped_key="$(escape_ere "$key")"
 
   if grep -qE "^${escaped_key}=" "$file"; then
@@ -334,7 +348,7 @@ set_env "PUBLIC_HOST" "$WOOSOO_HOST"
 set_env "PUBLIC_HTTP_PORT" "80"
 set_env "PUBLIC_HTTPS_PORT" "443"
 set_env "APP_ENV" "$_APP_ENV"
-set_env "APP_DEBUG" "$_APP_DEBUG"
+set_env "APP_DEBUG" "$_APP_DEBUG" raw
 set_env "APP_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "ASSET_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "APP_TIMEZONE" "${WOOSOO_TIMEZONE:-Asia/Manila}"
@@ -378,7 +392,7 @@ set_env "VITE_REVERB_SCHEME" "$WOOSOO_SCHEME"
 # SESSION_DOMAIN left empty so the cookie is scoped to whatever host the
 # request arrives on — prevents 419s when accessing from multiple IPs/hostnames.
 set_env "SESSION_DOMAIN" ""
-set_env "SESSION_SECURE_COOKIE" "$_SESSION_SECURE_COOKIE"
+set_env "SESSION_SECURE_COOKIE" "$_SESSION_SECURE_COOKIE" raw
 set_env "SESSION_SAME_SITE" "lax"
 set_env "SANCTUM_STATEFUL_DOMAINS" "${WOOSOO_HOST},${WOOSOO_HOST}:443,${WOOSOO_HOST}:80,${WOOSOO_HOST}:4443"
 set_env "CORS_ALLOWED_ORIGINS" "${WOOSOO_SCHEME}://${WOOSOO_HOST},http://${WOOSOO_HOST},${WOOSOO_SCHEME}://${WOOSOO_HOST}:4443"

--- a/scripts/deployment/apply-woosoo-config.sh
+++ b/scripts/deployment/apply-woosoo-config.sh
@@ -45,6 +45,36 @@ require_var WOOSOO_CIDR
 require_var WOOSOO_NEXUS_PATH
 require_var WOOSOO_SCHEME
 
+# WOOSOO_ENV selects the environment profile: local | staging | production.
+WOOSOO_ENV="${WOOSOO_ENV:-production}"
+case "$WOOSOO_ENV" in
+  local)
+    _APP_ENV="local"
+    _APP_DEBUG="true"
+    _LOG_LEVEL="debug"
+    ;;
+  staging)
+    _APP_ENV="staging"
+    _APP_DEBUG="false"
+    _LOG_LEVEL="info"
+    ;;
+  production)
+    _APP_ENV="production"
+    _APP_DEBUG="false"
+    _LOG_LEVEL="error"
+    ;;
+  *)
+    echo "ERROR: WOOSOO_ENV='${WOOSOO_ENV}' is not valid. Allowed values: local | staging | production" >&2
+    exit 1
+    ;;
+esac
+# SESSION_SECURE_COOKIE is derived from WOOSOO_SCHEME, not from WOOSOO_ENV.
+if [[ "${WOOSOO_SCHEME}" == "https" ]]; then
+  _SESSION_SECURE_COOKIE="true"
+else
+  _SESSION_SECURE_COOKIE="false"
+fi
+
 WOOSOO_APPLY_STATIC_IP="${WOOSOO_APPLY_STATIC_IP:-true}"
 WOOSOO_RESTART_DOCKER="${WOOSOO_RESTART_DOCKER:-true}"
 WOOSOO_DOCKER_COMPOSE="${WOOSOO_DOCKER_COMPOSE:-docker compose -f compose.yaml}"
@@ -295,6 +325,7 @@ fi
 
 safe_backup_file ".env"
 
+echo "Environment:   $WOOSOO_ENV (APP_ENV=${_APP_ENV}, APP_DEBUG=${_APP_DEBUG}, LOG_LEVEL=${_LOG_LEVEL}, SESSION_SECURE_COOKIE=${_SESSION_SECURE_COOKIE})"
 echo "Updating Laravel .env..."
 db_password_value="${WOOSOO_DB_PASSWORD:-change_this_password}"
 db_root_password_value="${WOOSOO_DB_ROOT_PASSWORD:-change_this_root_password}"
@@ -302,8 +333,8 @@ set_env "PUBLIC_SCHEME" "$WOOSOO_SCHEME"
 set_env "PUBLIC_HOST" "$WOOSOO_HOST"
 set_env "PUBLIC_HTTP_PORT" "80"
 set_env "PUBLIC_HTTPS_PORT" "443"
-set_env "APP_ENV" "production"
-set_env "APP_DEBUG" "false"
+set_env "APP_ENV" "$_APP_ENV"
+set_env "APP_DEBUG" "$_APP_DEBUG"
 set_env "APP_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "ASSET_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "APP_TIMEZONE" "${WOOSOO_TIMEZONE:-Asia/Manila}"
@@ -344,13 +375,15 @@ set_env "VITE_REVERB_APP_KEY" "${WOOSOO_REVERB_APP_KEY:-change_this_reverb_key}"
 set_env "VITE_REVERB_HOST" "$WOOSOO_HOST"
 set_env "VITE_REVERB_PORT" "443"
 set_env "VITE_REVERB_SCHEME" "$WOOSOO_SCHEME"
-set_env "SESSION_DOMAIN" "$WOOSOO_HOST"
-set_env "SESSION_SECURE_COOKIE" "true"
+# SESSION_DOMAIN left empty so the cookie is scoped to whatever host the
+# request arrives on — prevents 419s when accessing from multiple IPs/hostnames.
+set_env "SESSION_DOMAIN" ""
+set_env "SESSION_SECURE_COOKIE" "$_SESSION_SECURE_COOKIE"
 set_env "SESSION_SAME_SITE" "lax"
 set_env "SANCTUM_STATEFUL_DOMAINS" "${WOOSOO_HOST},${WOOSOO_HOST}:443,${WOOSOO_HOST}:80,${WOOSOO_HOST}:4443"
 set_env "CORS_ALLOWED_ORIGINS" "${WOOSOO_SCHEME}://${WOOSOO_HOST},http://${WOOSOO_HOST},${WOOSOO_SCHEME}://${WOOSOO_HOST}:4443"
 set_env "DEVICE_AUTH_PASSCODE" "${WOOSOO_DEVICE_AUTH_PASSCODE:-}"
-set_env "LOG_LEVEL" "error"
+set_env "LOG_LEVEL" "$_LOG_LEVEL"
 
 if ! grep -qE '^APP_KEY=base64:.+' .env; then
   echo "INFO: APP_KEY is not set. Before first production use, run: $WOOSOO_DOCKER_COMPOSE exec -T $WOOSOO_APP_SERVICE php artisan key:generate"

--- a/tests/Feature/Admin/DeviceTrashedRouteTest.php
+++ b/tests/Feature/Admin/DeviceTrashedRouteTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('GET devices/trashed redirects to devices index', function () {
+    $this->withoutVite();
+
+    $admin = User::factory()->admin()->create();
+
+    $this
+        ->actingAs($admin)
+        ->get(route('devices.trashed'))
+        ->assertRedirect(route('devices.index', ['view' => 'trashed']));
+});

--- a/tests/Feature/Admin/KdsControllerConnectivityTest.php
+++ b/tests/Feature/Admin/KdsControllerConnectivityTest.php
@@ -40,6 +40,21 @@ test('kds index returns 200 with empty tickets when pos connection fails', funct
         );
 });
 
+test('kds index returns 200 with tickets when pos unreachable and active orders exist', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+    \App\Models\DeviceOrder::factory()->confirmed()->create(['table_id' => null]);
+
+    actingAs($admin);
+
+    get(route('kds.display'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->has('initialTickets', 1)
+            ->where('initialTickets.0.table', '—')
+        );
+});
+
 test('kds index returns 200 with empty tickets when pos password is not configured', function () {
     Config::set('database.connections.pos', [
         'driver' => 'mysql',

--- a/tests/Feature/Admin/KdsControllerConnectivityTest.php
+++ b/tests/Feature/Admin/KdsControllerConnectivityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '127.0.0.1',
+        'port' => 1,
+        'database' => 'test',
+        'username' => 'test',
+        'password' => 'test',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+});
+
+test('kds index returns 200 with empty tickets when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    actingAs($admin);
+
+    get(route('kds.display'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->where('initialTickets', [])
+        );
+});
+
+test('kds index returns 200 with empty tickets when pos password is not configured', function () {
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '192.168.100.7',
+        'port' => 3308,
+        'database' => 'krypton_woosoo',
+        'username' => 'krypton_readonly',
+        'password' => '',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    actingAs($admin);
+
+    get(route('kds.display'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->where('initialTickets', [])
+        );
+});

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Models\DeviceOrder;
+use App\Models\DeviceOrderItems;
+use App\Models\User;
+
+test('admins can advance a confirmed order to in_progress', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::CONFIRMED]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJson(['status' => 'in_progress']);
+
+    expect($order->fresh()->status)->toBe(OrderStatus::IN_PROGRESS);
+});
+
+test('mark ready is gated when items are not all done', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'All items must be marked done before advancing to Ready.']);
+});
+
+test('mark ready advances when all items are done', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJson(['status' => 'ready']);
+
+    expect($order->fresh()->status)->toBe(OrderStatus::READY);
+});
+
+test('admins can toggle an item done flag', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertOk()
+        ->assertJson(['done' => true]);
+
+    expect($item->fresh()->done)->toBeTrue();
+});
+
+test('toggling a done item marks it undone', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertOk()
+        ->assertJson(['done' => false]);
+
+    expect($item->fresh()->done)->toBeFalse();
+    expect($item->fresh()->done_at)->toBeNull();
+});
+
+test('non-admin cannot access kds advance endpoint', function () {
+    $user = User::factory()->create(['is_admin' => false]);
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::CONFIRMED]);
+
+    $this->actingAs($user)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertForbidden();
+});

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -25,7 +25,7 @@ test('mark ready is gated when items are not all done', function () {
     $this->actingAs($admin)
         ->postJson("/kds/orders/{$order->id}/advance")
         ->assertUnprocessable()
-        ->assertJsonFragment(['message' => 'All items must be marked done before advancing to Ready.']);
+        ->assertJsonFragment(['message' => 'All items must be marked done before marking as served.']);
 });
 
 test('mark ready advances when all items are done', function () {
@@ -36,9 +36,9 @@ test('mark ready advances when all items are done', function () {
     $this->actingAs($admin)
         ->postJson("/kds/orders/{$order->id}/advance")
         ->assertOk()
-        ->assertJson(['status' => 'ready']);
+        ->assertJson(['status' => 'served']);
 
-    expect($order->fresh()->status)->toBe(OrderStatus::READY);
+    expect($order->fresh()->status)->toBe(OrderStatus::SERVED);
 });
 
 test('admins can toggle an item done flag', function () {
@@ -121,5 +121,5 @@ test('mark ready gate re-checks items inside the transaction', function () {
     $this->actingAs($admin)
         ->postJson("/kds/orders/{$order->id}/advance")
         ->assertUnprocessable()
-        ->assertJsonFragment(['message' => 'All items must be marked done before advancing to Ready.']);
+        ->assertJsonFragment(['message' => 'All items must be marked done before marking as served.']);
 });

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -76,3 +76,50 @@ test('non-admin cannot access kds advance endpoint', function () {
         ->postJson("/kds/orders/{$order->id}/advance")
         ->assertForbidden();
 });
+
+test('cannot toggle item on a served order', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::SERVED]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'Cannot toggle items on a completed or closed order.']);
+});
+
+test('cannot toggle item on a voided order', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::VOIDED]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'Cannot toggle items on a completed or closed order.']);
+});
+
+test('cannot toggle item on a completed order', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::COMPLETED]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'Cannot toggle items on a completed or closed order.']);
+});
+
+test('mark ready gate re-checks items inside the transaction', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+    // Simulate an item that was done when initially loaded but undone before advance commits.
+    $item->update(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'All items must be marked done before advancing to Ready.']);
+});

--- a/tests/Feature/Admin/KdsDisplayTest.php
+++ b/tests/Feature/Admin/KdsDisplayTest.php
@@ -15,7 +15,7 @@ test('non-admin users cannot access the KDS display', function () {
         ->assertForbidden();
 });
 
-test('admins can open the mock KDS display', function () {
+test('admins can open the KDS display with a tickets prop', function () {
     $admin = User::factory()->admin()->create();
 
     $this->actingAs($admin)
@@ -24,5 +24,6 @@ test('admins can open the mock KDS display', function () {
         ->assertInertia(fn (Assert $page) => $page
             ->component('KDS/Display')
             ->where('title', 'Kitchen Display')
+            ->has('initialTickets')
         );
 });

--- a/tests/Feature/Admin/KdsDisplayTest.php
+++ b/tests/Feature/Admin/KdsDisplayTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\User;
+use Inertia\Testing\AssertableInertia as Assert;
+
+test('guests are redirected away from the KDS display', function () {
+    $this->get('/kds')->assertRedirect('/login');
+});
+
+test('non-admin users cannot access the KDS display', function () {
+    $user = User::factory()->create(['is_admin' => false]);
+
+    $this->actingAs($user)
+        ->get('/kds')
+        ->assertForbidden();
+});
+
+test('admins can open the mock KDS display', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->get('/kds')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->where('title', 'Kitchen Display')
+        );
+});

--- a/tests/Feature/Admin/OrderBroadcastPosResilienceTest.php
+++ b/tests/Feature/Admin/OrderBroadcastPosResilienceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Helpers\OrderBroadcastPayload;
+use App\Models\DeviceOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Point the Krypton (POS) connection at an unreachable host so any POS query throws.
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '127.0.0.1',
+        'port' => 1,
+        'database' => 'test',
+        'username' => 'test',
+        'password' => 'test',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+});
+
+test('OrderBroadcastPayload degrades gracefully when POS is unreachable', function () {
+    // table_id references a Krypton (POS) table; the connection above cannot reach it.
+    $order = DeviceOrder::factory()->create([
+        'status' => OrderStatus::READY,
+        'table_id' => 1,
+    ]);
+
+    // Must not throw even though table/menu live on the unreachable POS connection —
+    // a POS outage must never 500 an order broadcast (e.g. KDS advance).
+    $payload = OrderBroadcastPayload::make($order);
+
+    expect($payload['status'])->toBe(OrderStatus::READY);
+    expect($payload['table'])->toBeNull();
+});

--- a/tests/Feature/Admin/PosControllerConnectivityTest.php
+++ b/tests/Feature/Admin/PosControllerConnectivityTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutVite();
+
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '127.0.0.1',
+        'port' => 1,
+        'database' => 'test',
+        'username' => 'test',
+        'password' => 'test',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+});
+
+test('pos index returns 200 with posConnected false when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('POS/Index')
+            ->where('posConnected', false)
+            ->where('posStatus', 'unreachable')
+            ->has('posMessage')
+            ->where('terminals', [])
+            ->where('currentSession', null)
+        );
+});
+
+test('pos index reports not_configured when mysql password is empty', function () {
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '192.168.100.7',
+        'port' => 3308,
+        'database' => 'krypton_woosoo',
+        'username' => 'krypton_readonly',
+        'password' => '',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('POS/Index')
+            ->where('posConnected', false)
+            ->where('posStatus', 'not_configured')
+            ->where('terminals', [])
+        );
+});
+
+test('pos terminal tables endpoint returns 503 when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.terminal.tables', ['terminalId' => '1']))
+        ->assertStatus(503)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('status', 'unreachable');
+});
+
+test('pos table orders endpoint returns 503 when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.table.orders', ['terminalId' => '1', 'tableId' => '1']))
+        ->assertStatus(503)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('status', 'unreachable');
+});

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -34,9 +34,11 @@ test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', 
     Event::fake([OrderCompleted::class, OrderVoided::class]);
 
     $admin = User::factory()->admin()->create();
+    // SERVED is the valid pre-completion state (SERVED → COMPLETED); the state machine
+    // rejects IN_PROGRESS → COMPLETED.
     $order = DeviceOrder::factory()->create([
         'order_id' => 8001,
-        'status' => OrderStatus::IN_PROGRESS,
+        'status' => OrderStatus::SERVED,
     ]);
 
     $this->actingAs($admin)

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -2,7 +2,6 @@
 
 use App\Enums\OrderStatus;
 use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderVoided;
 use App\Models\DeviceOrder;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -28,7 +27,9 @@ test('pos fill-order returns 404 when the order is not found (P1-07)', function 
 });
 
 test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
-    Event::fake([OrderCompleted::class, OrderVoided::class]);
+    // Fake all events so the order-status observer broadcast doesn't run during this
+    // fill-order happy-path assertion (the broadcast path is covered elsewhere).
+    Event::fake();
 
     $admin = User::factory()->admin()->create();
     $order = DeviceOrder::factory()->create([

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -49,3 +49,21 @@ test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', 
     expect($order->fresh()->status)->toBe(OrderStatus::COMPLETED);
     Event::assertDispatched(OrderCompleted::class);
 });
+
+test('pos fill-order voids an order and dispatches OrderVoided (P1-07)', function () {
+    Event::fake([OrderCompleted::class, OrderVoided::class]);
+
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create([
+        'order_id' => 8002,
+        'status' => OrderStatus::SERVED,
+    ]);
+
+    $this->actingAs($admin)
+        ->postJson('/pos/fill-order', ['order_id' => 8002, 'is_voided' => 1])
+        ->assertOk()
+        ->assertJson(['success' => true]);
+
+    expect($order->fresh()->status)->toBe(OrderStatus::VOIDED);
+    Event::assertDispatched(OrderVoided::class);
+});

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
+use App\Models\DeviceOrder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+test('pos fill-order rejects non-admins (P1-07)', function () {
+    $user = User::factory()->create(['is_admin' => false]);
+
+    $this->actingAs($user)
+        ->postJson('/pos/fill-order', ['order_id' => 1])
+        ->assertForbidden();
+});
+
+test('pos fill-order returns 404 when the order is not found (P1-07)', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->postJson('/pos/fill-order', ['order_id' => 999999])
+        ->assertNotFound()
+        ->assertJson(['success' => false]);
+});
+
+test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
+    Event::fake([OrderCompleted::class, OrderVoided::class]);
+
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create([
+        'order_id' => 8001,
+        'status' => OrderStatus::IN_PROGRESS,
+    ]);
+
+    $this->actingAs($admin)
+        ->postJson('/pos/fill-order', ['order_id' => 8001])
+        ->assertOk()
+        ->assertJson(['success' => true]);
+
+    expect($order->fresh()->status)->toBe(OrderStatus::COMPLETED);
+    Event::assertDispatched(OrderCompleted::class);
+});

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\OrderStatus;
 use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
 use App\Models\DeviceOrder;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -27,9 +28,10 @@ test('pos fill-order returns 404 when the order is not found (P1-07)', function 
 });
 
 test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
-    // Fake all events so the order-status observer broadcast doesn't run during this
-    // fill-order happy-path assertion (the broadcast path is covered elsewhere).
-    Event::fake();
+    // Fake only the fill-order events so Eloquent model events (e.g. user_uuid /
+    // order_uuid generation) still fire. The status-update observer broadcast runs for
+    // real but no longer throws — OrderBroadcastPayload guards the POS relations.
+    Event::fake([OrderCompleted::class, OrderVoided::class]);
 
     $admin = User::factory()->admin()->create();
     $order = DeviceOrder::factory()->create([

--- a/tests/Feature/Admin/TabletCategoryReorderTest.php
+++ b/tests/Feature/Admin/TabletCategoryReorderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\TabletCategory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('admin can reorder tablet categories via PUT reorder', function () {
+    $this->withoutVite();
+
+    $admin = User::factory()->admin()->create();
+
+    $a = TabletCategory::create(['name' => 'Alpha', 'sort_order' => 2]);
+    $b = TabletCategory::create(['name' => 'Beta', 'sort_order' => 0]);
+    $c = TabletCategory::create(['name' => 'Gamma', 'sort_order' => 1]);
+
+    $response = $this
+        ->actingAs($admin)
+        ->put(route('tablet-categories.reorder'), [
+            'ids' => [$b->id, $c->id, $a->id],
+        ]);
+
+    $response->assertRedirect();
+
+    expect($a->fresh()->sort_order)->toBe(2);
+    expect($b->fresh()->sort_order)->toBe(0);
+    expect($c->fresh()->sort_order)->toBe(1);
+});
+
+test('tablet-categories reorder requires valid ids array', function () {
+    $this->withoutVite();
+
+    $admin = User::factory()->admin()->create();
+
+    $this
+        ->actingAs($admin)
+        ->put(route('tablet-categories.reorder'), ['ids' => 'not-an-array'])
+        ->assertSessionHasErrors('ids');
+});

--- a/tests/Feature/Admin/UserShowRedirectTest.php
+++ b/tests/Feature/Admin/UserShowRedirectTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('GET users/{id} redirects to users edit', function () {
+    $this->withoutVite();
+
+    $admin = User::factory()->admin()->create();
+    $target = User::factory()->create();
+
+    $this
+        ->actingAs($admin)
+        ->get(route('users.show', $target))
+        ->assertRedirect(route('users.edit', $target));
+});

--- a/tests/Feature/Api/OrderDispatchGuardTest.php
+++ b/tests/Feature/Api/OrderDispatchGuardTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Events\PrintOrder;
+use App\Models\Branch;
+use App\Models\Device;
+use App\Models\DeviceOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+function dispatchTestDevice(): Device
+{
+    Branch::create(['name' => 'Main', 'location' => 'HQ']);
+
+    return Device::create([
+        'name' => 'Kitchen Station 1',
+        'ip_address' => '127.0.0.20',
+        'is_active' => true,
+        'table_id' => 1,
+        'branch_id' => 1,
+    ]);
+}
+
+test('dispatch does not fire PrintOrder when the order does not exist (P1-06)', function () {
+    Event::fake([PrintOrder::class]);
+    Sanctum::actingAs(dispatchTestDevice(), [], 'device');
+
+    $this->getJson('/api/order/999999/dispatch')
+        ->assertNotFound();
+
+    // The pre-fix code dispatched PrintOrder with a null order — guard must prevent that.
+    Event::assertNotDispatched(PrintOrder::class);
+});
+
+test('dispatch fires PrintOrder for an existing order (P1-06)', function () {
+    Event::fake([PrintOrder::class]);
+    Sanctum::actingAs(dispatchTestDevice(), [], 'device');
+
+    DeviceOrder::factory()->create([
+        'order_id' => 7001,
+        'status' => OrderStatus::IN_PROGRESS,
+    ]);
+
+    $this->getJson('/api/order/7001/dispatch')
+        ->assertOk()
+        ->assertJson(['status' => 'dispatched']);
+
+    Event::assertDispatched(PrintOrder::class);
+});

--- a/tests/Feature/DebugPosErrorHandlingTest.php
+++ b/tests/Feature/DebugPosErrorHandlingTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Regression guard for nex-case-019 (commit 645a80f): the debug/pos
+ * stored-procedure route must NOT leak the raw exception message — it logs
+ * the real error and returns a generic 500 instead. Without this test the
+ * info-leak protection could silently regress.
+ *
+ * @see routes/api.php — GET /api/debug/pos/menus/course
+ */
+it('hides the raw POS exception and logs it when the stored procedure throws', function () {
+    // Route is gated behind local env OR app.debug; the test env is "testing".
+    config(['app.debug' => true]);
+
+    Log::spy();
+
+    // Force DB::connection('pos')->select(...) to throw with a recognisable
+    // secret. A proxied partial mock keeps every other method (transactionLevel,
+    // rollBack, ...) delegating to the real sqlite connection so RefreshDatabase
+    // and tearDown draining still work.
+    $secret = 'SECRET-LEAK SQLSTATE[42000] get_menus_by_course internals';
+    $throwingPos = Mockery::mock(DB::connection('pos'))->makePartial();
+    $throwingPos->shouldReceive('select')->andThrow(new RuntimeException($secret));
+
+    // Swap the cached 'pos' connection in the DatabaseManager for our throwing one.
+    $manager = app('db');
+    $connectionsProp = new ReflectionProperty($manager, 'connections');
+    $connectionsProp->setAccessible(true);
+    $connections = $connectionsProp->getValue($manager);
+    $connections['pos'] = $throwingPos;
+    $connectionsProp->setValue($manager, $connections);
+
+    $response = $this->getJson('/api/debug/pos/menus/course?course=1');
+
+    $response->assertStatus(500)
+        ->assertJson([
+            'success' => false,
+            'message' => 'POS stored procedure failed. Check Laravel log.',
+        ]);
+
+    // The raw exception detail must never reach the client.
+    expect($response->getContent())
+        ->not->toContain($secret)
+        ->not->toContain('SQLSTATE');
+
+    // The real error must still be logged server-side for debugging.
+    Log::shouldHaveReceived('error')
+        ->once()
+        ->withArgs(function (string $message, array $context = []) use ($secret) {
+            return $message === '[debug/pos] stored procedure failed'
+                && ($context['error'] ?? null) === $secret;
+        });
+});

--- a/tests/Feature/DeviceOrderIntentContractTest.php
+++ b/tests/Feature/DeviceOrderIntentContractTest.php
@@ -25,12 +25,12 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_accepts_intent_only_initial_order_payload(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 3,
-            'package_id'  => 46,
-            'items'       => [
+            'package_id' => 46,
+            'items' => [
                 ['menu_id' => 10, 'quantity' => 2],
                 ['menu_id' => 13, 'quantity' => 2],
             ],
@@ -46,11 +46,11 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_initial_order_rejects_missing_package_id(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 3,
-            'items'       => [['menu_id' => 10, 'quantity' => 2]],
+            'items' => [['menu_id' => 10, 'quantity' => 2]],
         ];
 
         $validator = Validator::make($payload, $rules);
@@ -61,11 +61,11 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_initial_order_rejects_missing_items(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 3,
-            'package_id'  => 46,
+            'package_id' => 46,
         ];
 
         $validator = Validator::make($payload, $rules);
@@ -76,12 +76,12 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_initial_order_rejects_item_without_menu_id(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 3,
-            'package_id'  => 46,
-            'items'       => [['quantity' => 2]],
+            'package_id' => 46,
+            'items' => [['quantity' => 2]],
         ];
 
         $validator = Validator::make($payload, $rules);
@@ -92,12 +92,12 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_initial_order_does_not_require_client_totals(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 2,
-            'package_id'  => 47,
-            'items'       => [['menu_id' => 15, 'quantity' => 1]],
+            'package_id' => 47,
+            'items' => [['menu_id' => 15, 'quantity' => 1]],
             // subtotal / tax / discount / total_amount intentionally omitted
         ];
 
@@ -111,12 +111,12 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_initial_order_does_not_require_item_name_or_price(): void
     {
-        $rules = (new StoreDeviceOrderRequest())->rules();
+        $rules = (new StoreDeviceOrderRequest)->rules();
 
         $payload = [
             'guest_count' => 2,
-            'package_id'  => 47,
-            'items'       => [
+            'package_id' => 47,
+            'items' => [
                 ['menu_id' => 15, 'quantity' => 1],
                 // no 'name', no 'price', no 'subtotal'
             ],
@@ -133,15 +133,15 @@ class DeviceOrderIntentContractTest extends TestCase
     public function test_initial_order_request_strips_non_intent_fields_before_validation(): void
     {
         $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', [
-            'guest_count'  => 2,
-            'package_id'   => 47,
+            'guest_count' => 2,
+            'package_id' => 47,
             'total_amount' => 123.45,
-            'items'        => [
+            'items' => [
                 [
-                    'menu_id'  => 15,
+                    'menu_id' => 15,
                     'quantity' => 1,
-                    'price'    => 99.99,
-                    'name'     => 'Ignored',
+                    'price' => 99.99,
+                    'name' => 'Ignored',
                 ],
             ],
         ]);
@@ -151,8 +151,8 @@ class DeviceOrderIntentContractTest extends TestCase
         $this->assertSame(
             [
                 'guest_count' => 2,
-                'package_id'  => 47,
-                'items'       => [
+                'package_id' => 47,
+                'items' => [
                     ['menu_id' => 15, 'quantity' => 1],
                 ],
             ],
@@ -164,7 +164,7 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_accepts_intent_only_refill_payload(): void
     {
-        $rules = (new RefillOrderRequest())->rules();
+        $rules = (new RefillOrderRequest)->rules();
 
         $payload = [
             'items' => [
@@ -183,7 +183,7 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_refill_rejects_missing_menu_id(): void
     {
-        $rules = (new RefillOrderRequest())->rules();
+        $rules = (new RefillOrderRequest)->rules();
 
         $payload = [
             'items' => [
@@ -199,7 +199,7 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_refill_does_not_require_item_name(): void
     {
-        $rules = (new RefillOrderRequest())->rules();
+        $rules = (new RefillOrderRequest)->rules();
 
         $payload = [
             'items' => [
@@ -218,7 +218,7 @@ class DeviceOrderIntentContractTest extends TestCase
 
     public function test_refill_rejects_zero_quantity(): void
     {
-        $rules = (new RefillOrderRequest())->rules();
+        $rules = (new RefillOrderRequest)->rules();
 
         $payload = [
             'items' => [['menu_id' => 10, 'quantity' => 0]],
@@ -230,7 +230,28 @@ class DeviceOrderIntentContractTest extends TestCase
         $this->assertArrayHasKey('items.0.quantity', $validator->errors()->toArray());
     }
 
-    public function test_expandIntentPayload_shape(): void
+    public function test_refill_does_not_accept_client_price(): void
+    {
+        $rules = (new RefillOrderRequest)->rules();
+
+        $payload = [
+            'items' => [
+                ['menu_id' => 10, 'quantity' => 1, 'price' => 999.99],
+            ],
+        ];
+
+        $validator = Validator::make($payload, $rules);
+        $validator->passes(); // run validation so validated() is available
+        $validated = $validator->validated();
+
+        $this->assertArrayNotHasKey(
+            'price',
+            $validated['items'][0] ?? [],
+            'Refill request must not accept client-supplied price (backend owns pricing).'
+        );
+    }
+
+    public function test_expand_intent_payload_shape(): void
     {
         DB::table('packages')->insert([
             'id' => 46,
@@ -242,14 +263,14 @@ class DeviceOrderIntentContractTest extends TestCase
             'updated_at' => now(),
         ]);
 
-        $controller = new DeviceOrderApiController();
+        $controller = new DeviceOrderApiController;
         $expand = new \ReflectionMethod($controller, 'expandIntentPayload');
         $expand->setAccessible(true);
 
         $input = [
             'guest_count' => 3,
-            'package_id'  => 46,
-            'items'       => [
+            'package_id' => 46,
+            'items' => [
                 ['menu_id' => 10, 'quantity' => 2],
                 ['menu_id' => 13, 'quantity' => 1],
             ],
@@ -259,7 +280,7 @@ class DeviceOrderIntentContractTest extends TestCase
 
         $this->assertCount(1, $result['items']);
         $this->assertEquals(46, $result['items'][0]['menu_id']);
-        $this->assertEquals(3,  $result['items'][0]['quantity']);
+        $this->assertEquals(3, $result['items'][0]['quantity']);
         $this->assertTrue($result['items'][0]['is_package']);
         $this->assertCount(2, $result['items'][0]['modifiers']);
         $this->assertEquals(10, $result['items'][0]['modifiers'][0]['menu_id']);
@@ -267,9 +288,9 @@ class DeviceOrderIntentContractTest extends TestCase
         $this->assertGreaterThan(0, $result['items'][0]['menu_id']);
     }
 
-    public function test_expandIntentPayload_rejects_invalid_initial_payload(): void
+    public function test_expand_intent_payload_rejects_invalid_initial_payload(): void
     {
-        $controller = new \App\Http\Controllers\Api\V1\DeviceOrderApiController();
+        $controller = new DeviceOrderApiController;
         $expand = new \ReflectionMethod($controller, 'expandIntentPayload');
         $expand->setAccessible(true);
 

--- a/tests/Feature/DeviceOrderIntentContractTest.php
+++ b/tests/Feature/DeviceOrderIntentContractTest.php
@@ -130,6 +130,36 @@ class DeviceOrderIntentContractTest extends TestCase
         );
     }
 
+    public function test_initial_order_request_strips_non_intent_fields_before_validation(): void
+    {
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', [
+            'guest_count'  => 2,
+            'package_id'   => 47,
+            'total_amount' => 123.45,
+            'items'        => [
+                [
+                    'menu_id'  => 15,
+                    'quantity' => 1,
+                    'price'    => 99.99,
+                    'name'     => 'Ignored',
+                ],
+            ],
+        ]);
+
+        $request->setContainer($this->app)->validateResolved();
+
+        $this->assertSame(
+            [
+                'guest_count' => 2,
+                'package_id'  => 47,
+                'items'       => [
+                    ['menu_id' => 15, 'quantity' => 1],
+                ],
+            ],
+            $request->validated()
+        );
+    }
+
     // ─── Refill order ─────────────────────────────────────────────────────────
 
     public function test_accepts_intent_only_refill_payload(): void

--- a/tests/Feature/DeviceOrderIntentPayloadHardeningTest.php
+++ b/tests/Feature/DeviceOrderIntentPayloadHardeningTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrderStatus;
+use App\Models\Branch;
+use App\Models\Device;
+use App\Models\DeviceOrder;
+use App\Models\DeviceOrderItems;
+use App\Models\Package;
+use App\Services\Krypton\OrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\MocksKryptonSession;
+
+class DeviceOrderIntentPayloadHardeningTest extends TestCase
+{
+    use MocksKryptonSession, RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockActiveKryptonSession();
+    }
+
+    public function test_create_order_strips_client_fields_before_order_service(): void
+    {
+        Branch::create(['name' => 'Main', 'location' => 'HQ']);
+
+        Package::query()->create([
+            'name' => 'Classic Feast',
+            'krypton_menu_id' => 46,
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $device = Device::create([
+            'name' => 'Intent Hardening Device',
+            'ip_address' => '192.168.100.8',
+            'is_active' => true,
+            'table_id' => 10,
+        ]);
+
+        $sessionId = $this->createTestSession();
+        $capturedPayload = null;
+
+        $this->mock(OrderService::class, function ($mock) use ($device, $sessionId, &$capturedPayload) {
+            $mock->shouldReceive('processOrder')
+                ->once()
+                ->andReturnUsing(function ($deviceArg, array $payload) use ($device, $sessionId, &$capturedPayload) {
+                    $capturedPayload = $payload;
+
+                    $deviceOrder = DeviceOrder::create([
+                        'device_id' => $device->id,
+                        'table_id' => $device->table_id,
+                        'terminal_session_id' => 1,
+                        'session_id' => $sessionId,
+                        'order_id' => 34567,
+                        'order_number' => 'ORD-000001-34567',
+                        'status' => OrderStatus::CONFIRMED->value,
+                        'subtotal' => 399.00,
+                        'tax' => 39.90,
+                        'discount' => 0.00,
+                        'total' => 438.90,
+                        'guest_count' => 2,
+                    ]);
+
+                    DeviceOrderItems::create([
+                        'order_id' => $deviceOrder->id,
+                        'menu_id' => 46,
+                        'quantity' => 2,
+                        'price' => 399.00,
+                        'subtotal' => 798.00,
+                        'tax' => 79.80,
+                        'total' => 877.80,
+                    ]);
+
+                    return $deviceOrder;
+                });
+        });
+
+        $token = $device->createToken('test-token')->plainTextToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Accept' => 'application/json',
+            'X-Idempotency-Key' => Str::uuid()->toString(),
+        ])->postJson('/api/devices/create-order', [
+            'guest_count'  => 2,
+            'package_id'   => 46,
+            'subtotal'     => 1.00,
+            'tax'          => 0.10,
+            'discount'     => 0.50,
+            'total_amount' => 0.60,
+            'session_id'   => 999,
+            'items'        => [
+                [
+                    'menu_id'         => 10,
+                    'quantity'        => 2,
+                    'name'            => 'Tampered Item',
+                    'price'           => 0.01,
+                    'subtotal'        => 0.02,
+                    'ordered_menu_id' => 12345,
+                    'modifiers'       => [
+                        ['menu_id' => 99, 'quantity' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('success', true);
+
+        $this->assertIsArray($capturedPayload);
+        $this->assertSame(2, $capturedPayload['guest_count']);
+        $this->assertSame(46, $capturedPayload['package_id']);
+        $this->assertArrayNotHasKey('subtotal', $capturedPayload);
+        $this->assertArrayNotHasKey('tax', $capturedPayload);
+        $this->assertArrayNotHasKey('discount', $capturedPayload);
+        $this->assertArrayNotHasKey('total_amount', $capturedPayload);
+        $this->assertArrayNotHasKey('session_id', $capturedPayload);
+
+        $this->assertCount(1, $capturedPayload['items']);
+        $this->assertTrue($capturedPayload['items'][0]['is_package']);
+        $this->assertSame(46, $capturedPayload['items'][0]['menu_id']);
+        $this->assertSame(2, $capturedPayload['items'][0]['quantity']);
+        $this->assertSame(
+            [['menu_id' => 10, 'quantity' => 2]],
+            $capturedPayload['items'][0]['modifiers']
+        );
+
+        $persisted = DeviceOrder::query()->where('device_id', $device->id)->first();
+        $this->assertNotNull($persisted);
+        $this->assertSame(399.00, (float) $persisted->subtotal);
+        $this->assertSame(438.90, (float) $persisted->total);
+        $this->assertSame(2, $persisted->guest_count);
+    }
+}

--- a/tests/Feature/DeviceOrderValidationTest.php
+++ b/tests/Feature/DeviceOrderValidationTest.php
@@ -2,34 +2,72 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreDeviceOrderRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
 
 class DeviceOrderValidationTest extends TestCase
 {
-    public function test_ordered_menu_id_allows_null_and_rejects_zero(): void
+    public function test_validated_output_strips_client_pricing_and_modifier_fields(): void
+    {
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', [
+            'guest_count'  => 2,
+            'package_id'   => 46,
+            'subtotal'     => 999.99,
+            'tax'          => 99.99,
+            'discount'     => 50.00,
+            'total_amount' => 1049.98,
+            'session_id'   => 123,
+            'items'        => [
+                [
+                    'menu_id'         => 10,
+                    'quantity'        => 2,
+                    'name'            => 'Client Name',
+                    'price'           => 100.00,
+                    'subtotal'        => 200.00,
+                    'ordered_menu_id' => 999,
+                    'modifiers'       => [
+                        ['menu_id' => 1, 'quantity' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $request->setContainer($this->app)->validateResolved();
+
+        $validated = $request->validated();
+
+        $this->assertSame(
+            [
+                'guest_count' => 2,
+                'package_id'  => 46,
+                'items'       => [
+                    ['menu_id' => 10, 'quantity' => 2],
+                ],
+            ],
+            $validated
+        );
+    }
+
+    public function test_extra_top_level_fields_do_not_pass_validation_rules(): void
     {
         $rules = (new StoreDeviceOrderRequest())->rules();
 
         $payload = [
-            'guest_count' => 1,
-            'package_id'  => 46,
-            'items' => [
-                [
-                    'menu_id'         => 1,
-                    'quantity'        => 1,
-                    'ordered_menu_id' => null,
-                ]
+            'guest_count'  => 1,
+            'package_id'   => 46,
+            'client_total' => 500.00,
+            'items'        => [
+                ['menu_id' => 1, 'quantity' => 1],
             ],
         ];
 
-        $validator = Validator::make($payload, $rules);
-        $this->assertTrue($validator->passes(), 'ordered_menu_id should allow null for non-meats');
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', $payload);
+        $request->setContainer($this->app)->validateResolved();
 
-        $payload['items'][0]['ordered_menu_id'] = 0;
-        $validatorZero = Validator::make($payload, $rules);
-        $this->assertFalse($validatorZero->passes(), 'ordered_menu_id should reject zero');
-        $this->assertArrayHasKey('items.0.ordered_menu_id', $validatorZero->errors()->toArray());
+        $this->assertArrayNotHasKey('client_total', $request->validated());
+
+        $validator = Validator::make($request->validated(), $rules);
+        $this->assertTrue($validator->passes());
     }
 }

--- a/tests/Feature/OrderCreateAndRefillTest.php
+++ b/tests/Feature/OrderCreateAndRefillTest.php
@@ -2,27 +2,28 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Tests\Traits\MocksKryptonSession;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Mockery;
+use App\Enums\OrderStatus;
 use App\Models\Branch;
 use App\Models\Device;
 use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
 use App\Services\Krypton\KryptonContextService;
-use App\Enums\OrderStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+use Tests\Traits\MocksKryptonSession;
 
 class OrderCreateAndRefillTest extends TestCase
 {
-    use RefreshDatabase, MocksKryptonSession;
+    use MocksKryptonSession, RefreshDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         // Mock active Krypton session for all tests
         $this->mockActiveKryptonSession();
 
@@ -50,7 +51,7 @@ class OrderCreateAndRefillTest extends TestCase
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
         parent::tearDown();
@@ -111,7 +112,7 @@ class OrderCreateAndRefillTest extends TestCase
         $qb->shouldReceive('where')->andReturnSelf();
         $qb->shouldReceive('whereIn')->andReturnSelf();
         $qb->shouldReceive('delete')->andReturn(true);
-        $qb->shouldReceive('first')->andReturn((object)[
+        $qb->shouldReceive('first')->andReturn((object) [
             'id' => 9002,
             'order_id' => 1001,
             'menu_id' => 46,
@@ -124,7 +125,7 @@ class OrderCreateAndRefillTest extends TestCase
         $posConn->shouldReceive('table')->with('ordered_menus')->andReturn($qb);
 
         $realDb = DB::getFacadeRoot();
-            DB::shouldReceive('getDefaultConnection')->andReturn('testing');
+        DB::shouldReceive('getDefaultConnection')->andReturn('testing');
         DB::shouldReceive('connection')->andReturnUsing(function ($name = null) use ($posConn, $realDb) {
             if ($name === 'pos') {
                 return $posConn;
@@ -148,18 +149,17 @@ class OrderCreateAndRefillTest extends TestCase
                     'menu_id' => 46,
                     'name' => 'Classic Feast',
                     'quantity' => 2,
-                    'price' => 399.00,
                     'index' => 2,
                     'seat_number' => 1,
                     'note' => 'Refill',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $response = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization' => 'Bearer '.$token,
             'Accept' => 'application/json',
-            'X-Idempotency-Key' => \Illuminate\Support\Str::uuid()->toString(),
+            'X-Idempotency-Key' => Str::uuid()->toString(),
         ])->postJson('/api/order/1001/refill', $payload);
 
         $response->assertStatus(200)->assertJson(['success' => true]);

--- a/tests/Feature/OrderRealtimeBroadcastTest.php
+++ b/tests/Feature/OrderRealtimeBroadcastTest.php
@@ -2,25 +2,27 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCancelled;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderStatusUpdated;
+use App\Events\Order\OrderVoided;
+use App\Helpers\OrderBroadcastPayload;
 use App\Models\Branch;
 use App\Models\Device;
 use App\Models\DeviceOrder;
-use App\Enums\OrderStatus;
-use App\Events\Order\OrderStatusUpdated;
-use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderVoided;
-use App\Events\Order\OrderCancelled;
-use App\Helpers\OrderBroadcastPayload;
+use App\Models\DeviceOrderItems;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
 
 class OrderRealtimeBroadcastTest extends TestCase
 {
     use RefreshDatabase;
 
     private Device $device;
+
     private int $sessionId;
 
     protected function setUp(): void
@@ -29,9 +31,9 @@ class OrderRealtimeBroadcastTest extends TestCase
 
         $branch = Branch::create(['name' => 'RT Branch', 'location' => 'RT']);
         $this->device = Device::create([
-            'name'       => 'rt-device',
+            'name' => 'rt-device',
             'ip_address' => '127.9.0.1',
-            'branch_id'  => $branch->id,
+            'branch_id' => $branch->id,
         ]);
         $this->sessionId = $this->createTestSession();
     }
@@ -39,20 +41,20 @@ class OrderRealtimeBroadcastTest extends TestCase
     private function makeOrder(array $attributes = []): DeviceOrder
     {
         return DeviceOrder::create(array_merge([
-            'device_id'          => $this->device->id,
-            'branch_id'          => $this->device->branch_id,
-            'table_id'           => 1,
-            'terminal_session_id'=> 1,
-            'session_id'         => $this->sessionId,
-            'order_id'           => rand(100000, 999999),
-            'order_number'       => 'ORD-RT-' . rand(1000, 9999),
-            'status'             => OrderStatus::CONFIRMED->value,
-            'subtotal'           => 100.00,
-            'tax'                => 10.00,
-            'discount'           => 0,
-            'total'              => 110.00,
-            'guest_count'        => 2,
-            'is_printed'         => false,
+            'device_id' => $this->device->id,
+            'branch_id' => $this->device->branch_id,
+            'table_id' => 1,
+            'terminal_session_id' => 1,
+            'session_id' => $this->sessionId,
+            'order_id' => rand(100000, 999999),
+            'order_number' => 'ORD-RT-'.rand(1000, 9999),
+            'status' => OrderStatus::CONFIRMED->value,
+            'subtotal' => 100.00,
+            'tax' => 10.00,
+            'discount' => 0,
+            'total' => 110.00,
+            'guest_count' => 2,
+            'is_printed' => false,
         ], $attributes));
     }
 
@@ -230,6 +232,20 @@ class OrderRealtimeBroadcastTest extends TestCase
         }
     }
 
+    public function test_broadcast_payload_items_expose_done_state_for_kds(): void
+    {
+        $order = $this->makeOrder();
+        DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+        $payload = OrderBroadcastPayload::make($order);
+
+        $this->assertNotEmpty($payload['items'], 'Order should broadcast its items');
+        $item = $payload['items'][0];
+        $this->assertArrayHasKey('done', $item, 'Broadcast item must expose "done" so KDS can reconcile checkbox state');
+        $this->assertArrayHasKey('done_at', $item, 'Broadcast item must expose "done_at" for KDS reconcile');
+        $this->assertTrue($item['done']);
+    }
+
     public function test_all_terminal_event_payloads_contain_order_key(): void
     {
         $order = $this->makeOrder();
@@ -243,7 +259,7 @@ class OrderRealtimeBroadcastTest extends TestCase
 
         foreach ($events as $event) {
             $data = $event->broadcastWith();
-            $this->assertArrayHasKey('order', $data, get_class($event) . '::broadcastWith() must wrap payload in "order" key');
+            $this->assertArrayHasKey('order', $data, get_class($event).'::broadcastWith() must wrap payload in "order" key');
             $this->assertIsArray($data['order']);
         }
     }

--- a/tests/Feature/OrderRefillTest.php
+++ b/tests/Feature/OrderRefillTest.php
@@ -2,27 +2,28 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Tests\Traits\MocksKryptonSession;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Mockery;
+use App\Enums\OrderStatus;
 use App\Models\Branch;
 use App\Models\Device;
 use App\Models\DeviceOrder;
 use App\Models\PrintEvent;
 use App\Services\Krypton\KryptonContextService;
-use App\Enums\OrderStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+use Tests\Traits\MocksKryptonSession;
 
 class OrderRefillTest extends TestCase
 {
-    use RefreshDatabase, MocksKryptonSession;
+    use MocksKryptonSession, RefreshDatabase;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         // Mock active Krypton session for all tests
         $this->mockActiveKryptonSession();
 
@@ -50,7 +51,7 @@ class OrderRefillTest extends TestCase
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
         parent::tearDown();
@@ -90,15 +91,13 @@ class OrderRefillTest extends TestCase
         $kctxMock->shouldReceive('getData')->andReturn(['employee_log_id' => 12]);
         $this->app->instance(KryptonContextService::class, $kctxMock);
 
-        // No Krypton Menu lookup required — controller accepts `menu_id` + `price` directly.
-
         // Mock POS connection to accept ordered_menus inserts
         $qb = Mockery::mock();
         $qb->shouldReceive('insertGetId')->andReturn(9001);
         $qb->shouldReceive('where')->andReturnSelf();
         $qb->shouldReceive('whereIn')->andReturnSelf();
         $qb->shouldReceive('delete')->andReturn(true);
-        $qb->shouldReceive('first')->andReturn((object)[
+        $qb->shouldReceive('first')->andReturn((object) [
             'id' => 9001,
             'order_id' => 1001,
             'menu_id' => 46,
@@ -136,18 +135,17 @@ class OrderRefillTest extends TestCase
                     'menu_id' => 46,
                     'name' => 'Classic Feast',
                     'quantity' => 2,
-                    'price' => 399.00,
                     'index' => 1,
                     'seat_number' => 1,
                     'note' => 'Refill',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $response = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization' => 'Bearer '.$token,
             'Accept' => 'application/json',
-            'X-Idempotency-Key' => \Illuminate\Support\Str::uuid()->toString(),
+            'X-Idempotency-Key' => Str::uuid()->toString(),
         ])->postJson('/api/order/1001/refill', $payload);
 
         $response->assertStatus(200)->assertJson(['success' => true]);
@@ -210,7 +208,7 @@ class OrderRefillTest extends TestCase
         $qb->shouldReceive('where')->andReturnSelf();
         $qb->shouldReceive('whereIn')->andReturnSelf();
         $qb->shouldReceive('delete')->andReturn(true);
-        $qb->shouldReceive('first')->andReturn((object)[
+        $qb->shouldReceive('first')->andReturn((object) [
             'id' => 9002,
             'order_id' => 1002,
             'menu_id' => 47,
@@ -249,7 +247,6 @@ class OrderRefillTest extends TestCase
                     'menu_id' => 47,
                     'name' => 'Marinated Beef',
                     'quantity' => 1,
-                    'price' => 88.00,
                     'index' => 1,
                     'seat_number' => 1,
                     'note' => 'Refill',
@@ -258,7 +255,6 @@ class OrderRefillTest extends TestCase
                     'menu_id' => 48,
                     'name' => 'Pickled Cucumber',
                     'quantity' => 1,
-                    'price' => 10.00,
                     'index' => 2,
                     'seat_number' => 1,
                     'note' => 'Refill',
@@ -316,7 +312,7 @@ class OrderRefillTest extends TestCase
         $qb->shouldReceive('where')->andReturnSelf();
         $qb->shouldReceive('whereIn')->andReturnSelf();
         $qb->shouldReceive('delete')->andReturn(true);
-        $qb->shouldReceive('first')->andReturn((object)[
+        $qb->shouldReceive('first')->andReturn((object) [
             'id' => 9003,
             'order_id' => 2002,
             'menu_id' => 46,
@@ -352,18 +348,17 @@ class OrderRefillTest extends TestCase
                     'menu_id' => 46,
                     'name' => 'Classic Feast',
                     'quantity' => 2,
-                    'price' => 399.00,
                     'index' => 1,
                     'seat_number' => 1,
                     'note' => 'Refill',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $response = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization' => 'Bearer '.$token,
             'Accept' => 'application/json',
-            'X-Idempotency-Key' => \Illuminate\Support\Str::uuid()->toString(),
+            'X-Idempotency-Key' => Str::uuid()->toString(),
         ])->postJson('/api/order/2002/refill', $payload);
 
         $response->assertStatus(200)->assertJson(['success' => true]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -311,6 +311,7 @@ abstract class TestCase extends BaseTestCase
                     $table->string('order_number')->nullable();
                     $table->uuid('order_uuid')->nullable()->unique();
                     $table->string('status')->nullable();
+                    $table->smallInteger('recalled')->default(0);
                     $table->decimal('subtotal', 8, 2)->nullable();
                     $table->decimal('tax', 8, 2)->nullable();
                     $table->decimal('discount', 8, 2)->nullable();
@@ -347,6 +348,8 @@ abstract class TestCase extends BaseTestCase
                     $table->integer('seat_number')->nullable();
                     $table->integer('index')->nullable();
                     $table->boolean('is_refill')->default(false);
+                    $table->boolean('done')->default(false);
+                    $table->timestamp('done_at')->nullable();
                     $table->boolean('is_printed')->default(false);
                     $table->timestamp('printed_at')->nullable();
                     $table->unsignedBigInteger('printed_by_print_event_id')->nullable();
@@ -370,6 +373,7 @@ abstract class TestCase extends BaseTestCase
                 $table->string('order_number')->nullable();
                 $table->uuid('order_uuid')->nullable()->unique();
                 $table->string('status')->nullable();
+                $table->smallInteger('recalled')->default(0);
                 $table->decimal('subtotal', 8, 2)->nullable();
                 $table->decimal('tax', 8, 2)->nullable();
                 $table->decimal('discount', 8, 2)->nullable();
@@ -402,6 +406,8 @@ abstract class TestCase extends BaseTestCase
                 $table->integer('seat_number')->nullable();
                 $table->integer('index')->nullable();
                 $table->boolean('is_refill')->default(false);
+                $table->boolean('done')->default(false);
+                $table->timestamp('done_at')->nullable();
                 $table->boolean('is_printed')->default(false);
                 $table->timestamp('printed_at')->nullable();
                 $table->unsignedBigInteger('printed_by_print_event_id')->nullable();
@@ -497,7 +503,7 @@ abstract class TestCase extends BaseTestCase
                     // If we can't get the level, assume we need to purge
                     $level = 1;
                 }
-                
+
                 // Rollback all nested transactions/savepoints
                 while ($level > 0) {
                     try {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['resources/js/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- **Laravel Boost config** — added `config/boost.php` (master switch, browser-logs watcher, Tinker MCP toggle); wired `BOOST_TINKER_TOOL_ENABLED` across all three env templates (enabled locally, disabled for Docker/production).
- **Laravel Boost guide** — new `docs/LARAVEL_BOOST_GUIDE.md` covering installation, local-only activation, MCP tools reference, Tinker safety guardrails, and Cursor editor setup; linked from `docs/INDEX.md` and `docs/AI_ONBOARDING.md`.
- **KDS designer spec** — new `docs/kds-designer-spec.md` (v1.0): layout, ticket card anatomy, workflow stages, color tokens, accessibility requirements, implementer file list, and designer handoff checklist.
- **Deployment profile wiring** (`apply-woosoo-config.sh`) — added `WOOSOO_ENV` input (local|staging|production, default production) driving `APP_ENV`/`APP_DEBUG`/`LOG_LEVEL`; `WOOSOO_SCHEME` case-block deriving `SESSION_SECURE_COOKIE` with fail-fast on invalid values; `SESSION_DOMAIN` set to `""` (prevents 419 on multi-host LAN); `set_env` raw mode for boolean literals so PHP reads `false` not `"false"`; `docs/deployment/examples/woosoo.env.example` updated with `WOOSOO_ENV`.
- **Case docs** — nex-case-014 (session-419) and nex-case-011 (duplicate print) both marked COMPLETE/APPROVED.

## Documentation governance checks

- [x] This PR does not introduce duplicate canonical guidance.
- [x] This PR does not introduce a second production deployment flow.
- [x] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [x] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [x] `docs/INDEX.md` was updated if canonical docs changed.