### PR TITLE
fix(nexus): null print-dispatch guard + pos.fill-order error sanitization (nex-022 Track 2)

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -99,8 +99,15 @@ Route::middleware([
     'auth:device',
     UpdateDeviceLastSeen::class,
 ])->get('/order/{orderId}/dispatch', function (Request $request, int $orderId) {
-    $order = DeviceOrder::where(['order_id' => $orderId])->first();
+    $order = DeviceOrder::where('order_id', $orderId)->first();
+
+    if (! $order) {
+        return response()->json(['message' => 'Order not found.'], 404);
+    }
+
     PrintOrder::dispatch($order);
+
+    return response()->json(['status' => 'dispatched']);
 });
 
 // Device-only refill/printed endpoints moved under auth:device group below

--- a/routes/web.php
+++ b/routes/web.php
@@ -272,7 +272,16 @@ Route::middleware(['auth'])->group(function () {
 
                 return response()->json(['success' => false, 'message' => 'Device order not found'], 404);
             } catch (Throwable $e) {
-                return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+                // Log the real cause for ops; never leak the raw exception to the client.
+                \Illuminate\Support\Facades\Log::error('[pos.fill-order] update failed', [
+                    'order_id' => $orderId,
+                    'exception' => $e->getMessage(),
+                ]);
+
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Could not update the order. Please try again.',
+                ], 500);
             }
         })->name('pos.fill-order');
 

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -34,9 +34,11 @@ test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', 
     Event::fake([OrderCompleted::class, OrderVoided::class]);
 
     $admin = User::factory()->admin()->create();
+    // SERVED is the valid pre-completion state (SERVED → COMPLETED); the state machine
+    // rejects IN_PROGRESS → COMPLETED.
     $order = DeviceOrder::factory()->create([
         'order_id' => 8001,
-        'status' => OrderStatus::IN_PROGRESS,
+        'status' => OrderStatus::SERVED,
     ]);
 
     $this->actingAs($admin)

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -2,7 +2,6 @@
 
 use App\Enums\OrderStatus;
 use App\Events\Order\OrderCompleted;
-use App\Events\Order\OrderVoided;
 use App\Models\DeviceOrder;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -28,7 +27,9 @@ test('pos fill-order returns 404 when the order is not found (P1-07)', function 
 });
 
 test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
-    Event::fake([OrderCompleted::class, OrderVoided::class]);
+    // Fake all events so the order-status observer broadcast doesn't run during this
+    // fill-order happy-path assertion (the broadcast path is covered elsewhere).
+    Event::fake();
 
     $admin = User::factory()->admin()->create();
     $order = DeviceOrder::factory()->create([

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
+use App\Models\DeviceOrder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+
+uses(RefreshDatabase::class);
+
+test('pos fill-order rejects non-admins (P1-07)', function () {
+    $user = User::factory()->create(['is_admin' => false]);
+
+    $this->actingAs($user)
+        ->postJson('/pos/fill-order', ['order_id' => 1])
+        ->assertForbidden();
+});
+
+test('pos fill-order returns 404 when the order is not found (P1-07)', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->postJson('/pos/fill-order', ['order_id' => 999999])
+        ->assertNotFound()
+        ->assertJson(['success' => false]);
+});
+
+test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
+    Event::fake([OrderCompleted::class, OrderVoided::class]);
+
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create([
+        'order_id' => 8001,
+        'status' => OrderStatus::IN_PROGRESS,
+    ]);
+
+    $this->actingAs($admin)
+        ->postJson('/pos/fill-order', ['order_id' => 8001])
+        ->assertOk()
+        ->assertJson(['success' => true]);
+
+    expect($order->fresh()->status)->toBe(OrderStatus::COMPLETED);
+    Event::assertDispatched(OrderCompleted::class);
+});

--- a/tests/Feature/Admin/PosFillOrderTest.php
+++ b/tests/Feature/Admin/PosFillOrderTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\OrderStatus;
 use App\Events\Order\OrderCompleted;
+use App\Events\Order\OrderVoided;
 use App\Models\DeviceOrder;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -27,9 +28,10 @@ test('pos fill-order returns 404 when the order is not found (P1-07)', function 
 });
 
 test('pos fill-order completes an order and dispatches OrderCompleted (P1-07)', function () {
-    // Fake all events so the order-status observer broadcast doesn't run during this
-    // fill-order happy-path assertion (the broadcast path is covered elsewhere).
-    Event::fake();
+    // Fake only the fill-order events so Eloquent model events (e.g. user_uuid /
+    // order_uuid generation) still fire. The status-update observer broadcast runs for
+    // real but no longer throws — OrderBroadcastPayload guards the POS relations.
+    Event::fake([OrderCompleted::class, OrderVoided::class]);
 
     $admin = User::factory()->admin()->create();
     $order = DeviceOrder::factory()->create([

--- a/tests/Feature/Api/OrderDispatchGuardTest.php
+++ b/tests/Feature/Api/OrderDispatchGuardTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Enums\OrderStatus;
+use App\Events\PrintOrder;
+use App\Models\Branch;
+use App\Models\Device;
+use App\Models\DeviceOrder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+function dispatchTestDevice(): Device
+{
+    Branch::create(['name' => 'Main', 'location' => 'HQ']);
+
+    return Device::create([
+        'name' => 'Kitchen Station 1',
+        'ip_address' => '127.0.0.20',
+        'is_active' => true,
+        'table_id' => 1,
+        'branch_id' => 1,
+    ]);
+}
+
+test('dispatch does not fire PrintOrder when the order does not exist (P1-06)', function () {
+    Event::fake([PrintOrder::class]);
+    Sanctum::actingAs(dispatchTestDevice(), [], 'device');
+
+    $this->getJson('/api/order/999999/dispatch')
+        ->assertNotFound();
+
+    // The pre-fix code dispatched PrintOrder with a null order — guard must prevent that.
+    Event::assertNotDispatched(PrintOrder::class);
+});
+
+test('dispatch fires PrintOrder for an existing order (P1-06)', function () {
+    Event::fake([PrintOrder::class]);
+    Sanctum::actingAs(dispatchTestDevice(), [], 'device');
+
+    DeviceOrder::factory()->create([
+        'order_id' => 7001,
+        'status' => OrderStatus::IN_PROGRESS,
+    ]);
+
+    $this->getJson('/api/order/7001/dispatch')
+        ->assertOk()
+        ->assertJson(['status' => 'dispatched']);
+
+    Event::assertDispatched(PrintOrder::class);
+});


### PR DESCRIPTION
The two genuinely risky nex-case-022 P1 findings (crash path + info leak).

## P1-06 — null `PrintOrder` dispatch (`routes/api.php`)
`GET /api/order/{orderId}/dispatch` did `DeviceOrder::where('order_id', …)->first()` then `PrintOrder::dispatch($order)` with **no null check** — a bad/stale `order_id` dispatched a print job with a null order. Now returns **404** and skips the dispatch; valid orders return `{status: dispatched}`.

## P1-07 — raw exception leak (`routes/web.php`)
The `pos.fill-order` closure returned `$e->getMessage()` straight to the client on failure (info disclosure). Now **logs** the real cause and returns a **generic** message + 500.

## Tests (required — both are shipped-bug regression guards)
- `OrderDispatchGuardTest` — nonexistent order → 404 **and** `PrintOrder` not dispatched; existing order → dispatched.
- `PosFillOrderTest` — non-admin → 403; not-found → 404; admin happy path → completes order + dispatches `OrderCompleted`.

## Notes
- **Simplest-working scope:** P1-07 sanitizes the closure in place (log + generic message). The optional closure→controller extraction is deferred — it's hygiene, not a security/correctness fix.
- Branched clean off `origin/dev`; independent of #185.
- ⚠️ Unverified by me (no PHP on the Windows host) — verifier runs `php artisan test --filter="OrderDispatchGuard|PosFillOrder"` on WSL. CI will run automatically once #185's `dev`-trigger fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)