### PR TITLE
fix(kds): also exclude items.menu from eager-load when POS unreachable

### DIFF
--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -41,7 +41,7 @@ class KdsController extends Controller
     {
         $with = $this->posConnection->isReachable()
             ? ['device.table', 'table', 'items.menu']
-            : ['device', 'items.menu'];
+            : ['device', 'items'];
 
         $orders = DeviceOrder::with($with)
             ->whereNotIn('status', array_map(fn ($s) => $s->value, self::HIDDEN_STATUSES))

--- a/tests/Feature/Admin/KdsControllerConnectivityTest.php
+++ b/tests/Feature/Admin/KdsControllerConnectivityTest.php
@@ -40,6 +40,21 @@ test('kds index returns 200 with empty tickets when pos connection fails', funct
         );
 });
 
+test('kds index returns 200 with tickets when pos unreachable and active orders exist', function () {
+    $admin = User::factory()->create(['is_admin' => true]);
+    \App\Models\DeviceOrder::factory()->confirmed()->create(['table_id' => null]);
+
+    actingAs($admin);
+
+    get(route('kds.display'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->has('initialTickets', 1)
+            ->where('initialTickets.0.table', '—')
+        );
+});
+
 test('kds index returns 200 with empty tickets when pos password is not configured', function () {
     Config::set('database.connections.pos', [
         'driver' => 'mysql',


### PR DESCRIPTION
## Problem

PR #188 guarded `device.table` and `table` but left `items.menu` in the fallback. `menus` is also a POS-connection table (Krypton), so `GET /kds` still produced a 500 when POS was unreachable.

Confirmed in the live app log:
`SQLSTATE[1045] Access denied ... SQL: select * from menus where menus.id in (1) (Connection: pos)`

## Fix

Fallback `\` is now `['device', 'items']` — no POS relations when unreachable. `toTicket()` already handles null menu: `\->menu?->receipt_name ?? \->menu?->name ?? \->name ?? ''`.

## Tests

- 3 tests pass: unreachable host, empty password, and new: active order in DB with POS down -> 200 with ticket rendered (table shows '---')

Generated with Claude Code