### PR TITLE
fix(deploy): sync apply-woosoo-config.sh with WOOSOO_ENV implementation; fix nex-011 case run state

### DIFF
--- a/docs/cases/nex-case-011-duplicate-order-printing.md
+++ b/docs/cases/nex-case-011-duplicate-order-printing.md
@@ -8,22 +8,22 @@ scope: app
 
 ## Run State
 - task_slug: nex-case-011-duplicate-order-printing
-- tier: 1
+- tier: 3
 - branch: fix/nex-011-duplicate-print
-- status: IMPLEMENTED
+- status: COMPLETE
 - last_completed_agent: executioner
-- next_agent: reviewer
+- next_agent: done
 - active_runner: claude
 - interrupted: false
 - interrupt_reason: none
-- updated: 2026-06-04
+- updated: 2026-06-05
 
 ## Handoff
-- Phase in progress: intake complete; ready for implementation.
-- Done so far: Root causes fully isolated with file + line citations. Three distinct duplicate-print vectors identified; two are in nexus, one is a bridge-side amplifier. Fix is surgical — no schema changes, no new abstractions.
-- Exact next action: Executioner to (1) remove `PrintOrder::dispatch()` from all `markPrinted` paths (both controllers), (2) add `is_printed` idempotency guard to `OrderApiController::markPrinted`, (3) verify the bridge receives only `OrderPrinted` on ack and no spurious re-print. nex-case-005 (legacy non-idempotent path) is addressed by action (2) and can be closed together.
-- Working-tree state: no app edits applied yet.
-- Risks / do-not-redo: Do not remove `PrintOrder::dispatch()` from `OrderService::processOrder()` — that is the correct initial print trigger. Only remove it from the ack/mark-printed paths. Do not touch the `OrderPrinted` dispatches — those are the correct post-print notifications. Do not enable `NEXUS_PRINT_EVENTS_ENABLED` as part of this fix; the PrintEvent system is separately gated.
+- Phase in progress: none — COMPLETE.
+- Done so far: Root cause isolated (two vectors). Code fix executed and approved: `PrintOrder::dispatch()` removed from all `markPrinted` ack paths in both controllers; `is_printed` idempotency guard added to `OrderApiController::markPrinted`; nex-case-005 closed inline. PR #163 merged to woosoo-nexus `dev` on 2026-06-04.
+- Exact next action (operator, on Pi — Bucket B): confirm `NEXUS_PRINT_EVENTS_ENABLED=true`; disable 3rd-party Krypton POS printer so only BT thermal printer prints; verify one order → one ticket on BT only, POS still receives order for billing.
+- Working-tree state: PR #163 merged to woosoo-nexus `dev`. No further code changes needed for this case.
+- Risks / do-not-redo: Do not remove `PrintOrder::dispatch()` from `OrderService::processOrder()` — that is the correct initial print trigger. Do not touch the `OrderPrinted` dispatches. Do not disable `CreateOrderedMenu` — the POS needs the mirror for billing; only the POS printer output is suppressed.
 
 ## Tier
 1 — operational P1. Duplicate kitchen tickets cause double-cooking, waste, and staff confusion. Gates dev→staging promotion.

--- a/docs/deployment/examples/woosoo.env.example
+++ b/docs/deployment/examples/woosoo.env.example
@@ -14,6 +14,14 @@ WOOSOO_GATEWAY="192.168.100.1"
 WOOSOO_CIDR="24"
 WOOSOO_NEXUS_PATH="/opt/woosoo/woosoo-nexus"
 WOOSOO_SCHEME="https"
+# WOOSOO_ENV selects the environment profile applied by apply-woosoo-config.sh.
+# Allowed values: local | staging | production
+# - local:      APP_ENV=local,      APP_DEBUG=true,  LOG_LEVEL=debug
+# - staging:    APP_ENV=staging,    APP_DEBUG=false, LOG_LEVEL=info
+# - production: APP_ENV=production, APP_DEBUG=false, LOG_LEVEL=error
+# SESSION_SECURE_COOKIE is derived from WOOSOO_SCHEME (https → true; http → false)
+# and is NOT affected by this variable.
+WOOSOO_ENV="production"
 
 # OPTIONAL (has defaults or deployment-specific values)
 WOOSOO_DNS_FORWARDERS="1.1.1.1 8.8.8.8"

--- a/scripts/deployment/apply-woosoo-config.sh
+++ b/scripts/deployment/apply-woosoo-config.sh
@@ -45,6 +45,36 @@ require_var WOOSOO_CIDR
 require_var WOOSOO_NEXUS_PATH
 require_var WOOSOO_SCHEME
 
+# WOOSOO_ENV selects the environment profile: local | staging | production.
+WOOSOO_ENV="${WOOSOO_ENV:-production}"
+case "$WOOSOO_ENV" in
+  local)
+    _APP_ENV="local"
+    _APP_DEBUG="true"
+    _LOG_LEVEL="debug"
+    ;;
+  staging)
+    _APP_ENV="staging"
+    _APP_DEBUG="false"
+    _LOG_LEVEL="info"
+    ;;
+  production)
+    _APP_ENV="production"
+    _APP_DEBUG="false"
+    _LOG_LEVEL="error"
+    ;;
+  *)
+    echo "ERROR: WOOSOO_ENV='${WOOSOO_ENV}' is not valid. Allowed values: local | staging | production" >&2
+    exit 1
+    ;;
+esac
+# SESSION_SECURE_COOKIE is derived from WOOSOO_SCHEME, not from WOOSOO_ENV.
+if [[ "${WOOSOO_SCHEME}" == "https" ]]; then
+  _SESSION_SECURE_COOKIE="true"
+else
+  _SESSION_SECURE_COOKIE="false"
+fi
+
 WOOSOO_APPLY_STATIC_IP="${WOOSOO_APPLY_STATIC_IP:-true}"
 WOOSOO_RESTART_DOCKER="${WOOSOO_RESTART_DOCKER:-true}"
 WOOSOO_DOCKER_COMPOSE="${WOOSOO_DOCKER_COMPOSE:-docker compose -f compose.yaml}"
@@ -295,6 +325,7 @@ fi
 
 safe_backup_file ".env"
 
+echo "Environment:   $WOOSOO_ENV (APP_ENV=${_APP_ENV}, APP_DEBUG=${_APP_DEBUG}, LOG_LEVEL=${_LOG_LEVEL}, SESSION_SECURE_COOKIE=${_SESSION_SECURE_COOKIE})"
 echo "Updating Laravel .env..."
 db_password_value="${WOOSOO_DB_PASSWORD:-change_this_password}"
 db_root_password_value="${WOOSOO_DB_ROOT_PASSWORD:-change_this_root_password}"
@@ -302,8 +333,8 @@ set_env "PUBLIC_SCHEME" "$WOOSOO_SCHEME"
 set_env "PUBLIC_HOST" "$WOOSOO_HOST"
 set_env "PUBLIC_HTTP_PORT" "80"
 set_env "PUBLIC_HTTPS_PORT" "443"
-set_env "APP_ENV" "production"
-set_env "APP_DEBUG" "false"
+set_env "APP_ENV" "$_APP_ENV"
+set_env "APP_DEBUG" "$_APP_DEBUG"
 set_env "APP_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "ASSET_URL" "${WOOSOO_SCHEME}://${WOOSOO_HOST}"
 set_env "APP_TIMEZONE" "${WOOSOO_TIMEZONE:-Asia/Manila}"
@@ -344,13 +375,15 @@ set_env "VITE_REVERB_APP_KEY" "${WOOSOO_REVERB_APP_KEY:-change_this_reverb_key}"
 set_env "VITE_REVERB_HOST" "$WOOSOO_HOST"
 set_env "VITE_REVERB_PORT" "443"
 set_env "VITE_REVERB_SCHEME" "$WOOSOO_SCHEME"
-set_env "SESSION_DOMAIN" "$WOOSOO_HOST"
-set_env "SESSION_SECURE_COOKIE" "true"
+# SESSION_DOMAIN left empty so the cookie is scoped to whatever host the
+# request arrives on — prevents 419s when accessing from multiple IPs/hostnames.
+set_env "SESSION_DOMAIN" ""
+set_env "SESSION_SECURE_COOKIE" "$_SESSION_SECURE_COOKIE"
 set_env "SESSION_SAME_SITE" "lax"
 set_env "SANCTUM_STATEFUL_DOMAINS" "${WOOSOO_HOST},${WOOSOO_HOST}:443,${WOOSOO_HOST}:80,${WOOSOO_HOST}:4443"
 set_env "CORS_ALLOWED_ORIGINS" "${WOOSOO_SCHEME}://${WOOSOO_HOST},http://${WOOSOO_HOST},${WOOSOO_SCHEME}://${WOOSOO_HOST}:4443"
 set_env "DEVICE_AUTH_PASSCODE" "${WOOSOO_DEVICE_AUTH_PASSCODE:-}"
-set_env "LOG_LEVEL" "error"
+set_env "LOG_LEVEL" "$_LOG_LEVEL"
 
 if ! grep -qE '^APP_KEY=base64:.+' .env; then
   echo "INFO: APP_KEY is not set. Before first production use, run: $WOOSOO_DOCKER_COMPOSE exec -T $WOOSOO_APP_SERVICE php artisan key:generate"


### PR DESCRIPTION
## Summary

- **`scripts/deployment/apply-woosoo-config.sh`** — nexus copy was a stale fork of the platform deploy script, missing the nex-case-014 changes. Synced:
  - `WOOSOO_ENV` case block (local|staging|production, default=production) drives `APP_ENV`/`APP_DEBUG`/`LOG_LEVEL` via profile variables; invalid values exit 1 with a clear error
  - `SESSION_DOMAIN` changed from `"$WOOSOO_HOST"` → `""` (host-only cookie — the core nex-case-014 fix; prevents 419s on multi-host Pi access)
  - `SESSION_SECURE_COOKIE` changed from hardcoded `"true"` → derived from `WOOSOO_SCHEME` (https→true, anything else→false)
  - Environment-profile diagnostic echo added on startup
- **`docs/deployment/examples/woosoo.env.example`** — adds `WOOSOO_ENV="production"` with allowed-values comment block
- **`docs/cases/nex-case-011-duplicate-order-printing.md`** — fixes stale run state: `IMPLEMENTED`/`next_agent:reviewer` → `COMPLETE`/`next_agent:done`; corrects pre-implementation handoff text that survived after PR #163 merged

Resolves CodeRabbit findings on PR #170 (comment threads 3366752981, 3366752983, 3366752984 — all replied and resolved).

## Test plan

- [x] `php artisan test --compact` — 441 passed / 1556 assertions (no PHP code changed; deploy script is bash-only)
- [ ] On Pi: run `apply-woosoo-config.sh` with `WOOSOO_ENV=local`, `staging`, `production` and confirm correct `APP_ENV`/`APP_DEBUG`/`LOG_LEVEL` in `.env`; confirm `SESSION_DOMAIN` is empty; confirm `SESSION_SECURE_COOKIE` tracks `WOOSOO_SCHEME`
- [ ] On Pi: confirm invalid `WOOSOO_ENV` value exits 1 with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)