### PR TITLE
chore(ci): watch dev branch and gate PRs with all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - tests, lint, security
 
 on:
   push:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
   pull_request:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,11 @@ name: linter
 on:
   push:
     branches:
-      - develop
+      - dev
       - main
   pull_request:
     branches:
-      - develop
+      - dev
       - main
 
 jobs:

--- a/.github/workflows/pwa-ci.yml
+++ b/.github/workflows/pwa-ci.yml
@@ -2,7 +2,9 @@ name: PWA CI - tests + smoke
 
 on:
   push:
-    branches: [ main, develop, staging ]
+    branches: [ main, dev, staging ]
+  pull_request:
+    branches: [ main, dev, staging ]
 
 jobs:
   pwa:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,12 @@ name: tests
 on:
   push:
     branches:
-      - develop
+      - dev
+      - main
+      - staging
+  pull_request:
+    branches:
+      - dev
       - main
       - staging
 


### PR DESCRIPTION
## Summary
- Replace stale `develop` branch references with `dev` across all four GitHub Actions workflows
- Add `pull_request` triggers to `tests.yml` and `pwa-ci.yml` (previously push-only)
- Fixes CI blind spot where PRs into `dev` (e.g. #181) showed no build/test checks

## Context
Integration branch is `dev`, but workflows watched non-existent `develop`. Only CodeRabbit ran on feature→dev PRs.

## Test plan
- [ ] Confirm all 4 workflows appear on this PR: CI, linter, tests, PWA CI
- [ ] Verify no workflow still references `develop`
- [ ] After merge, re-open or re-run checks on #181 to confirm CI gates feature PRs into `dev`

## Rollback
Revert this single commit — workflows return to watching `develop` (broken state).