### PR TITLE
fix(nexus): enforce intent-only payload on device order create (NEX-CASE-015)

### DIFF
--- a/app/Http/Requests/StoreDeviceOrderRequest.php
+++ b/app/Http/Requests/StoreDeviceOrderRequest.php
@@ -15,6 +15,30 @@ class StoreDeviceOrderRequest extends FormRequest
     }
 
     /**
+     * Strip any non-intent fields before validation so client-supplied pricing,
+     * modifiers, and POS mapping never enter validated() output.
+     *
+     * Contract: contracts/tablet-api.contract.md (intent-only payload).
+     */
+    protected function prepareForValidation(): void
+    {
+        $items = collect($this->input('items', []))
+            ->filter(static fn ($item) => is_array($item))
+            ->map(static fn (array $item) => [
+                'menu_id' => $item['menu_id'] ?? null,
+                'quantity' => $item['quantity'] ?? null,
+            ])
+            ->values()
+            ->all();
+
+        $this->replace([
+            'guest_count' => $this->input('guest_count'),
+            'package_id' => $this->input('package_id'),
+            'items' => $items,
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
@@ -22,34 +46,11 @@ class StoreDeviceOrderRequest extends FormRequest
     public function rules(): array
     {
         return [
-            // Intent-only fields (tablet staging contract)
-            'guest_count'  => ['required', 'integer', 'min:1', 'max:20'],
-            'package_id'   => ['required', 'integer', 'min:1'],
-
-            // Client-supplied totals are optional; server always recalculates them.
-            'subtotal'      => ['nullable', 'numeric', 'min:0'],
-            'tax'           => ['nullable', 'numeric', 'min:0'],
-            'discount'      => ['nullable', 'numeric', 'min:0'],
-            'total_amount'  => ['nullable', 'numeric', 'min:0'],
-
-            'session_id' => ['nullable', 'integer'],
-
-            // Items: only menu_id + quantity are required; name/price/subtotal are optional
-            // (server resolves them from POS menu catalog)
-            'items'                    => ['required', 'array', 'min:1'],
-            'items.*.menu_id'          => ['required', 'integer', 'min:1'],
-            'items.*.quantity'         => ['required', 'integer', 'min:1', 'max:50'],
-            'items.*.name'             => ['nullable', 'string'],
-            'items.*.price'            => ['nullable', 'numeric', 'min:0'],
-            'items.*.note'             => ['nullable', 'string'],
-            'items.*.subtotal'         => ['nullable', 'numeric', 'min:0'],
-            'items.*.ordered_menu_id'  => ['nullable', 'integer', 'min:1'],
-            'items.*.tax'              => ['nullable', 'numeric', 'min:0'],
-            'items.*.discount'         => ['nullable', 'numeric', 'min:0'],
-            'items.*.is_package'       => ['nullable', 'boolean'],
-            'items.*.modifiers'        => ['nullable', 'array'],
-            'items.*.modifiers.*.menu_id'  => ['required_with:items.*.modifiers', 'integer'],
-            'items.*.modifiers.*.quantity' => ['required_with:items.*.modifiers', 'integer', 'min:1'],
+            'guest_count' => ['required', 'integer', 'min:1', 'max:20'],
+            'package_id' => ['required', 'integer', 'min:1'],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.menu_id' => ['required', 'integer', 'min:1'],
+            'items.*.quantity' => ['required', 'integer', 'min:1', 'max:50'],
         ];
     }
 }

--- a/tests/Feature/DeviceOrderIntentContractTest.php
+++ b/tests/Feature/DeviceOrderIntentContractTest.php
@@ -130,6 +130,36 @@ class DeviceOrderIntentContractTest extends TestCase
         );
     }
 
+    public function test_initial_order_request_strips_non_intent_fields_before_validation(): void
+    {
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', [
+            'guest_count'  => 2,
+            'package_id'   => 47,
+            'total_amount' => 123.45,
+            'items'        => [
+                [
+                    'menu_id'  => 15,
+                    'quantity' => 1,
+                    'price'    => 99.99,
+                    'name'     => 'Ignored',
+                ],
+            ],
+        ]);
+
+        $request->setContainer($this->app)->validateResolved();
+
+        $this->assertSame(
+            [
+                'guest_count' => 2,
+                'package_id'  => 47,
+                'items'       => [
+                    ['menu_id' => 15, 'quantity' => 1],
+                ],
+            ],
+            $request->validated()
+        );
+    }
+
     // ─── Refill order ─────────────────────────────────────────────────────────
 
     public function test_accepts_intent_only_refill_payload(): void

--- a/tests/Feature/DeviceOrderIntentPayloadHardeningTest.php
+++ b/tests/Feature/DeviceOrderIntentPayloadHardeningTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\OrderStatus;
+use App\Models\Branch;
+use App\Models\Device;
+use App\Models\DeviceOrder;
+use App\Models\DeviceOrderItems;
+use App\Models\Package;
+use App\Services\Krypton\OrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+use Tests\Traits\MocksKryptonSession;
+
+class DeviceOrderIntentPayloadHardeningTest extends TestCase
+{
+    use MocksKryptonSession, RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockActiveKryptonSession();
+    }
+
+    public function test_create_order_strips_client_fields_before_order_service(): void
+    {
+        Branch::create(['name' => 'Main', 'location' => 'HQ']);
+
+        Package::query()->create([
+            'name' => 'Classic Feast',
+            'krypton_menu_id' => 46,
+            'is_active' => true,
+            'sort_order' => 0,
+        ]);
+
+        $device = Device::create([
+            'name' => 'Intent Hardening Device',
+            'ip_address' => '192.168.100.8',
+            'is_active' => true,
+            'table_id' => 10,
+        ]);
+
+        $sessionId = $this->createTestSession();
+        $capturedPayload = null;
+
+        $this->mock(OrderService::class, function ($mock) use ($device, $sessionId, &$capturedPayload) {
+            $mock->shouldReceive('processOrder')
+                ->once()
+                ->andReturnUsing(function ($deviceArg, array $payload) use ($device, $sessionId, &$capturedPayload) {
+                    $capturedPayload = $payload;
+
+                    $deviceOrder = DeviceOrder::create([
+                        'device_id' => $device->id,
+                        'table_id' => $device->table_id,
+                        'terminal_session_id' => 1,
+                        'session_id' => $sessionId,
+                        'order_id' => 34567,
+                        'order_number' => 'ORD-000001-34567',
+                        'status' => OrderStatus::CONFIRMED->value,
+                        'subtotal' => 399.00,
+                        'tax' => 39.90,
+                        'discount' => 0.00,
+                        'total' => 438.90,
+                        'guest_count' => 2,
+                    ]);
+
+                    DeviceOrderItems::create([
+                        'order_id' => $deviceOrder->id,
+                        'menu_id' => 46,
+                        'quantity' => 2,
+                        'price' => 399.00,
+                        'subtotal' => 798.00,
+                        'tax' => 79.80,
+                        'total' => 877.80,
+                    ]);
+
+                    return $deviceOrder;
+                });
+        });
+
+        $token = $device->createToken('test-token')->plainTextToken;
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'Accept' => 'application/json',
+            'X-Idempotency-Key' => Str::uuid()->toString(),
+        ])->postJson('/api/devices/create-order', [
+            'guest_count'  => 2,
+            'package_id'   => 46,
+            'subtotal'     => 1.00,
+            'tax'          => 0.10,
+            'discount'     => 0.50,
+            'total_amount' => 0.60,
+            'session_id'   => 999,
+            'items'        => [
+                [
+                    'menu_id'         => 10,
+                    'quantity'        => 2,
+                    'name'            => 'Tampered Item',
+                    'price'           => 0.01,
+                    'subtotal'        => 0.02,
+                    'ordered_menu_id' => 12345,
+                    'modifiers'       => [
+                        ['menu_id' => 99, 'quantity' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('success', true);
+
+        $this->assertIsArray($capturedPayload);
+        $this->assertSame(2, $capturedPayload['guest_count']);
+        $this->assertSame(46, $capturedPayload['package_id']);
+        $this->assertArrayNotHasKey('subtotal', $capturedPayload);
+        $this->assertArrayNotHasKey('tax', $capturedPayload);
+        $this->assertArrayNotHasKey('discount', $capturedPayload);
+        $this->assertArrayNotHasKey('total_amount', $capturedPayload);
+        $this->assertArrayNotHasKey('session_id', $capturedPayload);
+
+        $this->assertCount(1, $capturedPayload['items']);
+        $this->assertTrue($capturedPayload['items'][0]['is_package']);
+        $this->assertSame(46, $capturedPayload['items'][0]['menu_id']);
+        $this->assertSame(2, $capturedPayload['items'][0]['quantity']);
+        $this->assertSame(
+            [['menu_id' => 10, 'quantity' => 2]],
+            $capturedPayload['items'][0]['modifiers']
+        );
+
+        $persisted = DeviceOrder::query()->where('device_id', $device->id)->first();
+        $this->assertNotNull($persisted);
+        $this->assertSame(399.00, (float) $persisted->subtotal);
+        $this->assertSame(438.90, (float) $persisted->total);
+        $this->assertSame(2, $persisted->guest_count);
+    }
+}

--- a/tests/Feature/DeviceOrderValidationTest.php
+++ b/tests/Feature/DeviceOrderValidationTest.php
@@ -2,34 +2,72 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\StoreDeviceOrderRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
 
 class DeviceOrderValidationTest extends TestCase
 {
-    public function test_ordered_menu_id_allows_null_and_rejects_zero(): void
+    public function test_validated_output_strips_client_pricing_and_modifier_fields(): void
+    {
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', [
+            'guest_count'  => 2,
+            'package_id'   => 46,
+            'subtotal'     => 999.99,
+            'tax'          => 99.99,
+            'discount'     => 50.00,
+            'total_amount' => 1049.98,
+            'session_id'   => 123,
+            'items'        => [
+                [
+                    'menu_id'         => 10,
+                    'quantity'        => 2,
+                    'name'            => 'Client Name',
+                    'price'           => 100.00,
+                    'subtotal'        => 200.00,
+                    'ordered_menu_id' => 999,
+                    'modifiers'       => [
+                        ['menu_id' => 1, 'quantity' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $request->setContainer($this->app)->validateResolved();
+
+        $validated = $request->validated();
+
+        $this->assertSame(
+            [
+                'guest_count' => 2,
+                'package_id'  => 46,
+                'items'       => [
+                    ['menu_id' => 10, 'quantity' => 2],
+                ],
+            ],
+            $validated
+        );
+    }
+
+    public function test_extra_top_level_fields_do_not_pass_validation_rules(): void
     {
         $rules = (new StoreDeviceOrderRequest())->rules();
 
         $payload = [
-            'guest_count' => 1,
-            'package_id'  => 46,
-            'items' => [
-                [
-                    'menu_id'         => 1,
-                    'quantity'        => 1,
-                    'ordered_menu_id' => null,
-                ]
+            'guest_count'  => 1,
+            'package_id'   => 46,
+            'client_total' => 500.00,
+            'items'        => [
+                ['menu_id' => 1, 'quantity' => 1],
             ],
         ];
 
-        $validator = Validator::make($payload, $rules);
-        $this->assertTrue($validator->passes(), 'ordered_menu_id should allow null for non-meats');
+        $request = StoreDeviceOrderRequest::create('/api/devices/create-order', 'POST', $payload);
+        $request->setContainer($this->app)->validateResolved();
 
-        $payload['items'][0]['ordered_menu_id'] = 0;
-        $validatorZero = Validator::make($payload, $rules);
-        $this->assertFalse($validatorZero->passes(), 'ordered_menu_id should reject zero');
-        $this->assertArrayHasKey('items.0.ordered_menu_id', $validatorZero->errors()->toArray());
+        $this->assertArrayNotHasKey('client_total', $request->validated());
+
+        $validator = Validator::make($request->validated(), $rules);
+        $this->assertTrue($validator->passes());
     }
 }


### PR DESCRIPTION
## Summary
- Strip client pricing, modifiers, and POS mapping fields in \StoreDeviceOrderRequest\ before validation (\prepareForValidation\ + intent-only rules).
- Ensures \\->validated()\ and \OrderService::processOrder\ only receive \guest_count\, \package_id\, and \items[{menu_id, quantity}]\ per \contracts/tablet-api.contract.md\.

## Test plan
- [x] \php artisan test --filter=DeviceOrderValidationTest|DeviceOrderIntentContractTest|DeviceOrderIntentPayloadHardeningTest\ — 16 passed
- [x] Full suite \php artisan test\ — 447 passed (1592 assertions)


Made with [Cursor](https://cursor.com)