### PR TITLE
feat(kds): wire recall button to served tickets

### DIFF
--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ArrowRight, Check } from 'lucide-vue-next'
+import { ArrowRight, Check, RotateCcw } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { elapsedFor, formatElapsed, isAdvanceBlocked, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
+import { canRecallTicket, elapsedFor, formatElapsed, isAdvanceBlocked, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
 import type { KdsDensity, KdsTicket } from './kdsTypes'
 
 const props = defineProps<{
@@ -15,6 +15,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   advance: [ticketId: string]
+  recall: [ticketId: string]
   toggleItem: [ticketId: string, itemId: string]
 }>()
 
@@ -25,6 +26,7 @@ const elapsed = computed(() => elapsedFor(props.ticket, props.now))
 const urgency = computed(() => urgencyFor(props.ticket, props.now))
 const nextState = computed(() => nextStateFor(props.ticket.state))
 const advanceBlocked = computed(() => isAdvanceBlocked(props.ticket))
+const recallable = computed(() => canRecallTicket(props.ticket))
 const actionLabel = computed(() => {
   if (props.ticket.state === 'new') return 'Start Preparing'
   if (props.ticket.state === 'preparing' || props.ticket.state === 'ready') return 'Mark as Served'
@@ -146,6 +148,17 @@ function splitSafetyName(name: string) {
       >
         {{ actionLabel }}
         <ArrowRight data-icon="inline-end" aria-hidden="true" />
+      </Button>
+
+      <Button
+        v-else-if="recallable"
+        type="button"
+        variant="outline"
+        class="kds-card-action kds-recall-action"
+        @click="emit('recall', ticket.id)"
+      >
+        <RotateCcw data-icon="inline-start" aria-hidden="true" />
+        Recall
       </Button>
     </footer>
   </article>

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -33,6 +33,24 @@ export async function postKdsAdvance(orderId: string): Promise<{ status: string 
   return response.json()
 }
 
+export async function postKdsRecall(orderId: string): Promise<{ status: string }> {
+  const response = await fetch(route('kds.orders.recall', orderId), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': csrfToken(),
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseError(response))
+  }
+
+  return response.json()
+}
+
 export async function postKdsToggleItem(itemId: string): Promise<{ done: boolean; done_at: string | null }> {
   const response = await fetch(route('kds.toggle-item', itemId), {
     method: 'POST',

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyAdvance, canAdvanceTicket, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
+import { applyAdvance, canAdvanceTicket, canRecallTicket, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
 import type { KdsTicket, KdsTicketState } from './kdsTypes'
 
 function preparingTicket(itemsDone: boolean[]): KdsTicket {
@@ -75,6 +75,16 @@ describe('Mark as Served gating', () => {
     const ticket = preparingTicket([true, false])
 
     expect(applyAdvance(ticket, now).state).toBe('preparing')
+  })
+})
+
+describe('Recall gating', () => {
+  it('allows recall on served tickets only', () => {
+    expect(canRecallTicket(makeTicket('served'))).toBe(true)
+  })
+
+  it.each<KdsTicketState>(['new', 'preparing', 'ready', 'voided'])('rejects recall from %s', (state) => {
+    expect(canRecallTicket(makeTicket(state))).toBe(false)
   })
 })
 

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -131,6 +131,11 @@ export function canAdvanceTicket(ticket: KdsTicket): boolean {
   return nextStateFor(ticket.state) !== null
 }
 
+/** Recall is the served→in_progress edge only; voided orders need a new ticket (see order-state.contract.md). */
+export function canRecallTicket(ticket: KdsTicket): boolean {
+  return ticket.state === 'served'
+}
+
 /** Primary action `:disabled` — Mark as Served gated until every checklist item is done. */
 export function isAdvanceBlocked(ticket: KdsTicket): boolean {
   if (nextStateFor(ticket.state) === null) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -8,7 +8,7 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { postKdsAdvance, postKdsToggleItem } from '@/components/KDS/kdsApi'
+import { postKdsAdvance, postKdsRecall, postKdsToggleItem } from '@/components/KDS/kdsApi'
 import { ACTIVE_STATES, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 import { useKdsBoard } from '@/components/KDS/useKdsBoard'
@@ -35,6 +35,7 @@ const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
 const pendingAdvance = ref<Set<string>>(new Set())
+const pendingRecall = ref<Set<string>>(new Set())
 const pendingToggle = ref<Set<string>>(new Set())
 let timer: ReturnType<typeof setInterval> | null = null
 
@@ -110,6 +111,28 @@ async function advanceTicket(ticketId: string) {
   }
 }
 
+async function recallTicket(ticketId: string) {
+  const ticket = tickets.value.find((item) => item.id === ticketId)
+
+  if (!ticket || ticket.state !== 'served') {
+    return
+  }
+
+  if (pendingRecall.value.has(ticketId)) {
+    return
+  }
+
+  pendingRecall.value.add(ticketId)
+
+  try {
+    await postKdsRecall(ticketId)
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Unable to recall order.')
+  } finally {
+    pendingRecall.value.delete(ticketId)
+  }
+}
+
 function toggleDensity() {
   density.value = density.value === 'comfortable' ? 'compact' : 'comfortable'
   try {
@@ -181,6 +204,7 @@ onBeforeUnmount(() => {
               :now="now"
               :density="density"
               @advance="advanceTicket"
+              @recall="recallTicket"
               @toggle-item="toggleItem"
             />
           </div>
@@ -862,6 +886,17 @@ body.kds-active {
 :deep(.kds-card-action:focus-visible) {
   outline: 3px solid rgb(246 181 109 / 0.45);
   outline-offset: 2px;
+}
+
+:deep(.kds-recall-action) {
+  border-color: rgb(246 181 109 / 0.35);
+  background: rgb(246 181 109 / 0.08);
+  color: var(--kds-accent);
+}
+
+:deep(.kds-recall-action:hover) {
+  background: rgb(246 181 109 / 0.16);
+  color: var(--kds-accent);
 }
 
 :deep(.kds-empty) {


### PR DESCRIPTION
## Summary

Frontend half of P2 recall. The backend edge (`served→in_progress`, `POST /kds/orders/{order}/recall`, merged in `8cee9c9`) had no UI trigger — kitchen staff could not recall a served order. Tracked follow-up from `kds-implementation-plan.md`.

- **kdsHelpers** — `canRecallTicket()`: served-only gate matching `contracts/order-state.contract.md` (voided orders need a new ticket, not a recall)
- **kdsApi** — `postKdsRecall()` following the existing advance/toggle fetch pattern (CSRF, JSON error parsing)
- **KdsTicketCard** — Recall button rendered on served tickets only (outline variant, accent-tinted to match the `Recalled xN` badge)
- **Display** — `recallTicket` handler with pending-set re-entry guard + error toast; no optimistic apply — board reconciles via the existing `useKdsEcho` broadcast, identical to advance

## Verification

- `npm run test:unit` — 24 passed (2 new: recall gating served-only + each-state rejection)
- `npm run typecheck` / `npm run lint` / `npm run build` — clean
- No PHP changes; backend transition already covered by `OrderStatusRecallTest` (13 tests) from the P2 chain
- Browser E2E: deferred to the staging stack at 192.168.100.7 (host dev server is not the validation surface per platform conventions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)