### PR TITLE
fix(nexus): POS connection pre-flight guard + disconnected UI (nex-021)

### DIFF
--- a/app/Http/Controllers/Admin/PosController.php
+++ b/app/Http/Controllers/Admin/PosController.php
@@ -8,9 +8,11 @@ use App\Models\DeviceOrder;
 use App\Services\AuditLogService;
 use App\Services\Pos\PosOrderService;
 use App\Services\Pos\PosTableService;
+use App\Services\PosConnectionService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -19,6 +21,7 @@ class PosController extends Controller
     public function __construct(
         private readonly PosOrderService $orderService,
         private readonly PosTableService $tableService,
+        private readonly PosConnectionService $posConnection,
     ) {}
 
     /**
@@ -26,66 +29,111 @@ class PosController extends Controller
      */
     public function index(): Response
     {
-        $currentSession = DB::connection('pos')
-            ->table('sessions')
-            ->orderByDesc('id')
-            ->first();
+        $posStatus = $this->posConnection->posStatus();
+        if (! $posStatus['connected']) {
+            return $this->disconnectedPosPage($posStatus);
+        }
 
-        $terminals = DB::connection('pos')
-            ->table('terminals as t')
-            ->leftJoin('devices as d', 'd.id', '=', 't.id')
-            ->leftJoin('terminal_sessions as ts', function ($join): void {
-                $join->on('ts.terminal_id', '=', 't.id')
-                    ->whereRaw('ts.id = (SELECT MAX(ts2.id) FROM terminal_sessions ts2 WHERE ts2.terminal_id = t.id)');
-            })
-            ->leftJoin('sessions as s', 's.id', '=', 'ts.session_id')
-            ->leftJoin('orders as o', function ($join): void {
-                $join->on('o.terminal_id', '=', 't.id')
-                    ->where('o.is_open', 1)
-                    ->where('o.is_voided', 0);
-            })
-            ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
-            ->groupBy(
-                't.id',
-                't.type',
-                'd.name',
-                'd.ip_address',
-                'd.port',
-                'd.is_active',
-                'ts.id',
-                'ts.session_id',
-                'ts.date_time_opened',
-                'ts.date_time_closed',
-                's.date_time_closed'
-            )
-            ->orderByDesc('d.is_active')
-            ->orderBy('d.name')
-            ->select([
-                't.id',
-                DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name"),
-                DB::raw("COALESCE(d.type, t.type, 'Terminal') as type"),
-                'd.ip_address',
-                'd.port',
-                'd.is_active',
-                'ts.id as terminal_session_id',
-                'ts.session_id',
-                'ts.date_time_opened as terminal_session_opened_at',
-                'ts.date_time_closed as terminal_session_closed_at',
-                's.date_time_closed as session_closed_at',
-                DB::raw('COUNT(o.id) as open_orders_count'),
-            ])
-            ->get();
+        try {
+            $currentSession = DB::connection('pos')
+                ->table('sessions')
+                ->orderByDesc('id')
+                ->first();
 
-        $initialTerminalId = $terminals->first()->id ?? null;
-        $tables = $initialTerminalId ? $this->tableService->getTablesForTerminal((string) $initialTerminalId) : collect();
+            $terminals = DB::connection('pos')
+                ->table('terminals as t')
+                ->leftJoin('devices as d', 'd.id', '=', 't.id')
+                ->leftJoin('terminal_sessions as ts', function ($join): void {
+                    $join->on('ts.terminal_id', '=', 't.id')
+                        ->whereRaw('ts.id = (SELECT MAX(ts2.id) FROM terminal_sessions ts2 WHERE ts2.terminal_id = t.id)');
+                })
+                ->leftJoin('sessions as s', 's.id', '=', 'ts.session_id')
+                ->leftJoin('orders as o', function ($join): void {
+                    $join->on('o.terminal_id', '=', 't.id')
+                        ->where('o.is_open', 1)
+                        ->where('o.is_voided', 0);
+                })
+                ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
+                ->groupBy(
+                    't.id',
+                    't.type',
+                    'd.name',
+                    'd.ip_address',
+                    'd.port',
+                    'd.is_active',
+                    'ts.id',
+                    'ts.session_id',
+                    'ts.date_time_opened',
+                    'ts.date_time_closed',
+                    's.date_time_closed'
+                )
+                ->orderByDesc('d.is_active')
+                ->orderBy('d.name')
+                ->select([
+                    't.id',
+                    DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name"),
+                    DB::raw("COALESCE(d.type, t.type, 'Terminal') as type"),
+                    'd.ip_address',
+                    'd.port',
+                    'd.is_active',
+                    'ts.id as terminal_session_id',
+                    'ts.session_id',
+                    'ts.date_time_opened as terminal_session_opened_at',
+                    'ts.date_time_closed as terminal_session_closed_at',
+                    's.date_time_closed as session_closed_at',
+                    DB::raw('COUNT(o.id) as open_orders_count'),
+                ])
+                ->get();
 
+            $initialTerminalId = $terminals->first()->id ?? null;
+            $tables = $initialTerminalId ? $this->tableService->getTablesForTerminal((string) $initialTerminalId) : collect();
+
+            return Inertia::render('POS/Index', [
+                'title' => 'POS',
+                'description' => 'Krypton POS terminal and table operations',
+                'terminals' => $terminals,
+                'tables' => $tables,
+                'currentSession' => $currentSession,
+                'posConnected' => true,
+                'posStatus' => 'connected',
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[PosController] POS connection failure in index: '.$e->getMessage());
+
+            return $this->disconnectedPosPage($this->posConnection->failureFromThrowable($e));
+        }
+    }
+
+    /**
+     * @param  array{connected: bool, status: string, message: string}  $posStatus
+     */
+    private function disconnectedPosPage(array $posStatus): Response
+    {
         return Inertia::render('POS/Index', [
             'title' => 'POS',
             'description' => 'Krypton POS terminal and table operations',
-            'terminals' => $terminals,
-            'tables' => $tables,
-            'currentSession' => $currentSession,
+            'terminals' => [],
+            'tables' => collect(),
+            'currentSession' => null,
+            'posConnected' => false,
+            'posStatus' => $posStatus['status'],
+            'posMessage' => $posStatus['message'],
         ]);
+    }
+
+    private function posConnectionError(string $context, ?\Throwable $e = null): JsonResponse
+    {
+        $posStatus = $e !== null
+            ? $this->posConnection->failureFromThrowable($e)
+            : $this->posConnection->posStatus();
+
+        Log::warning("[PosController] POS connection failure in {$context}: ".($e?->getMessage() ?? $posStatus['message']));
+
+        return response()->json([
+            'success' => false,
+            'status' => $posStatus['status'],
+            'message' => $posStatus['message'],
+        ], 503);
     }
 
     /**
@@ -93,28 +141,32 @@ class PosController extends Controller
      */
     public function terminalTables(string $terminalId): JsonResponse
     {
-        $terminal = DB::connection('pos')
-            ->table('terminals as t')
-            ->leftJoin('devices as d', 'd.id', '=', 't.id')
-            ->where('t.id', $terminalId)
-            ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
-            ->select(['t.id', DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name")])
-            ->first();
+        try {
+            $terminal = DB::connection('pos')
+                ->table('terminals as t')
+                ->leftJoin('devices as d', 'd.id', '=', 't.id')
+                ->where('t.id', $terminalId)
+                ->whereRaw("UPPER(COALESCE(d.type, t.type, '')) <> 'PRINTER'")
+                ->select(['t.id', DB::raw("COALESCE(d.name, CONCAT('Terminal ', t.id)) as name")])
+                ->first();
 
-        if (! $terminal) {
+            if (! $terminal) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Terminal not found in Krypton.',
+                ], 404);
+            }
+
+            $tables = $this->tableService->getTablesForTerminal($terminalId);
+
             return response()->json([
-                'success' => false,
-                'message' => 'Terminal not found in Krypton.',
-            ], 404);
+                'success' => true,
+                'terminal' => $terminal,
+                'tables' => $tables,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $tables = $this->tableService->getTablesForTerminal($terminalId);
-
-        return response()->json([
-            'success' => true,
-            'terminal' => $terminal,
-            'tables' => $tables,
-        ]);
     }
 
     /**
@@ -122,195 +174,215 @@ class PosController extends Controller
      */
     public function tableOrders(string $terminalId, string $tableId): JsonResponse
     {
-        $table = DB::connection('pos')
-            ->table('tables')
-            ->where('id', $tableId)
-            ->first();
+        try {
+            $table = DB::connection('pos')
+                ->table('tables')
+                ->where('id', $tableId)
+                ->first();
 
-        if (! $table) {
+            if (! $table) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Table not found in Krypton.',
+                ], 404);
+            }
+
+            $orders = DB::connection('pos')
+                ->table('orders as o')
+                // Subquery restricts to the single latest check per order, preventing
+                // duplicate rows when an order has multiple order_check records.
+                ->leftJoin(
+                    DB::raw('(SELECT order_id, MAX(id) AS max_id FROM order_checks GROUP BY order_id) AS oc_latest'),
+                    'oc_latest.order_id', '=', 'o.id'
+                )
+                ->leftJoin('order_checks as oc', 'oc.id', '=', 'oc_latest.max_id')
+                ->leftJoin('table_orders as tor', 'tor.order_id', '=', 'o.id')
+                ->leftJoin('tables as t', 't.id', '=', 'tor.table_id')
+                ->where('o.terminal_id', $terminalId)
+                ->where('tor.table_id', $tableId)
+                ->where('o.is_open', 1)
+                ->where('o.is_voided', 0)
+                ->groupBy(
+                    'o.id',
+                    'o.reference',
+                    'o.date_time_opened',
+                    'o.date_time_closed',
+                    'o.guest_count',
+                    'o.terminal_id',
+                    'o.is_open',
+                    'o.is_voided',
+                    'oc.total_amount',
+                    'oc.paid_amount',
+                    'oc.is_settled',
+                    'oc.resetable_transaction_number'
+                )
+                ->orderByDesc('o.date_time_opened')
+                ->select([
+                    'o.id',
+                    'o.reference',
+                    'o.date_time_opened',
+                    'o.date_time_closed',
+                    'o.guest_count',
+                    'o.terminal_id',
+                    'o.is_open',
+                    'o.is_voided',
+                    DB::raw('COALESCE(oc.total_amount, 0) as total_amount'),
+                    DB::raw('COALESCE(oc.paid_amount, 0) as paid_amount'),
+                    DB::raw('COALESCE(oc.is_settled, 0) as is_settled'),
+                    'oc.resetable_transaction_number',
+                    DB::raw("GROUP_CONCAT(DISTINCT t.name ORDER BY t.name SEPARATOR ', ') as table_names"),
+                ])
+                ->limit(50)
+                ->get();
+
             return response()->json([
-                'success' => false,
-                'message' => 'Table not found in Krypton.',
-            ], 404);
+                'success' => true,
+                'terminal_id' => $terminalId,
+                'table' => $table,
+                'orders' => $orders,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $orders = DB::connection('pos')
-            ->table('orders as o')
-            // Subquery restricts to the single latest check per order, preventing
-            // duplicate rows when an order has multiple order_check records.
-            ->leftJoin(
-                DB::raw('(SELECT order_id, MAX(id) AS max_id FROM order_checks GROUP BY order_id) AS oc_latest'),
-                'oc_latest.order_id', '=', 'o.id'
-            )
-            ->leftJoin('order_checks as oc', 'oc.id', '=', 'oc_latest.max_id')
-            ->leftJoin('table_orders as tor', 'tor.order_id', '=', 'o.id')
-            ->leftJoin('tables as t', 't.id', '=', 'tor.table_id')
-            ->where('o.terminal_id', $terminalId)
-            ->where('tor.table_id', $tableId)
-            ->where('o.is_open', 1)
-            ->where('o.is_voided', 0)
-            ->groupBy(
-                'o.id',
-                'o.reference',
-                'o.date_time_opened',
-                'o.date_time_closed',
-                'o.guest_count',
-                'o.terminal_id',
-                'o.is_open',
-                'o.is_voided',
-                'oc.total_amount',
-                'oc.paid_amount',
-                'oc.is_settled',
-                'oc.resetable_transaction_number'
-            )
-            ->orderByDesc('o.date_time_opened')
-            ->select([
-                'o.id',
-                'o.reference',
-                'o.date_time_opened',
-                'o.date_time_closed',
-                'o.guest_count',
-                'o.terminal_id',
-                'o.is_open',
-                'o.is_voided',
-                DB::raw('COALESCE(oc.total_amount, 0) as total_amount'),
-                DB::raw('COALESCE(oc.paid_amount, 0) as paid_amount'),
-                DB::raw('COALESCE(oc.is_settled, 0) as is_settled'),
-                'oc.resetable_transaction_number',
-                DB::raw("GROUP_CONCAT(DISTINCT t.name ORDER BY t.name SEPARATOR ', ') as table_names"),
-            ])
-            ->limit(50)
-            ->get();
-
-        return response()->json([
-            'success' => true,
-            'terminal_id' => $terminalId,
-            'table' => $table,
-            'orders' => $orders,
-        ]);
     }
 
     public function addOrder(string $terminalId, string $tableId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'guest_count' => ['required', 'integer', 'min:1', 'max:50'],
-            'reference'   => ['nullable', 'string', 'max:50'],
+            'reference' => ['nullable', 'string', 'max:50'],
         ]);
 
-        $table = DB::connection('pos')->table('tables')->where('id', $tableId)->first();
-        if (! $table) {
-            return response()->json(['success' => false, 'message' => 'Table not found.'], 404);
+        try {
+            $table = DB::connection('pos')->table('tables')->where('id', $tableId)->first();
+            if (! $table) {
+                return response()->json(['success' => false, 'message' => 'Table not found.'], 404);
+            }
+
+            $result = $this->orderService->createOrder(
+                $terminalId,
+                $tableId,
+                (int) $validated['guest_count'],
+                $validated['reference'] ?? null,
+            );
+
+            AuditLogService::adminAction($request, 'pos.order_added', (int) $request->user()->id, [
+                'terminal_id' => $terminalId,
+                'table_id' => $tableId,
+                'order_id' => $result['order_id'] ?? null,
+            ]);
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Order created in Krypton successfully.',
+                'result' => $result,
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        $result = $this->orderService->createOrder(
-            $terminalId,
-            $tableId,
-            (int) $validated['guest_count'],
-            $validated['reference'] ?? null,
-        );
-
-        AuditLogService::adminAction($request, 'pos.order_added', (int) $request->user()->id, [
-            'terminal_id' => $terminalId,
-            'table_id'    => $tableId,
-            'order_id'    => $result['order_id'] ?? null,
-        ]);
-
-        return response()->json([
-            'success' => true,
-            'message' => 'Order created in Krypton successfully.',
-            'result'  => $result,
-        ]);
     }
 
     public function editOrder(string $orderId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'guest_count' => ['required', 'integer', 'min:1', 'max:50'],
-            'reference'   => ['nullable', 'string', 'max:50'],
+            'reference' => ['nullable', 'string', 'max:50'],
         ]);
 
-        $updated = $this->orderService->updateOrder(
-            $orderId,
-            (int) $validated['guest_count'],
-            $validated['reference'] ?? null,
-        );
+        try {
+            $updated = $this->orderService->updateOrder(
+                $orderId,
+                (int) $validated['guest_count'],
+                $validated['reference'] ?? null,
+            );
 
-        if (! $updated) {
-            return response()->json(['success' => false, 'message' => 'Order not found or already voided.'], 404);
+            if (! $updated) {
+                return response()->json(['success' => false, 'message' => 'Order not found or already voided.'], 404);
+            }
+
+            return response()->json(['success' => true, 'message' => 'Order updated in Krypton successfully.']);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        return response()->json(['success' => true, 'message' => 'Order updated in Krypton successfully.']);
     }
 
     public function voidOrder(string $orderId, Request $request): JsonResponse
     {
-        $voided = $this->orderService->voidOrder($orderId);
+        try {
+            $voided = $this->orderService->voidOrder($orderId);
 
-        if (! $voided) {
-            return response()->json(['success' => false, 'message' => 'Order not found.'], 404);
+            if (! $voided) {
+                return response()->json(['success' => false, 'message' => 'Order not found.'], 404);
+            }
+
+            AuditLogService::adminAction($request, 'pos.order_voided', (int) $request->user()->id, [
+                'order_id' => $orderId,
+            ]);
+
+            $deviceOrder = DeviceOrder::where('order_id', $orderId)
+                ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
+                ->first();
+            if ($deviceOrder) {
+                $deviceOrder->status = OrderStatus::VOIDED;
+                $deviceOrder->save();
+            }
+
+            return response()->json(['success' => true, 'message' => 'Order voided in Krypton.']);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
         }
-
-        AuditLogService::adminAction($request, 'pos.order_voided', (int) $request->user()->id, [
-            'order_id' => $orderId,
-        ]);
-
-        $deviceOrder = DeviceOrder::where('order_id', $orderId)
-            ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
-            ->first();
-        if ($deviceOrder) {
-            $deviceOrder->status = OrderStatus::VOIDED;
-            $deviceOrder->save();
-        }
-
-        return response()->json(['success' => true, 'message' => 'Order voided in Krypton.']);
     }
 
     public function payOrder(string $orderId, Request $request): JsonResponse
     {
         $validated = $request->validate([
             'payment_type_id' => ['required', 'integer'],
-            'amount'          => ['required', 'numeric', 'min:0.01'],
-            'tip'             => ['nullable', 'numeric', 'min:0'],
-            'card_company'    => ['nullable', 'string', 'max:50'],
-            'card_number'     => ['nullable', 'string', 'max:30'],
-            'unique_code'     => ['nullable', 'string', 'max:50'],
-            'auth_code'       => ['nullable', 'string', 'max:50'],
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'tip' => ['nullable', 'numeric', 'min:0'],
+            'card_company' => ['nullable', 'string', 'max:50'],
+            'card_number' => ['nullable', 'string', 'max:30'],
+            'unique_code' => ['nullable', 'string', 'max:50'],
+            'auth_code' => ['nullable', 'string', 'max:50'],
             'expiration_date' => ['nullable', 'string', 'max:16'],
         ]);
 
-        $result = $this->orderService->payOrder($orderId, $validated);
+        try {
+            $result = $this->orderService->payOrder($orderId, $validated);
 
-        if (isset($result['error'])) {
-            return response()->json(['success' => false, 'message' => 'Payment processing failed: ' . $result['error']], 500);
-        }
-        if (isset($result['not_found'])) {
-            return response()->json(['success' => false, 'message' => 'Order not found, already closed, or voided.'], 404);
-        }
-        if (isset($result['check_not_found'])) {
-            return response()->json(['success' => false, 'message' => 'Order check not found.'], 404);
-        }
-
-        AuditLogService::adminAction($request, 'pos.order_paid', (int) $request->user()->id, [
-            'order_id'   => $orderId,
-            'amount'     => $validated['amount'],
-            'is_settled' => (bool) $result['is_settled'],
-        ]);
-
-        if ($result['is_settled']) {
-            $deviceOrder = DeviceOrder::where('order_id', $orderId)
-                ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
-                ->first();
-            if ($deviceOrder) {
-                $deviceOrder->status = OrderStatus::COMPLETED;
-                $deviceOrder->save();
+            if (isset($result['error'])) {
+                return response()->json(['success' => false, 'message' => 'Payment processing failed: '.$result['error']], 500);
             }
-        }
+            if (isset($result['not_found'])) {
+                return response()->json(['success' => false, 'message' => 'Order not found, already closed, or voided.'], 404);
+            }
+            if (isset($result['check_not_found'])) {
+                return response()->json(['success' => false, 'message' => 'Order check not found.'], 404);
+            }
 
-        return response()->json([
-            'success'    => true,
-            'message'    => $result['is_settled'] ? 'Order paid and closed.' : 'Payment recorded.',
-            'payment'    => $result['payment'],
-            'is_settled' => $result['is_settled'],
-        ]);
+            AuditLogService::adminAction($request, 'pos.order_paid', (int) $request->user()->id, [
+                'order_id' => $orderId,
+                'amount' => $validated['amount'],
+                'is_settled' => (bool) $result['is_settled'],
+            ]);
+
+            if ($result['is_settled']) {
+                $deviceOrder = DeviceOrder::where('order_id', $orderId)
+                    ->whereNotIn('status', [OrderStatus::COMPLETED->value, OrderStatus::VOIDED->value])
+                    ->first();
+                if ($deviceOrder) {
+                    $deviceOrder->status = OrderStatus::COMPLETED;
+                    $deviceOrder->save();
+                }
+            }
+
+            return response()->json([
+                'success' => true,
+                'message' => $result['is_settled'] ? 'Order paid and closed.' : 'Payment recorded.',
+                'payment' => $result['payment'],
+                'is_settled' => $result['is_settled'],
+            ]);
+        } catch (\Throwable $e) {
+            return $this->posConnectionError(__FUNCTION__, $e);
+        }
     }
 }

--- a/app/Services/PosConnectionService.php
+++ b/app/Services/PosConnectionService.php
@@ -28,11 +28,15 @@ class PosConnectionService
 
             $creds = SystemSetting::getPosConnection();
 
+            if (blank($creds['password'] ?? null)) {
+                Log::warning('[PosConnectionService] POS host/database/username are configured but the password is empty — connections will fail with access denied');
+            }
+
             $current = Config::get('database.connections.pos', []);
 
             $override = array_filter([
-                'host'     => $creds['host'],
-                'port'     => $creds['port'],
+                'host' => $creds['host'],
+                'port' => $creds['port'],
                 'database' => $creds['database'],
                 'username' => $creds['username'],
                 'password' => $creds['password'] ?? '',
@@ -52,8 +56,96 @@ class PosConnectionService
                 DB::purge('pos');
             }
         } catch (\Throwable $e) {
-            Log::warning('[PosConnectionService] Failed to apply POS connection from DB: ' . $e->getMessage());
+            Log::warning('[PosConnectionService] Failed to apply POS connection from DB: '.$e->getMessage());
         }
+    }
+
+    /**
+     * @return array{connected: bool, status: string, message: string}
+     */
+    public function posStatus(): array
+    {
+        return once(function (): array {
+            if (! $this->hasPasswordConfigured()) {
+                return [
+                    'connected' => false,
+                    'status' => 'not_configured',
+                    'message' => 'POS password is not configured. Open Configuration → POS Connection and enter the database password.',
+                ];
+            }
+
+            try {
+                DB::connection('pos')->getPdo();
+
+                return [
+                    'connected' => true,
+                    'status' => 'connected',
+                    'message' => '',
+                ];
+            } catch (\Throwable $e) {
+                return $this->failureFromThrowable($e);
+            }
+        });
+    }
+
+    public function isReachable(): bool
+    {
+        return $this->posStatus()['connected'];
+    }
+
+    /**
+     * @return array{connected: bool, status: string, message: string}
+     */
+    public function failureFromThrowable(\Throwable $e): array
+    {
+        $message = $e->getMessage();
+
+        if (str_contains($message, '1045') || str_contains($message, 'Access denied')) {
+            return [
+                'connected' => false,
+                'status' => 'auth_failed',
+                'message' => 'POS database rejected the credentials. Check Configuration → POS Connection and verify the username and password.',
+            ];
+        }
+
+        if (
+            str_contains($message, '2002')
+            || str_contains($message, '2003')
+            || str_contains($message, 'Connection refused')
+            || str_contains($message, 'timed out')
+            || str_contains($message, 'getaddrinfo')
+        ) {
+            return [
+                'connected' => false,
+                'status' => 'unreachable',
+                'message' => 'Unable to reach the POS database. Confirm the host and port are correct and the MySQL server is running.',
+            ];
+        }
+
+        return [
+            'connected' => false,
+            'status' => 'unreachable',
+            'message' => 'Unable to reach the POS system. Check Configuration → POS Connection.',
+        ];
+    }
+
+    private function hasPasswordConfigured(): bool
+    {
+        if (Config::get('database.connections.pos.driver') === 'sqlite') {
+            return true;
+        }
+
+        try {
+            if (Schema::hasTable('system_settings') && SystemSetting::hasPosConnection()) {
+                $password = SystemSetting::getPosConnection()['password'] ?? null;
+
+                return filled($password);
+            }
+        } catch (\Throwable) {
+            // Fall through to env-based check.
+        }
+
+        return filled(Config::get('database.connections.pos.password'));
     }
 
     /**
@@ -62,21 +154,21 @@ class PosConnectionService
      */
     public function testCredentials(string $host, string $port, string $database, string $username, string $password): array
     {
-        $tempName = 'pos_probe_' . uniqid();
+        $tempName = 'pos_probe_'.uniqid();
 
         try {
             Config::set("database.connections.{$tempName}", [
-                'driver'    => 'mysql',
-                'host'      => $host,
-                'port'      => (int) $port,
-                'database'  => $database,
-                'username'  => $username,
-                'password'  => $password,
-                'charset'   => 'utf8mb4',
+                'driver' => 'mysql',
+                'host' => $host,
+                'port' => (int) $port,
+                'database' => $database,
+                'username' => $username,
+                'password' => $password,
+                'charset' => 'utf8mb4',
                 'collation' => 'utf8mb4_unicode_ci',
-                'prefix'    => '',
-                'strict'    => true,
-                'options'   => [
+                'prefix' => '',
+                'strict' => true,
+                'options' => [
                     \PDO::ATTR_TIMEOUT => 5, // 5-second connect timeout
                 ],
             ]);

--- a/resources/js/pages/POS/Index.vue
+++ b/resources/js/pages/POS/Index.vue
@@ -12,7 +12,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { MonitorSmartphone, Circle, ReceiptText } from 'lucide-vue-next'
+import { MonitorSmartphone, Circle, ReceiptText, RefreshCw } from 'lucide-vue-next'
 import EditOrderDialog from '@/components/pos/EditOrderDialog.vue'
 import PaymentDialog from '@/components/pos/PaymentDialog.vue'
 import PosTableCard from '@/components/pos/PosTableCard.vue'
@@ -31,8 +31,6 @@ import {
     Skeleton,
 } from '@/components/ui/skeleton'
 
-// Interfaces imported from @/types/pos
-
 const props = defineProps<{
     title: string
     description: string
@@ -43,6 +41,9 @@ const props = defineProps<{
         date_time_opened: string
         date_time_closed: string | null
     } | null
+    posConnected?: boolean
+    posStatus?: 'connected' | 'not_configured' | 'auth_failed' | 'unreachable'
+    posMessage?: string
 }>()
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -53,19 +54,34 @@ const breadcrumbs: BreadcrumbItem[] = [
 ]
 
 const pageTitle = computed(() => props.title || 'POS')
+
+const posBannerTitle = computed(() => {
+    switch (props.posStatus) {
+        case 'not_configured':
+            return 'POS password not configured'
+        case 'auth_failed':
+            return 'POS credentials rejected'
+        case 'unreachable':
+            return 'POS not reachable'
+        default:
+            return 'POS not connected'
+    }
+})
 const terminals = computed<PosTerminal[]>(() => (Array.isArray(props.terminals) ? props.terminals : []))
-const currentSession = computed(() => props.currentSession ?? null)
 
 const selectedTerminalId = ref<string | null>(terminals.value[0]?.id ?? null)
-const tables = ref<PosTable[]>(Array.isArray(props.tables) ? props.tables : [])
+const terminalTables = ref<PosTable[]>(Array.isArray(props.tables) ? props.tables : [])
 const tablesLoading = ref(false)
 const tablesError = ref<string | null>(null)
+const loadingTerminalId = ref<string | null>(null)
+let tablesLoadSeq = 0
 
 const showOrdersModal = ref(false)
 const selectedTable = ref<PosTable | null>(null)
 const selectedOrders = ref<PosOrder[]>([])
 const ordersLoading = ref(false)
 const ordersError = ref<string | null>(null)
+const addOrderError = ref<string | null>(null)
 const actionLoading = ref(false)
 
 const form = useForm({
@@ -91,14 +107,14 @@ const selectedTerminal = computed(() =>
     terminals.value.find((terminal) => String(terminal.id) === String(selectedTerminalId.value)) ?? null
 )
 
-const occupiedTables = computed(() => tables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
+const occupiedTables = computed(() => terminalTables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
 
 const currentSessionStatus = computed(() => {
-    if (!currentSession.value) {
+    if (!props.currentSession) {
         return 'No Session'
     }
 
-    return currentSession.value.date_time_closed ? 'Closed' : 'Open'
+    return props.currentSession.date_time_closed ? 'Closed' : 'Open'
 })
 
 const readJsonPayload = async (response: Response): Promise<any> => {
@@ -172,7 +188,9 @@ const fetchWithCsrf = async (url: string, options: RequestInit): Promise<Respons
 }
 
 const loadTablesForTerminal = async (terminalId: string) => {
+    const seq = ++tablesLoadSeq
     selectedTerminalId.value = terminalId
+    loadingTerminalId.value = terminalId
     tablesLoading.value = true
     tablesError.value = null
 
@@ -184,17 +202,24 @@ const loadTablesForTerminal = async (terminalId: string) => {
             },
         })
 
+        if (seq !== tablesLoadSeq) return
+
         const payload = await readJsonPayload(response)
 
         if (!response.ok || !payload?.success) {
             throw new Error(payload?.message || 'Failed to load tables for selected terminal.')
         }
 
-        tables.value = Array.isArray(payload.tables) ? payload.tables : []
+        terminalTables.value = Array.isArray(payload.tables) ? payload.tables : []
     } catch (error: any) {
-        tablesError.value = error?.message || 'Unable to load tables from Krypton.'
+        if (seq === tablesLoadSeq) {
+            tablesError.value = error?.message || 'Unable to load tables from Krypton.'
+        }
     } finally {
-        tablesLoading.value = false
+        if (seq === tablesLoadSeq) {
+            tablesLoading.value = false
+            loadingTerminalId.value = null
+        }
     }
 }
 
@@ -206,6 +231,7 @@ const openTableOrders = async (table: PosTable) => {
     selectedTable.value = table
     selectedOrders.value = []
     ordersError.value = null
+    addOrderError.value = null
     ordersLoading.value = true
     showOrdersModal.value = true
 
@@ -251,7 +277,7 @@ const addOrderForTable = () => {
             loadTablesForTerminal(selectedTerminalId.value!)
         },
         onError: (errors) => {
-            ordersError.value = errors.message || 'Unable to add order from POS.'
+            addOrderError.value = errors.message || 'Unable to add order from POS.'
         },
     })
 }
@@ -375,6 +401,12 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-5">
+            <div v-if="posConnected === false" class="rounded-[18px] border border-destructive/40 bg-destructive/10 px-5 py-4 text-sm text-destructive">
+                <p class="font-semibold">{{ posBannerTitle }}</p>
+                <p class="mt-1">{{ posMessage }}</p>
+                <a :href="route('pos-connection.index')" class="mt-2 inline-block underline underline-offset-2 hover:opacity-80">Go to Configuration → POS Connection</a>
+            </div>
+
             <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
                 <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                     <div class="max-w-3xl space-y-3">
@@ -411,8 +443,8 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 </div>
                 <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
                     <p class="text-xs uppercase tracking-wide text-muted-foreground">Current Session</p>
-                    <p class="mt-1 text-lg font-semibold">#{{ currentSession?.id || '—' }} • {{ currentSessionStatus }}</p>
-                    <p class="text-xs text-muted-foreground">Opened: {{ formatDateTime(currentSession?.date_time_opened) }}</p>
+                    <p class="mt-1 text-lg font-semibold">#{{ props.currentSession?.id || '—' }} • {{ currentSessionStatus }}</p>
+                    <p class="text-xs text-muted-foreground">Opened: {{ formatDateTime(props.currentSession?.date_time_opened) }}</p>
                 </div>
             </section>
 
@@ -427,8 +459,9 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                             v-for="terminal in terminals"
                             :key="terminal.id"
                             type="button"
-                            class="group rounded-[22px] border border-black/8 bg-gradient-to-b from-slate-900/95 to-slate-950 p-4 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-woosoo-accent/70 hover:shadow-woosoo-accent/20 dark:border-white/10"
+                            class="group rounded-[22px] border border-black/8 bg-gradient-to-b from-slate-900/95 to-slate-950 p-4 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-woosoo-accent/70 hover:shadow-woosoo-accent/20 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10"
                             :class="String(selectedTerminalId) === String(terminal.id) ? 'ring-2 ring-woosoo-accent/70' : ''"
+                            :disabled="tablesLoading && loadingTerminalId === String(terminal.id)"
                             @click="loadTablesForTerminal(String(terminal.id))"
                         >
                             <div class="mb-3 flex items-center justify-between">
@@ -441,9 +474,15 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
 
                             <div class="mx-auto mb-4 flex h-44 w-full max-w-[220px] items-center justify-center rounded-[1.7rem] border-[10px] border-slate-700 bg-slate-800 shadow-inner">
                                 <div class="flex h-full w-full flex-col items-center justify-center rounded-[1.2rem] bg-slate-900 text-center text-white/90">
-                                    <MonitorSmartphone class="mb-2 h-10 w-10 text-woosoo-accent" />
-                                    <p class="px-2 text-sm font-semibold leading-tight">{{ terminal.name }}</p>
-                                    <p class="mt-1 text-[11px] text-white/50">{{ terminal.type }}</p>
+                                    <template v-if="tablesLoading && loadingTerminalId === String(terminal.id)">
+                                        <RefreshCw class="mb-2 h-10 w-10 animate-spin text-woosoo-accent" />
+                                        <p class="px-2 text-[11px] text-white/50">Loading tables…</p>
+                                    </template>
+                                    <template v-else>
+                                        <MonitorSmartphone class="mb-2 h-10 w-10 text-woosoo-accent" />
+                                        <p class="px-2 text-sm font-semibold leading-tight">{{ terminal.name }}</p>
+                                        <p class="mt-1 text-[11px] text-white/50">{{ terminal.type }}</p>
+                                    </template>
                                 </div>
                             </div>
 
@@ -469,7 +508,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                             </p>
                         </div>
                         <div class="text-right text-xs text-muted-foreground">
-                            <p>Registered Tables: <span class="font-semibold text-foreground">{{ tables.length }}</span></p>
+                            <p>Registered Tables: <span class="font-semibold text-foreground">{{ terminalTables.length }}</span></p>
                             <p>Occupied Tables: <span class="font-semibold text-destructive">{{ occupiedTables }}</span></p>
                         </div>
                     </div>
@@ -488,9 +527,13 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                         {{ tablesError }}
                     </div>
 
+                    <div v-else-if="terminalTables.length === 0" class="rounded-xl border border-black/8 bg-muted/30 px-4 py-8 text-center text-sm text-muted-foreground dark:border-white/10">
+                        No tables found for this terminal.
+                    </div>
+
                     <div v-else class="grid grid-cols-2 gap-4 md:grid-cols-4 xl:grid-cols-6">
                         <PosTableCard
-                            v-for="table in tables"
+                            v-for="table in terminalTables"
                             :key="table.id"
                             :table="table"
                             :selected="selectedTable?.id === table.id"
@@ -515,29 +558,37 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 <div class="max-h-[62vh] overflow-auto px-6 py-4">
                     <div class="mb-4 rounded-xl border border-black/8 bg-muted/30 p-4 dark:border-white/10">
                         <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Add Order by Table</p>
-                        <div class="flex flex-wrap items-end gap-3">
-                            <div>
-                                <label class="mb-1 block text-xs text-muted-foreground">Guest Count</label>
-                                <input
-                                    v-model.number="form.guest_count"
-                                    type="number"
-                                    min="1"
-                                    class="w-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                >
-                            </div>
-                            <div>
-                                <label class="mb-1 block text-xs text-muted-foreground">Reference</label>
-                                <input
-                                    v-model="form.reference"
-                                    type="text"
-                                    class="w-56 rounded-md border border-input bg-background px-3 py-2 text-sm"
-                                    placeholder="Optional"
-                                >
-                            </div>
-                            <Button :disabled="form.processing" @click="addOrderForTable">
-                                Add Order
-                            </Button>
+                        <div v-if="props.currentSession?.date_time_closed" class="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                            Session closed — orders cannot be added.
                         </div>
+                        <template v-else>
+                            <div class="flex flex-wrap items-end gap-3">
+                                <div>
+                                    <label class="mb-1 block text-xs text-muted-foreground">Guest Count</label>
+                                    <input
+                                        v-model.number="form.guest_count"
+                                        type="number"
+                                        min="1"
+                                        class="w-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                    >
+                                </div>
+                                <div>
+                                    <label class="mb-1 block text-xs text-muted-foreground">Reference</label>
+                                    <input
+                                        v-model="form.reference"
+                                        type="text"
+                                        class="w-56 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                                        placeholder="Optional"
+                                    >
+                                </div>
+                                <Button :disabled="form.processing" @click="addOrderForTable">
+                                    Add Order
+                                </Button>
+                            </div>
+                            <div v-if="addOrderError" class="mt-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                                {{ addOrderError }}
+                            </div>
+                        </template>
                     </div>
 
                     <div v-if="ordersLoading" class="space-y-3 py-4">
@@ -573,7 +624,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                                 <th class="px-2 py-3 text-right">Guests</th>
                                 <th class="px-2 py-3 text-right">Total</th>
                                 <th class="px-2 py-3 text-right">Paid</th>
-                                <th class="px-2 py-3 text-right">Resetable Txn#</th>
+                                <th class="px-2 py-3 text-right">Resettable Txn#</th>
                                 <th class="px-2 py-3 text-right">Actions</th>
                             </tr>
                         </thead>
@@ -599,37 +650,37 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                         </tbody>
                     </table>
                 </div>
-
-                <EditOrderDialog
-                    :open="editDialogOpen"
-                    :order="selectedOrderForEdit"
-                    @update:open="editDialogOpen = $event"
-                    @save="handleEditSave"
-                />
-
-                <PaymentDialog
-                    :open="paymentDialogOpen"
-                    :order="selectedOrderForPay"
-                    @update:open="paymentDialogOpen = $event"
-                    @pay="handlePay"
-                />
-
-                <AlertDialog :open="voidDialogOpen" @update:open="voidDialogOpen = $event">
-                    <AlertDialogContent>
-                        <AlertDialogHeader>
-                            <AlertDialogTitle>Void Order #{{ selectedOrderForVoid?.id }}</AlertDialogTitle>
-                            <AlertDialogDescription>
-                                Are you sure you want to void this order? This action cannot be undone.
-                            </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                            <AlertDialogCancel @click="voidDialogOpen = false">Cancel</AlertDialogCancel>
-                            <AlertDialogAction @click="handleVoidConfirm">Void Order</AlertDialogAction>
-                        </AlertDialogFooter>
-                    </AlertDialogContent>
-                </AlertDialog>
             </DialogContent>
         </Dialog>
         </div>
+
+        <EditOrderDialog
+            :open="editDialogOpen"
+            :order="selectedOrderForEdit"
+            @update:open="editDialogOpen = $event"
+            @save="handleEditSave"
+        />
+
+        <PaymentDialog
+            :open="paymentDialogOpen"
+            :order="selectedOrderForPay"
+            @update:open="paymentDialogOpen = $event"
+            @pay="handlePay"
+        />
+
+        <AlertDialog :open="voidDialogOpen" @update:open="voidDialogOpen = $event">
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Void Order #{{ selectedOrderForVoid?.id }}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        Are you sure you want to void this order? This action cannot be undone.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel @click="voidDialogOpen = false">Cancel</AlertDialogCancel>
+                    <AlertDialogAction @click="handleVoidConfirm">Void Order</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
     </AppLayout>
 </template>

--- a/tests/Feature/Admin/PosControllerConnectivityTest.php
+++ b/tests/Feature/Admin/PosControllerConnectivityTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->withoutVite();
+
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '127.0.0.1',
+        'port' => 1,
+        'database' => 'test',
+        'username' => 'test',
+        'password' => 'test',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+});
+
+test('pos index returns 200 with posConnected false when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('POS/Index')
+            ->where('posConnected', false)
+            ->where('posStatus', 'unreachable')
+            ->has('posMessage')
+            ->where('terminals', [])
+            ->where('currentSession', null)
+        );
+});
+
+test('pos index reports not_configured when mysql password is empty', function () {
+    Config::set('database.connections.pos', [
+        'driver' => 'mysql',
+        'host' => '192.168.100.7',
+        'port' => 3308,
+        'database' => 'krypton_woosoo',
+        'username' => 'krypton_readonly',
+        'password' => '',
+        'charset' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+        'prefix' => '',
+        'options' => [PDO::ATTR_TIMEOUT => 1],
+    ]);
+    DB::purge('pos');
+
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('POS/Index')
+            ->where('posConnected', false)
+            ->where('posStatus', 'not_configured')
+            ->where('terminals', [])
+        );
+});
+
+test('pos terminal tables endpoint returns 503 when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.terminal.tables', ['terminalId' => '1']))
+        ->assertStatus(503)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('status', 'unreachable');
+});
+
+test('pos table orders endpoint returns 503 when pos connection fails', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+
+    $this->actingAs($admin)
+        ->get(route('pos.table.orders', ['terminalId' => '1', 'tableId' => '1']))
+        ->assertStatus(503)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('status', 'unreachable');
+});


### PR DESCRIPTION
## Summary

- Adds `PosConnectionService::posStatus()` with per-request memoization (`once()`) — classifies `not_configured`, `auth_failed`, `unreachable`
- `PosController` calls `posStatus()` before any DB query; renders a graceful disconnected page (HTTP 200) instead of a raw 500 `QueryException`; all JSON endpoints return HTTP 503 with `{success: false, status, message}` on connectivity failure
- `POS/Index.vue` — new `posConnected`/`posStatus`/`posMessage` props drive a status-aware banner with a link to Configuration → POS Connection
- `PosControllerConnectivityTest` — 4 Pest regression tests covering unreachable + not-configured page render and JSON 503 responses

## Root cause fixed

`PosConnectionService::applyFromDatabase()` applied host/db/username from `system_settings` but did not require `pos.password`, causing MySQL 1045 access-denied to bubble up as an unhandled 500.

## Test plan

- [ ] `php artisan test --filter=PosControllerConnectivity` → 4/4 pass
- [ ] `GET /pos` with broken DB creds → HTTP 200 + disconnected banner (not 500)
- [ ] `GET /pos/{id}/tables` with broken DB creds → HTTP 503 JSON `{success: false, status: "unreachable"}`
- [ ] `scripts/pre-merge-check.ps1 -App woosoo-nexus` (Verifier gate)

## Operator follow-up (not in this PR)

Open Configuration → POS Connection and save the correct `krypton_readonly` password (encrypted in `system_settings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)