### PR TITLE
feat(kds): wire board to advance/toggle endpoints (Wave 1)

### DIFF
--- a/app/Helpers/OrderBroadcastPayload.php
+++ b/app/Helpers/OrderBroadcastPayload.php
@@ -50,6 +50,8 @@ class OrderBroadcastPayload
                 'price' => $it->price,
                 'subtotal' => $it->subtotal,
                 'is_refill' => (bool) ($it->is_refill ?? false),
+                'done' => (bool) ($it->done ?? false),
+                'done_at' => $it->done_at?->toIso8601String(),
                 'notes' => $it->notes ?? null,
                 'type' => $it->type ?? null,
             ])->values()->all(),

--- a/resources/js/components/KDS/useKdsBoard.test.ts
+++ b/resources/js/components/KDS/useKdsBoard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { useKdsBoard } from './useKdsBoard'
+import type { KdsTicket } from './kdsTypes'
+
+function ticketWithItems(itemsDone: boolean[]): KdsTicket {
+  return {
+    id: 'K-1',
+    table: 'T-1',
+    type: 'initial',
+    issued: '7:00 PM',
+    issuedAt: Date.now(),
+    elapsed: 60,
+    state: 'preparing',
+    items: itemsDone.map((done, index) => ({
+      id: `item-${index}`,
+      qty: 1,
+      name: `Item ${index}`,
+      done,
+    })),
+  }
+}
+
+describe('useKdsBoard.applyItemToggle', () => {
+  it('reconciles a matching item to done=true', () => {
+    const board = useKdsBoard([ticketWithItems([false, false])])
+
+    board.applyItemToggle({ order_id: 'K-1', item_id: 'item-0', done: true, done_at: '2026-06-09T12:00:00+00:00' })
+
+    expect(board.tickets.value[0].items[0].done).toBe(true)
+    expect(board.tickets.value[0].items[1].done).toBe(false)
+  })
+
+  it('reconciles a matching item to done=false', () => {
+    const board = useKdsBoard([ticketWithItems([true, true])])
+
+    board.applyItemToggle({ order_id: 'K-1', item_id: 'item-1', done: false, done_at: null })
+
+    expect(board.tickets.value[0].items[1].done).toBe(false)
+    expect(board.tickets.value[0].items[0].done).toBe(true)
+  })
+
+  it('is a no-op for an unknown order id', () => {
+    const board = useKdsBoard([ticketWithItems([false])])
+
+    board.applyItemToggle({ order_id: 'K-999', item_id: 'item-0', done: true, done_at: null })
+
+    expect(board.tickets.value[0].items[0].done).toBe(false)
+  })
+})

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Head } from '@inertiajs/vue3'
+import axios from 'axios'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import 'vue-sonner/style.css'
@@ -9,6 +10,7 @@ import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
 import { ACTIVE_STATES, applyAdvance, applyRecall, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
+import { useKdsBoard } from '@/components/KDS/useKdsBoard'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 
 const props = defineProps<{
@@ -23,7 +25,8 @@ function seedTickets(source: KdsTicket[]): KdsTicket[] {
   }))
 }
 
-const tickets = ref<KdsTicket[]>(seedTickets(props.initialTickets))
+const board = useKdsBoard(seedTickets(props.initialTickets))
+const tickets = board.tickets
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
@@ -54,20 +57,34 @@ function updateTicket(ticketId: string, updater: (ticket: KdsTicket) => KdsTicke
   tickets.value = tickets.value.map((ticket) => ticket.id === ticketId ? updater(ticket) : ticket)
 }
 
-function toggleItem(ticketId: string, itemId: string) {
-  updateTicket(ticketId, (ticket) => {
-    if (ticket.state === 'served' || ticket.state === 'voided') {
-      return ticket
-    }
+async function toggleItem(ticketId: string, itemId: string) {
+  const ticket = tickets.value.find((t) => t.id === ticketId)
 
-    return {
-      ...ticket,
-      items: ticket.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
-    }
-  })
+  if (!ticket || ticket.state === 'served' || ticket.state === 'voided') {
+    return
+  }
+
+  const prevDone = ticket.items.find((item) => item.id === itemId)?.done ?? false
+
+  // Optimistic flip; reconcile to the server's authoritative state on success.
+  updateTicket(ticketId, (current) => ({
+    ...current,
+    items: current.items.map((item) => item.id === itemId ? { ...item, done: !item.done } : item),
+  }))
+
+  try {
+    const { data } = await axios.post(route('kds.toggle-item', itemId))
+    board.applyItemToggle({ order_id: ticketId, item_id: itemId, done: data.done, done_at: data.done_at })
+  } catch (error) {
+    updateTicket(ticketId, (current) => ({
+      ...current,
+      items: current.items.map((item) => item.id === itemId ? { ...item, done: prevDone } : item),
+    }))
+    toast.error((error as any)?.response?.data?.message ?? 'Could not update item.', { duration: 3500 })
+  }
 }
 
-function advanceTicket(ticketId: string) {
+async function advanceTicket(ticketId: string) {
   const ticket = tickets.value.find((item) => item.id === ticketId)
 
   if (!ticket) {
@@ -81,7 +98,16 @@ function advanceTicket(ticketId: string) {
     return
   }
 
+  // Snapshot for rollback, then advance optimistically (client nextStateFor mirrors server nextStatus).
+  const snapshot = ticket
   updateTicket(ticketId, (current) => applyAdvance(current, now.value))
+
+  try {
+    await axios.post(route('kds.advance', ticketId))
+  } catch (error) {
+    updateTicket(ticketId, () => snapshot)
+    toast.error((error as any)?.response?.data?.message ?? 'Could not advance ticket.', { duration: 3500 })
+  }
 }
 
 function toggleDensity() {
@@ -94,6 +120,8 @@ function toggleDensity() {
 }
 
 function recallTicket(ticketId: string) {
+  // Wave 3: wire to POST /kds/orders/{order}/recall (route + enum edge + contract not yet built).
+  // Until then recall is local-only and does not persist.
   updateTicket(ticketId, (ticket) => applyRecall(ticket, now.value))
   selectedFilter.value = 'active'
   toast.success('Ticket recalled to the line.', {

--- a/tests/Feature/OrderRealtimeBroadcastTest.php
+++ b/tests/Feature/OrderRealtimeBroadcastTest.php
@@ -2,25 +2,27 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Event;
-use Tests\TestCase;
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCancelled;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderStatusUpdated;
+use App\Events\Order\OrderVoided;
+use App\Helpers\OrderBroadcastPayload;
 use App\Models\Branch;
 use App\Models\Device;
 use App\Models\DeviceOrder;
-use App\Enums\OrderStatus;
-use App\Events\Order\OrderStatusUpdated;
-use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderVoided;
-use App\Events\Order\OrderCancelled;
-use App\Helpers\OrderBroadcastPayload;
+use App\Models\DeviceOrderItems;
 use Illuminate\Broadcasting\Channel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
 
 class OrderRealtimeBroadcastTest extends TestCase
 {
     use RefreshDatabase;
 
     private Device $device;
+
     private int $sessionId;
 
     protected function setUp(): void
@@ -29,9 +31,9 @@ class OrderRealtimeBroadcastTest extends TestCase
 
         $branch = Branch::create(['name' => 'RT Branch', 'location' => 'RT']);
         $this->device = Device::create([
-            'name'       => 'rt-device',
+            'name' => 'rt-device',
             'ip_address' => '127.9.0.1',
-            'branch_id'  => $branch->id,
+            'branch_id' => $branch->id,
         ]);
         $this->sessionId = $this->createTestSession();
     }
@@ -39,20 +41,20 @@ class OrderRealtimeBroadcastTest extends TestCase
     private function makeOrder(array $attributes = []): DeviceOrder
     {
         return DeviceOrder::create(array_merge([
-            'device_id'          => $this->device->id,
-            'branch_id'          => $this->device->branch_id,
-            'table_id'           => 1,
-            'terminal_session_id'=> 1,
-            'session_id'         => $this->sessionId,
-            'order_id'           => rand(100000, 999999),
-            'order_number'       => 'ORD-RT-' . rand(1000, 9999),
-            'status'             => OrderStatus::CONFIRMED->value,
-            'subtotal'           => 100.00,
-            'tax'                => 10.00,
-            'discount'           => 0,
-            'total'              => 110.00,
-            'guest_count'        => 2,
-            'is_printed'         => false,
+            'device_id' => $this->device->id,
+            'branch_id' => $this->device->branch_id,
+            'table_id' => 1,
+            'terminal_session_id' => 1,
+            'session_id' => $this->sessionId,
+            'order_id' => rand(100000, 999999),
+            'order_number' => 'ORD-RT-'.rand(1000, 9999),
+            'status' => OrderStatus::CONFIRMED->value,
+            'subtotal' => 100.00,
+            'tax' => 10.00,
+            'discount' => 0,
+            'total' => 110.00,
+            'guest_count' => 2,
+            'is_printed' => false,
         ], $attributes));
     }
 
@@ -230,6 +232,20 @@ class OrderRealtimeBroadcastTest extends TestCase
         }
     }
 
+    public function test_broadcast_payload_items_expose_done_state_for_kds(): void
+    {
+        $order = $this->makeOrder();
+        DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+        $payload = OrderBroadcastPayload::make($order);
+
+        $this->assertNotEmpty($payload['items'], 'Order should broadcast its items');
+        $item = $payload['items'][0];
+        $this->assertArrayHasKey('done', $item, 'Broadcast item must expose "done" so KDS can reconcile checkbox state');
+        $this->assertArrayHasKey('done_at', $item, 'Broadcast item must expose "done_at" for KDS reconcile');
+        $this->assertTrue($item['done']);
+    }
+
     public function test_all_terminal_event_payloads_contain_order_key(): void
     {
         $order = $this->makeOrder();
@@ -243,7 +259,7 @@ class OrderRealtimeBroadcastTest extends TestCase
 
         foreach ($events as $event) {
             $data = $event->broadcastWith();
-            $this->assertArrayHasKey('order', $data, get_class($event) . '::broadcastWith() must wrap payload in "order" key');
+            $this->assertArrayHasKey('order', $data, get_class($event).'::broadcastWith() must wrap payload in "order" key');
             $this->assertIsArray($data['order']);
         }
     }


### PR DESCRIPTION
Display.vue was a local-state mock: toggling items and advancing tickets never reached the backend. Adopt useKdsBoard for ticket state and wire advanceTicket/toggleItem to the existing kds.advance / kds.toggle-item JSON endpoints via axios, with optimistic UI, snapshot rollback, and a 422 error toast. toggleItem reconciles to the authoritative done state on success. Recall stays local-only (Wave 3).

Add done/done_at to OrderBroadcastPayload items so a future status broadcast (Wave 2) preserves checkbox state instead of resetting it.

Tests: useKdsBoard.applyItemToggle reconcile (Vitest); broadcast payload exposes done/done_at (Pest). typecheck, build, unit + feature suites green.

## Summary

Describe the change briefly.

## Documentation governance checks

- [ ] This PR does not introduce duplicate canonical guidance.
- [ ] This PR does not introduce a second production deployment flow.
- [ ] This PR does not contradict `woosoo-nexus/compose.yaml` authority.
- [ ] Historical/deprecated content is archived under `docs/archive/` (if applicable).
- [ ] `docs/INDEX.md` was updated if canonical docs changed.
