### PR TITLE
feat(admin): admin pages UI redesign — UI-only polish

### DIFF
--- a/resources/js/components/pos/PosTableCard.vue
+++ b/resources/js/components/pos/PosTableCard.vue
@@ -6,6 +6,17 @@ import { Button } from '@/components/ui/button'
 
 const DINING_TARGET_MINUTES = 90
 
+function elapsedFromOpened(opened: string | null | undefined): { label: string; minutes: number } {
+    if (!opened) return { label: '—', minutes: 0 }
+    const diffMs = Date.now() - new Date(opened).getTime()
+    if (!Number.isFinite(diffMs) || diffMs < 0) return { label: '—', minutes: 0 }
+    const mins = Math.floor(diffMs / 60000)
+    if (mins < 60) return { label: `${mins}m`, minutes: mins }
+    const hrs = Math.floor(mins / 60)
+    const rem = mins % 60
+    return { label: rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`, minutes: mins }
+}
+
 interface Props {
     table: PosTable
     selected?: boolean
@@ -36,25 +47,11 @@ const guestCount = computed(() => {
     return Number(raw) || 0
 })
 
-const elapsedLabel = computed(() => {
-    const opened = props.table.order_created_in
-    if (!opened) return '—'
-    const diffMs = Date.now() - new Date(opened).getTime()
-    if (!Number.isFinite(diffMs) || diffMs < 0) return '—'
-    const mins = Math.floor(diffMs / 60000)
-    if (mins < 60) return `${mins}m`
-    const hrs = Math.floor(mins / 60)
-    const rem = mins % 60
-    return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`
-})
+const elapsed = computed(() => elapsedFromOpened(props.table.order_created_in))
 
-const elapsedMinutes = computed(() => {
-    const opened = props.table.order_created_in
-    if (!opened) return 0
-    const diffMs = Date.now() - new Date(opened).getTime()
-    if (!Number.isFinite(diffMs) || diffMs < 0) return 0
-    return Math.floor(diffMs / 60000)
-})
+const elapsedLabel = computed(() => elapsed.value.label)
+
+const elapsedMinutes = computed(() => elapsed.value.minutes)
 
 const progressPct = computed(() =>
     Math.min(100, Math.round((elapsedMinutes.value / DINING_TARGET_MINUTES) * 100)),

--- a/resources/js/components/pos/PosTableCard.vue
+++ b/resources/js/components/pos/PosTableCard.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { TableProperties } from 'lucide-vue-next'
+import { computed } from 'vue'
+import { Plus } from 'lucide-vue-next'
 import type { PosTable } from '@/types/pos'
+import { Button } from '@/components/ui/button'
+
+const DINING_TARGET_MINUTES = 90
 
 interface Props {
     table: PosTable
@@ -10,54 +14,111 @@ interface Props {
 const props = defineProps<Props>()
 const emit = defineEmits<{
     (e: 'select', table: PosTable): void
+    (e: 'new-order', table: PosTable): void
 }>()
 
-const handleClick = () => {
+const isOpen = computed(() => Boolean(Number(props.table.is_occupied)))
+
+const tableNumber = computed(() => {
+    const name = String(props.table.name ?? '')
+    const match = name.match(/\d+/)
+    return match?.[0] ?? props.table.id
+})
+
+const packageName = computed(() => {
+    const t = props.table as PosTable & { package_name?: string; package?: { name?: string } }
+    return t.package_name ?? t.package?.name ?? '—'
+})
+
+const guestCount = computed(() => {
+    const t = props.table as PosTable & { guest_count?: number | string }
+    const raw = t.guest_count ?? props.table.open_orders_count ?? 0
+    return Number(raw) || 0
+})
+
+const elapsedLabel = computed(() => {
+    const opened = props.table.order_created_in
+    if (!opened) return '—'
+    const diffMs = Date.now() - new Date(opened).getTime()
+    if (!Number.isFinite(diffMs) || diffMs < 0) return '—'
+    const mins = Math.floor(diffMs / 60000)
+    if (mins < 60) return `${mins}m`
+    const hrs = Math.floor(mins / 60)
+    const rem = mins % 60
+    return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`
+})
+
+const elapsedMinutes = computed(() => {
+    const opened = props.table.order_created_in
+    if (!opened) return 0
+    const diffMs = Date.now() - new Date(opened).getTime()
+    if (!Number.isFinite(diffMs) || diffMs < 0) return 0
+    return Math.floor(diffMs / 60000)
+})
+
+const progressPct = computed(() =>
+    Math.min(100, Math.round((elapsedMinutes.value / DINING_TARGET_MINUTES) * 100)),
+)
+
+const handleCardClick = () => {
     emit('select', props.table)
+}
+
+const handleNewOrder = (event: Event) => {
+    event.stopPropagation()
+    emit('new-order', props.table)
 }
 </script>
 
 <template>
     <button
         type="button"
-        class="group relative rounded-2xl border p-4 text-left transition-all duration-200"
+        class="group relative flex flex-col gap-3 rounded-[18px] border p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
         :class="[
-            Number(table.is_occupied)
-                ? 'border-destructive/40 bg-destructive/10'
-                : 'border-woosoo-green/30 bg-woosoo-green/10',
-            selected ? 'ring-2 ring-primary/70' : '',
-            'hover:border-primary hover:shadow-lg hover:-translate-y-0.5'
+            isOpen
+                ? 'border-woosoo-accent/40 bg-woosoo-accent/5'
+                : 'border-black/8 bg-white/60 dark:border-white/10 dark:bg-white/[0.04]',
+            selected ? 'ring-2 ring-woosoo-accent/60' : '',
         ]"
-        @click="handleClick"
+        @click="handleCardClick"
     >
-        <!-- Status indicator -->
-        <div class="mb-2 flex items-center justify-between">
-            <TableProperties class="h-4 w-4 text-foreground/70" />
+        <div class="flex items-start justify-between gap-2">
+            <span class="font-mono text-lg font-bold text-foreground">T-{{ tableNumber }}</span>
             <span
-                class="text-[10px] font-semibold uppercase tracking-wide"
-                :class="Number(table.is_occupied) ? 'text-destructive' : 'text-woosoo-green'"
+                class="inline-flex shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+                :class="isOpen
+                    ? 'bg-woosoo-accent/15 text-woosoo-primary-dark'
+                    : 'bg-muted text-muted-foreground'"
             >
-                {{ Number(table.is_occupied) ? 'Occupied' : 'Available' }}
+                {{ isOpen ? 'Open' : 'Closed' }}
             </span>
         </div>
 
-        <!-- Table name -->
-        <p class="text-base font-semibold">{{ table.name }}</p>
-        <p class="text-[11px] text-muted-foreground">ID {{ table.id }}</p>
-
-        <!-- Order count -->
-        <p class="mt-2 text-xs text-muted-foreground">
-            Orders: <span class="font-semibold text-foreground">{{ Number(table.open_orders_count) }}</span>
+        <p class="truncate text-sm font-medium text-foreground">{{ packageName }}</p>
+        <p class="text-xs text-muted-foreground">
+            {{ guestCount }} guests · {{ elapsedLabel }}
         </p>
 
-        <!-- Occupied pulse indicator (subtle, respects reduced-motion) -->
-        <div
-            v-if="Number(table.is_occupied)"
-            class="absolute right-3 top-3 flex h-2 w-2"
-            aria-hidden="true"
-        >
-            <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-destructive opacity-75"></span>
-            <span class="relative inline-flex h-2 w-2 rounded-full bg-destructive"></span>
+        <div v-if="isOpen" class="space-y-1">
+            <div class="h-1.5 overflow-hidden rounded-full bg-black/10 dark:bg-white/10">
+                <div
+                    class="h-full rounded-full bg-woosoo-accent transition-all"
+                    :style="{ width: `${progressPct}%` }"
+                />
+            </div>
+            <p class="text-[9px] text-muted-foreground">{{ elapsedMinutes }} / {{ DINING_TARGET_MINUTES }} min</p>
         </div>
+
+        <Button
+            v-if="isOpen"
+            type="button"
+            variant="outline"
+            size="sm"
+            class="mt-auto h-8 w-full text-xs"
+            @click="handleNewOrder"
+        >
+            <Plus class="mr-1 h-3 w-3" />
+            New Order
+        </Button>
     </button>
 </template>

--- a/resources/js/pages/Devices/Index.vue
+++ b/resources/js/pages/Devices/Index.vue
@@ -3,8 +3,8 @@ import { computed, ref } from 'vue'
 import { Head, Link, router, usePage } from '@inertiajs/vue3'
 import { toast } from 'vue-sonner'
 import {
-    MonitorSmartphone, RotateCcw, Plus, Eye, Download, RefreshCw, ShieldCheck,
-    ShieldAlert, AlertTriangle,
+    MonitorSmartphone, RotateCcw, Plus, Eye, Download, RefreshCw,
+    AlertTriangle,
 } from 'lucide-vue-next'
 import AppLayout from '@/layouts/AppLayout.vue'
 import DeviceDetailSheet from '@/components/Devices/DeviceDetailSheet.vue'
@@ -62,6 +62,14 @@ const isSyncingAll = ref(false)
 
 const activeDevices = computed(() => props.devices.filter((d) => !d.deleted_at))
 
+const ordersTodayStat = computed(() => {
+    if (!props.stats || !Array.isArray(props.stats) || props.stats.length === 0) return null
+    const match = props.stats.find((s: any) =>
+        String(s?.title ?? '').toLowerCase().includes('order'),
+    )
+    return match ?? null
+})
+
 function deviceStatus(device: Device): 'online' | 'warning' | 'offline' {
     if (device.deleted_at) return 'offline'
     const s = (device.status ?? '').toLowerCase()
@@ -104,13 +112,6 @@ function batteryBg(pct: number | null): string {
     if (pct >= 60) return 'bg-woosoo-green'
     if (pct >= 15) return 'bg-woosoo-accent'
     return 'bg-woosoo-red'
-}
-
-function isVersionMismatch(device: Device): boolean {
-    if (!device.app_version) return false
-    const modal = props.fleetStats?.modal_app_version
-    if (!modal || !device.app_version) return false
-    return device.app_version !== modal && deviceStatus(device) !== 'online'
 }
 
 function openDeviceDetail(device: Device) {
@@ -335,31 +336,35 @@ function syncAll() {
                                 </p>
                             </div>
 
-                            <!-- Footer: version check + actions -->
-                            <div class="flex items-center justify-between">
-                                <span
-                                    class="inline-flex items-center gap-1 text-[10px] font-medium"
-                                    :class="isVersionMismatch(device) ? 'text-woosoo-red' : 'text-woosoo-green'"
+                            <!-- Optional orders-today from stats -->
+                            <div
+                                v-if="ordersTodayStat"
+                                class="rounded-lg border border-woosoo-accent/20 bg-woosoo-accent/5 px-3 py-2"
+                            >
+                                <p class="text-[9px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                                    {{ ordersTodayStat.title }}
+                                </p>
+                                <p class="mt-0.5 font-mono text-sm font-semibold tabular-nums">
+                                    {{ ordersTodayStat.value }}
+                                </p>
+                            </div>
+
+                            <!-- Footer actions -->
+                            <div class="flex items-center justify-end gap-1">
+                                <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openDeviceDetail(device)">
+                                    <Eye class="mr-1 h-3 w-3" />
+                                    View
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    class="h-7 px-2 text-xs"
+                                    :disabled="isRestarting === device.id"
+                                    @click="confirmRestart(device)"
                                 >
-                                    <component :is="isVersionMismatch(device) ? ShieldAlert : ShieldCheck" class="h-3 w-3" />
-                                    {{ isVersionMismatch(device) ? 'Ver Mismatch' : 'Ver OK' }}
-                                </span>
-                                <div class="flex gap-1">
-                                    <Button variant="ghost" size="sm" class="h-7 px-2 text-xs" @click="openDeviceDetail(device)">
-                                        <Eye class="mr-1 h-3 w-3" />
-                                        View
-                                    </Button>
-                                    <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        class="h-7 px-2 text-xs"
-                                        :disabled="isRestarting === device.id"
-                                        @click="confirmRestart(device)"
-                                    >
-                                        <RotateCcw class="mr-1 h-3 w-3" :class="{ 'animate-spin': isRestarting === device.id }" />
-                                        Regen Code
-                                    </Button>
-                                </div>
+                                    <RotateCcw class="mr-1 h-3 w-3" :class="{ 'animate-spin': isRestarting === device.id }" />
+                                    Restart
+                                </Button>
                             </div>
                         </div>
                     </div>

--- a/resources/js/pages/Devices/Index.vue
+++ b/resources/js/pages/Devices/Index.vue
@@ -70,7 +70,39 @@ const ordersTodayStat = computed(() => {
     return match ?? null
 })
 
-function deviceStatus(device: Device): 'online' | 'warning' | 'offline' {
+type DeviceConnectionStatus = 'online' | 'warning' | 'offline'
+
+const DEVICE_STATUS_TONE: Record<DeviceConnectionStatus, {
+    cardBorder: string
+    iconBg: string
+    iconText: string
+    pill: string
+    dot: string
+}> = {
+    online: {
+        cardBorder: '',
+        iconBg: 'bg-woosoo-green/10',
+        iconText: 'text-woosoo-green',
+        pill: 'bg-woosoo-green/10 text-woosoo-green',
+        dot: 'bg-woosoo-green',
+    },
+    warning: {
+        cardBorder: 'border-woosoo-accent/30 dark:border-woosoo-accent/20',
+        iconBg: 'bg-woosoo-accent/10',
+        iconText: 'text-woosoo-accent',
+        pill: 'bg-woosoo-accent/10 text-woosoo-accent',
+        dot: 'bg-woosoo-accent',
+    },
+    offline: {
+        cardBorder: 'border-woosoo-red/30 dark:border-woosoo-red/20',
+        iconBg: 'bg-woosoo-red/10',
+        iconText: 'text-woosoo-red',
+        pill: 'bg-woosoo-red/10 text-woosoo-red',
+        dot: 'bg-woosoo-red',
+    },
+}
+
+function deviceStatus(device: Device): DeviceConnectionStatus {
     if (device.deleted_at) return 'offline'
     const s = (device.status ?? '').toLowerCase()
     if (s === 'online') return 'online'
@@ -83,6 +115,10 @@ function deviceStatus(device: Device): 'online' | 'warning' | 'offline' {
     if (diffMin > 30) return 'offline'
     if (diffMin > 5) return 'warning'
     return 'online'
+}
+
+function deviceStatusTone(device: Device) {
+    return DEVICE_STATUS_TONE[deviceStatus(device)]
 }
 
 function lastPingLabel(device: Device): string {
@@ -244,28 +280,17 @@ function syncAll() {
                             v-for="device in activeDevices"
                             :key="device.id"
                             class="group relative flex flex-col gap-3 rounded-[18px] border border-black/8 bg-white/60 p-4 transition-all duration-150 hover:border-white/20 hover:shadow-sm dark:border-white/10 dark:bg-white/[0.04]"
-                            :class="{
-                                'border-woosoo-red/30 dark:border-woosoo-red/20': deviceStatus(device) === 'offline',
-                                'border-woosoo-accent/30 dark:border-woosoo-accent/20': deviceStatus(device) === 'warning',
-                            }"
+                            :class="deviceStatusTone(device).cardBorder"
                         >
                             <!-- Card header: icon + name + status -->
                             <div class="flex items-start gap-3">
                                 <div
                                     class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
-                                    :class="{
-                                        'bg-woosoo-green/10': deviceStatus(device) === 'online',
-                                        'bg-woosoo-accent/10': deviceStatus(device) === 'warning',
-                                        'bg-woosoo-red/10': deviceStatus(device) === 'offline',
-                                    }"
+                                    :class="deviceStatusTone(device).iconBg"
                                 >
                                     <MonitorSmartphone
                                         class="h-4 w-4"
-                                        :class="{
-                                            'text-woosoo-green': deviceStatus(device) === 'online',
-                                            'text-woosoo-accent': deviceStatus(device) === 'warning',
-                                            'text-woosoo-red': deviceStatus(device) === 'offline',
-                                        }"
+                                        :class="deviceStatusTone(device).iconText"
                                     />
                                 </div>
                                 <div class="min-w-0 flex-1">
@@ -278,19 +303,9 @@ function syncAll() {
                                 <!-- Status pill -->
                                 <span
                                     class="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase"
-                                    :class="{
-                                        'bg-woosoo-green/10 text-woosoo-green': deviceStatus(device) === 'online',
-                                        'bg-woosoo-accent/10 text-woosoo-accent': deviceStatus(device) === 'warning',
-                                        'bg-woosoo-red/10 text-woosoo-red': deviceStatus(device) === 'offline',
-                                    }"
+                                    :class="deviceStatusTone(device).pill"
                                 >
-                                    <span class="h-1 w-1 rounded-full"
-                                        :class="{
-                                            'bg-woosoo-green': deviceStatus(device) === 'online',
-                                            'bg-woosoo-accent': deviceStatus(device) === 'warning',
-                                            'bg-woosoo-red': deviceStatus(device) === 'offline',
-                                        }"
-                                    />
+                                    <span class="h-1 w-1 rounded-full" :class="deviceStatusTone(device).dot" />
                                     {{ deviceStatus(device) }}
                                 </span>
                             </div>

--- a/resources/js/pages/Orders/Index.vue
+++ b/resources/js/pages/Orders/Index.vue
@@ -7,8 +7,9 @@ import { Head, usePage } from '@inertiajs/vue3';
 import { columns } from '@/components/Orders/columns';
 import DataTable from '@/components/Orders/DataTable.vue'
 import OrderDetailSheet from '@/components/Orders/OrderDetailSheet.vue'
-import StatsCards from '@/components/Stats/StatsCards.vue'
+import OrderStatusBadge from '@/components/Orders/OrderStatusBadge.vue'
 import type { DeviceOrder, User} from '@/types/models';
+import { formatCurrency } from '@/lib/utils';
 import { toast } from 'vue-sonner';
 import {
     Tabs,
@@ -100,21 +101,65 @@ watch(echoStatus, (newStatus, oldStatus) => {
 // Track which order IDs have active print animations to prevent duplicate animations
 const animatedOrderIds = new Set<number>()
 
-// Reactive stats always derived from live local arrays — never stale server snapshot
-const liveStats = computed(() => [
-  {
-    title: 'Live Orders',
-    value: localOrders.value.length,
-    subtitle: 'Pending and in-progress',
-    variant: 'primary' as const,
-  },
-  {
-    title: 'Order History',
-    value: localOrderHistory.value.length,
-    subtitle: 'Completed / voided',
-    variant: 'default' as const,
-  },
-])
+const KANBAN_COLUMNS = [
+  { key: 'confirmed', label: 'CONFIRMED', statuses: ['confirmed', 'pending', 'in_progress', 'ready', 'served'] },
+  { key: 'completed', label: 'COMPLETED', statuses: ['completed'] },
+  { key: 'voided', label: 'VOIDED', statuses: ['voided'] },
+  { key: 'cancelled', label: 'CANCELLED', statuses: ['cancelled'] },
+] as const
+
+function orderStatusKey(order: DeviceOrder): string {
+  return String(order.status ?? '').toLowerCase()
+}
+
+function ordersInColumn(statuses: readonly string[]): DeviceOrder[] {
+  return localOrders.value.filter((o) => statuses.includes(orderStatusKey(o)))
+}
+
+const kanbanColumns = computed(() =>
+  KANBAN_COLUMNS.map((col) => ({
+    ...col,
+    orders: ordersInColumn(col.statuses),
+    count: ordersInColumn(col.statuses).length,
+  })),
+)
+
+const dispatchSummary = computed(() => {
+  const confirmed = ordersInColumn(KANBAN_COLUMNS[0].statuses).length
+  const completed = ordersInColumn(KANBAN_COLUMNS[1].statuses).length
+  const voidedCancelled =
+    ordersInColumn(KANBAN_COLUMNS[2].statuses).length +
+    ordersInColumn(KANBAN_COLUMNS[3].statuses).length
+  return { confirmed, completed, voidedCancelled }
+})
+
+function formatElapsed(createdAt?: string | null): string {
+  if (!createdAt) return '—'
+  const diffMs = Date.now() - new Date(createdAt).getTime()
+  if (!Number.isFinite(diffMs) || diffMs < 0) return '—'
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const rem = mins % 60
+  return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`
+}
+
+function orderTotal(order: DeviceOrder): number {
+  const raw = order.total ?? (order as any).total_amount ?? (order.meta as any)?.order_check?.total_amount
+  return typeof raw === 'number' ? raw : Number(raw || 0)
+}
+
+function orderItemsPreview(order: DeviceOrder): { name: string; quantity: number }[] {
+  const items = Array.isArray(order.items) ? order.items : []
+  return items.slice(0, 2).map((it: any) => ({
+    name: it.name || it.menu?.name || 'Item',
+    quantity: it.quantity ?? it.qty ?? 1,
+  }))
+}
+
+function packageLabel(order: DeviceOrder): string {
+  return order.name || (order.meta as any)?.package?.name || '—'
+}
 
 // Play a short audio ping for new orders (no external dependency)
 function playNewOrderPing() {
@@ -476,13 +521,13 @@ onUnmounted(() => {
           <div class="relative flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div class="space-y-2">
               <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
-                Live Operations
+                Kitchen Dispatch
               </span>
               <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
                 Orders
               </h2>
               <p class="text-sm text-muted-foreground">
-                Live kitchen queue and order history — updates in real time when connected.
+                Live kitchen queue by status — updates in real time when connected.
               </p>
             </div>
           </div>
@@ -539,20 +584,85 @@ onUnmounted(() => {
                     </TabsTrigger>
                 </TabsList>
                 <TabsContent value="live_orders" class="space-y-4 pt-3">
-                  <!-- Filters have been moved into the Orders DataTable toolbar -->
-                  <div class="flex flex-wrap items-center justify-between gap-3">
-                    <!-- Always reactive — derived from localOrders/localOrderHistory, never from static server prop -->
-                    <StatsCards :cards="liveStats" />
+                  <!-- Summary chip row -->
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="inline-flex items-center rounded-full border border-woosoo-accent/30 bg-woosoo-accent/10 px-3 py-1.5 text-xs font-medium text-foreground">
+                      {{ dispatchSummary.confirmed }} confirmed
+                      <span class="mx-1.5 text-muted-foreground">·</span>
+                      {{ dispatchSummary.completed }} completed
+                      <span class="mx-1.5 text-muted-foreground">·</span>
+                      {{ dispatchSummary.voidedCancelled }} voided/cancelled
+                    </span>
                   </div>
 
-                  <div class="w-full overflow-x-auto">
-                    <DataTable
-                      :data="localOrders"
-                      :columns="columns"
-                      :devices="devices"
-                      :tables="tables"
-                      @row-click="openOrderDetail"
-                    />
+                  <!-- Kanban columns -->
+                  <div class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+                    <div
+                      v-for="column in kanbanColumns"
+                      :key="column.key"
+                      class="flex min-h-[320px] flex-col rounded-[18px] border border-black/8 bg-white/50 dark:border-white/10 dark:bg-white/[0.03]"
+                    >
+                      <div class="flex items-center justify-between border-b border-black/8 px-4 py-3 dark:border-white/10">
+                        <h3 class="text-[10px] font-semibold tracking-[0.2em] text-muted-foreground uppercase">
+                          {{ column.label }}
+                        </h3>
+                        <Badge
+                          variant="secondary"
+                          class="h-5 min-w-5 rounded-full px-1.5 text-xs tabular-nums"
+                        >
+                          {{ column.count }}
+                        </Badge>
+                      </div>
+
+                      <div class="flex flex-1 flex-col gap-2 overflow-y-auto p-3">
+                        <button
+                          v-for="order in column.orders"
+                          :key="order.id ?? order.order_id ?? order.order_number"
+                          type="button"
+                          :data-order-id="order.id ?? order.order_id"
+                          class="group w-full rounded-[14px] border border-black/8 bg-card p-3 text-left transition-all hover:border-woosoo-accent/40 hover:shadow-sm dark:border-white/10"
+                          :class="{ 'ring-1 ring-woosoo-accent/30': order.__is_refill }"
+                          @click="openOrderDetail(order)"
+                        >
+                          <div class="flex items-start justify-between gap-2">
+                            <span class="text-sm font-bold text-foreground">ORD-{{ order.order_number }}</span>
+                            <OrderStatusBadge :status="orderStatusKey(order)" class="shrink-0 text-[10px]" />
+                          </div>
+                          <p class="mt-1.5 truncate text-xs text-muted-foreground">
+                            {{ order.device?.name ?? '—' }}
+                            <span v-if="order.table?.name"> · {{ order.table.name }}</span>
+                          </p>
+                          <p class="mt-1 truncate text-xs text-foreground/80">
+                            {{ packageLabel(order) }}
+                            <span class="text-muted-foreground"> · {{ order.guest_count ?? '—' }} pax</span>
+                          </p>
+                          <p v-if="orderItemsPreview(order).length" class="mt-1.5 space-y-0.5 text-xs text-muted-foreground">
+                            <span
+                              v-for="(item, idx) in orderItemsPreview(order)"
+                              :key="idx"
+                              class="block truncate"
+                            >
+                              {{ item.name }} ×{{ item.quantity }}
+                            </span>
+                          </p>
+                          <div class="mt-2 flex items-center justify-between gap-2 border-t border-black/5 pt-2 dark:border-white/8">
+                            <span class="text-sm font-semibold tabular-nums text-woosoo-accent">
+                              {{ formatCurrency(orderTotal(order)) }}
+                            </span>
+                            <span class="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              {{ formatElapsed(order.created_at) }}
+                            </span>
+                          </div>
+                        </button>
+
+                        <p
+                          v-if="column.orders.length === 0"
+                          class="flex flex-1 items-center justify-center py-8 text-center text-xs text-muted-foreground"
+                        >
+                          No {{ column.label.toLowerCase() }} orders
+                        </p>
+                      </div>
+                    </div>
                   </div>
                 </TabsContent>
                 <TabsContent value="order_history" class="space-y-4 pt-3">

--- a/resources/js/pages/Orders/Index.vue
+++ b/resources/js/pages/Orders/Index.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, computed, watch } from 'vue';
-import { router } from '@inertiajs/vue3';
+import { Head, router, usePage } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
-import { Head, usePage } from '@inertiajs/vue3';
 import { columns } from '@/components/Orders/columns';
-import DataTable from '@/components/Orders/DataTable.vue'
-import OrderDetailSheet from '@/components/Orders/OrderDetailSheet.vue'
-import OrderStatusBadge from '@/components/Orders/OrderStatusBadge.vue'
+import DataTable from '@/components/Orders/DataTable.vue';
+import OrderDetailSheet from '@/components/Orders/OrderDetailSheet.vue';
+import OrderStatusBadge from '@/components/Orders/OrderStatusBadge.vue';
 import type { DeviceOrder, User} from '@/types/models';
 import { formatCurrency } from '@/lib/utils';
 import { toast } from 'vue-sonner';
@@ -61,40 +60,32 @@ const echoStatus = ref<'connecting' | 'connected' | 'disconnected'>('connecting'
 // during the gap. When disconnected for too long, poll as a fallback.
 let disconnectPollTimer: ReturnType<typeof setTimeout> | null = null
 
+function refreshLocalOrdersFromPage() {
+  const updatedOrders = (page.props as any).orders ?? []
+  const updatedHistory = (page.props as any).orderHistory ?? []
+  localOrders.value = Array.isArray(updatedOrders) ? [...updatedOrders] : []
+  localOrderHistory.value = Array.isArray(updatedHistory) ? [...updatedHistory] : []
+}
+
+function reloadOrdersFromServer() {
+  router.reload({
+    only: ['orders', 'orderHistory'],
+    onSuccess: refreshLocalOrdersFromPage,
+  })
+}
+
 watch(echoStatus, (newStatus, oldStatus) => {
   if (newStatus === 'connected' && oldStatus === 'disconnected') {
     // Only reload when recovering from a real disconnection, not on initial connect.
-    // Using oldStatus === 'disconnected' prevents a spurious reload on first mount.
-    router.reload({
-      only: ['orders', 'orderHistory'],
-      onSuccess: () => {
-        // Refresh UI state from updated props after reload completes
-        const updatedOrders = (page.props as any).orders ?? []
-        const updatedHistory = (page.props as any).orderHistory ?? []
-        localOrders.value = Array.isArray(updatedOrders) ? [...updatedOrders] : []
-        localOrderHistory.value = Array.isArray(updatedHistory) ? [...updatedHistory] : []
-      },
-    })
+    reloadOrdersFromServer()
     if (disconnectPollTimer !== null) {
       clearTimeout(disconnectPollTimer)
       disconnectPollTimer = null
     }
   } else if (newStatus === 'disconnected') {
-    // Fallback: if still disconnected after 30 s, do a data reload so the admin
-    // at least sees the current state even without a live WebSocket.
+    // Fallback: if still disconnected after 30 s, reload so the admin sees current state.
     if (disconnectPollTimer !== null) clearTimeout(disconnectPollTimer)
-    disconnectPollTimer = setTimeout(() => {
-      router.reload({
-        only: ['orders', 'orderHistory'],
-        onSuccess: () => {
-          // Refresh UI state from updated props after reload completes
-          const updatedOrders = (page.props as any).orders ?? []
-          const updatedHistory = (page.props as any).orderHistory ?? []
-          localOrders.value = Array.isArray(updatedOrders) ? [...updatedOrders] : []
-          localOrderHistory.value = Array.isArray(updatedHistory) ? [...updatedHistory] : []
-        },
-      })
-    }, 30_000)
+    disconnectPollTimer = setTimeout(reloadOrdersFromServer, 30_000)
   }
 })
 
@@ -117,11 +108,10 @@ function ordersInColumn(statuses: readonly string[]): DeviceOrder[] {
 }
 
 const kanbanColumns = computed(() =>
-  KANBAN_COLUMNS.map((col) => ({
-    ...col,
-    orders: ordersInColumn(col.statuses),
-    count: ordersInColumn(col.statuses).length,
-  })),
+  KANBAN_COLUMNS.map((col) => {
+    const orders = ordersInColumn(col.statuses)
+    return { ...col, orders, count: orders.length }
+  }),
 )
 
 const dispatchSummary = computed(() => {
@@ -247,9 +237,6 @@ const handleDetailComplete = () => {
     },
   })
 }
-
-// DataTable handles all client-side column filtering
-
 
 const handleOrderEvent = (event: DeviceOrder) => {
   const incoming = (event as any)?.order ? (event as any).order : event

--- a/resources/js/pages/POS/Index.vue
+++ b/resources/js/pages/POS/Index.vue
@@ -12,7 +12,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { MonitorSmartphone, Circle, ReceiptText, RefreshCw } from 'lucide-vue-next'
+import { Circle, ReceiptText, RefreshCw } from 'lucide-vue-next'
 import EditOrderDialog from '@/components/pos/EditOrderDialog.vue'
 import PaymentDialog from '@/components/pos/PaymentDialog.vue'
 import PosTableCard from '@/components/pos/PosTableCard.vue'
@@ -99,15 +99,33 @@ const selectedOrderForVoid = ref<PosOrder | null>(null)
 
 const totalTerminals = computed(() => terminals.value.length)
 const activeTerminals = computed(() => terminals.value.filter((terminal) => Boolean(Number(terminal.is_active))).length)
-const totalOpenOrders = computed(() =>
-    terminals.value.reduce((total, terminal) => total + Number(terminal.open_orders_count || 0), 0)
-)
 
 const selectedTerminal = computed(() =>
     terminals.value.find((terminal) => String(terminal.id) === String(selectedTerminalId.value)) ?? null
 )
 
 const occupiedTables = computed(() => terminalTables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
+
+const openTablesCount = computed(() => occupiedTables.value)
+
+const guestsDiningCount = computed(() =>
+    terminalTables.value.reduce((sum, table) => {
+        if (!Number(table.is_occupied)) return sum
+        const t = table as PosTable & { guest_count?: number | string }
+        const guests = Number(t.guest_count ?? table.open_orders_count ?? 0)
+        return sum + (Number.isFinite(guests) ? guests : 0)
+    }, 0),
+)
+
+const syncPosTables = async () => {
+    if (!selectedTerminalId.value) return
+    await loadTablesForTerminal(String(selectedTerminalId.value))
+}
+
+const startNewOrderForTable = (table: PosTable) => {
+    selectedTable.value = table
+    addOrderForTable()
+}
 
 const currentSessionStatus = computed(() => {
     if (!props.currentSession) {
@@ -138,25 +156,6 @@ const formatMoney = (value: number | string): string => {
         currency: 'PHP',
         minimumFractionDigits: 2,
     }).format(Number.isFinite(numeric) ? numeric : 0)
-}
-
-const formatDateTime = (value: string | null | undefined): string => {
-    if (!value) {
-        return '—'
-    }
-
-    const date = new Date(value)
-    if (Number.isNaN(date.getTime())) {
-        return value
-    }
-
-    return date.toLocaleString('en-PH', {
-        year: 'numeric',
-        month: 'short',
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit',
-    })
 }
 
 /**
@@ -411,7 +410,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                     <div class="max-w-3xl space-y-3">
                         <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
-                            Live table view
+                            Live Table View
                         </span>
                         <h2 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
                             POS
@@ -428,72 +427,62 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                 </div>
             </section>
 
-            <section class="grid gap-4 sm:grid-cols-4">
-                <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
-                    <p class="text-xs uppercase tracking-wide text-muted-foreground">Terminals</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ totalTerminals }}</p>
+            <!-- Summary chips + session -->
+            <section class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div class="flex flex-wrap items-center gap-2">
+                    <span class="inline-flex items-center rounded-full border border-woosoo-green/30 bg-woosoo-green/10 px-3 py-1.5 text-xs font-semibold text-woosoo-green">
+                        Open Tables ({{ openTablesCount }})
+                    </span>
+                    <span class="inline-flex items-center rounded-full border border-woosoo-accent/30 bg-woosoo-accent/10 px-3 py-1.5 text-xs font-semibold text-foreground">
+                        Guests Dining ({{ guestsDiningCount }})
+                    </span>
                 </div>
-                <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
-                    <p class="text-xs uppercase tracking-wide text-muted-foreground">Active Terminals</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ activeTerminals }}</p>
-                </div>
-                <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
-                    <p class="text-xs uppercase tracking-wide text-muted-foreground">Open Orders</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ totalOpenOrders }}</p>
-                </div>
-                <div class="rounded-[18px] border border-black/8 bg-white/72 px-5 py-4 shadow-sm dark:border-white/10 dark:bg-white/[0.06]">
-                    <p class="text-xs uppercase tracking-wide text-muted-foreground">Current Session</p>
-                    <p class="mt-1 text-lg font-semibold">#{{ props.currentSession?.id || '—' }} • {{ currentSessionStatus }}</p>
-                    <p class="text-xs text-muted-foreground">Opened: {{ formatDateTime(props.currentSession?.date_time_opened) }}</p>
+                <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-xs text-muted-foreground">
+                        Session #{{ props.currentSession?.id || '—' }} · {{ currentSessionStatus }}
+                    </span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        :disabled="!selectedTerminalId || tablesLoading"
+                        @click="syncPosTables"
+                    >
+                        <RefreshCw class="mr-1.5 h-3.5 w-3.5" :class="{ 'animate-spin': tablesLoading }" />
+                        Sync POS
+                    </Button>
                 </div>
             </section>
 
-            <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 p-4 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 sm:p-5 lg:p-6">
-                <div class="mb-4 flex items-center justify-between">
-                    <h3 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">POS &gt; Terminal</h3>
-                    <p class="text-xs text-muted-foreground">Pick a terminal, then click a table to manage orders.</p>
+            <!-- Terminal pill tabs -->
+            <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 p-4 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 sm:p-5">
+                <div class="mb-3 flex items-center justify-between gap-3">
+                    <h3 class="text-[10px] font-semibold tracking-[0.2em] text-muted-foreground uppercase">Terminals</h3>
+                    <p class="text-xs text-muted-foreground">{{ totalTerminals }} registered · {{ activeTerminals }} active</p>
                 </div>
-                <div class="p-4 sm:p-5 lg:p-6">
-                    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                        <button
-                            v-for="terminal in terminals"
-                            :key="terminal.id"
-                            type="button"
-                            class="group rounded-[22px] border border-black/8 bg-gradient-to-b from-slate-900/95 to-slate-950 p-4 text-left shadow-lg transition-all hover:-translate-y-0.5 hover:border-woosoo-accent/70 hover:shadow-woosoo-accent/20 disabled:cursor-not-allowed disabled:opacity-60 dark:border-white/10"
-                            :class="String(selectedTerminalId) === String(terminal.id) ? 'ring-2 ring-woosoo-accent/70' : ''"
-                            :disabled="tablesLoading && loadingTerminalId === String(terminal.id)"
-                            @click="loadTablesForTerminal(String(terminal.id))"
+                <div class="flex flex-wrap gap-2">
+                    <button
+                        v-for="terminal in terminals"
+                        :key="terminal.id"
+                        type="button"
+                        class="inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition-all"
+                        :class="String(selectedTerminalId) === String(terminal.id)
+                            ? 'border-woosoo-accent bg-woosoo-accent/15 text-foreground shadow-sm'
+                            : 'border-black/10 bg-white/60 text-muted-foreground hover:border-woosoo-accent/40 dark:border-white/10 dark:bg-white/[0.04]'"
+                        :disabled="tablesLoading && loadingTerminalId === String(terminal.id)"
+                        @click="loadTablesForTerminal(String(terminal.id))"
+                    >
+                        <Circle
+                            :size="8"
+                            :class="Number(terminal.is_active) ? 'fill-woosoo-green text-woosoo-green' : 'fill-muted-foreground text-muted-foreground'"
+                        />
+                        {{ terminal.name }}
+                        <span
+                            v-if="tablesLoading && loadingTerminalId === String(terminal.id)"
+                            class="text-[10px] text-muted-foreground"
                         >
-                            <div class="mb-3 flex items-center justify-between">
-                                <span class="inline-flex items-center gap-1 rounded-full border border-white/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/80">
-                                    <Circle :size="8" :class="Number(terminal.is_active) ? 'fill-woosoo-green text-woosoo-green' : 'fill-destructive text-destructive'" />
-                                    {{ Number(terminal.is_active) ? 'Active' : 'Inactive' }}
-                                </span>
-                                <span class="text-[10px] font-semibold uppercase tracking-wider text-white/60">ID {{ terminal.id }}</span>
-                            </div>
-
-                            <div class="mx-auto mb-4 flex h-44 w-full max-w-[220px] items-center justify-center rounded-[1.7rem] border-[10px] border-slate-700 bg-slate-800 shadow-inner">
-                                <div class="flex h-full w-full flex-col items-center justify-center rounded-[1.2rem] bg-slate-900 text-center text-white/90">
-                                    <template v-if="tablesLoading && loadingTerminalId === String(terminal.id)">
-                                        <RefreshCw class="mb-2 h-10 w-10 animate-spin text-woosoo-accent" />
-                                        <p class="px-2 text-[11px] text-white/50">Loading tables…</p>
-                                    </template>
-                                    <template v-else>
-                                        <MonitorSmartphone class="mb-2 h-10 w-10 text-woosoo-accent" />
-                                        <p class="px-2 text-sm font-semibold leading-tight">{{ terminal.name }}</p>
-                                        <p class="mt-1 text-[11px] text-white/50">{{ terminal.type }}</p>
-                                    </template>
-                                </div>
-                            </div>
-
-                            <div class="space-y-1 text-xs text-white/70">
-                                <p><span class="text-white/45">IP:</span> {{ terminal.ip_address || '—' }}</p>
-                                <p><span class="text-white/45">Port:</span> {{ terminal.port ?? '—' }}</p>
-                                <p><span class="text-white/45">Session:</span> #{{ terminal.session_id || '—' }} • {{ terminal.session_closed_at ? 'Closed' : 'Open' }}</p>
-                                <p><span class="text-white/45">Open Orders:</span> <span class="font-semibold text-woosoo-accent">{{ Number(terminal.open_orders_count) }}</span></p>
-                            </div>
-                        </button>
-                    </div>
+                            …
+                        </span>
+                    </button>
                 </div>
             </section>
 
@@ -537,7 +526,8 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
                             :key="table.id"
                             :table="table"
                             :selected="selectedTable?.id === table.id"
-                            @select="openTableOrders(table)"
+                            @select="openTableOrders"
+                            @new-order="startNewOrderForTable"
                         />
                     </div>
                 </div>

--- a/resources/js/pages/POS/Index.vue
+++ b/resources/js/pages/POS/Index.vue
@@ -104,9 +104,9 @@ const selectedTerminal = computed(() =>
     terminals.value.find((terminal) => String(terminal.id) === String(selectedTerminalId.value)) ?? null
 )
 
-const occupiedTables = computed(() => terminalTables.value.filter((table) => Boolean(Number(table.is_occupied))).length)
-
-const openTablesCount = computed(() => occupiedTables.value)
+const occupiedTables = computed(() =>
+    terminalTables.value.filter((table) => Boolean(Number(table.is_occupied))).length,
+)
 
 const guestsDiningCount = computed(() =>
     terminalTables.value.reduce((sum, table) => {
@@ -281,7 +281,7 @@ const addOrderForTable = () => {
     })
 }
 
-const editOrder = async (order: PosOrder) => {
+const editOrder = (order: PosOrder) => {
     selectedOrderForEdit.value = order
     editDialogOpen.value = true
 }
@@ -353,7 +353,7 @@ const handleVoidConfirm = async () => {
     }
 }
 
-const payOrder = async (order: PosOrder) => {
+const payOrder = (order: PosOrder) => {
     selectedOrderForPay.value = order
     paymentDialogOpen.value = true
 }
@@ -431,7 +431,7 @@ const handlePay = async (amount: number, paymentTypeId: number, tip?: number) =>
             <section class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div class="flex flex-wrap items-center gap-2">
                     <span class="inline-flex items-center rounded-full border border-woosoo-green/30 bg-woosoo-green/10 px-3 py-1.5 text-xs font-semibold text-woosoo-green">
-                        Open Tables ({{ openTablesCount }})
+                        Open Tables ({{ occupiedTables }})
                     </span>
                     <span class="inline-flex items-center rounded-full border border-woosoo-accent/30 bg-woosoo-accent/10 px-3 py-1.5 text-xs font-semibold text-foreground">
                         Guests Dining ({{ guestsDiningCount }})

--- a/resources/js/pages/Packages/Index.vue
+++ b/resources/js/pages/Packages/Index.vue
@@ -92,8 +92,12 @@ function modifierLabelList(modifiers: PackageModifierVm[]): string[] {
         .map((m) => byId.get(m.krypton_menu_id) ?? `#${m.krypton_menu_id}`)
 }
 
-const packageMenuOptions = computed(() => {
-    return props.menuOptions ?? []
+const modifierLabelsByPackageId = computed(() => {
+    const labels = new Map<number, string[]>()
+    for (const item of orderedPackages.value) {
+        labels.set(item.id, modifierLabelList(item.modifiers ?? []))
+    }
+    return labels
 })
 
 const filteredModifierOptions = computed(() => {
@@ -285,7 +289,7 @@ function executeDelete() {
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectLabel>Available Menus</SelectLabel>
-                                    <SelectItem v-for="menu in packageMenuOptions" :key="menu.id" :value="menu.id">
+                                    <SelectItem v-for="menu in (menuOptions ?? [])" :key="menu.id" :value="menu.id">
                                         {{ menu.name }} (ID: {{ menu.id }})
                                     </SelectItem>
                                 </SelectContent>
@@ -404,13 +408,13 @@ function executeDelete() {
                                 Linked Menu · {{ menuNameForId(item.krypton_menu_id) }}
                             </span>
 
-                            <div v-if="modifierLabelList(item.modifiers ?? []).length > 0">
+                            <div v-if="(modifierLabelsByPackageId.get(item.id) ?? []).length > 0">
                                 <p class="mb-1.5 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
-                                    Meats · {{ modifierLabelList(item.modifiers ?? []).length }} cuts
+                                    Meats · {{ (modifierLabelsByPackageId.get(item.id) ?? []).length }} cuts
                                 </p>
                                 <ul class="space-y-0.5">
                                     <li
-                                        v-for="(name, idx) in modifierLabelList(item.modifiers ?? [])"
+                                        v-for="(name, idx) in (modifierLabelsByPackageId.get(item.id) ?? [])"
                                         :key="`${item.id}-mod-${idx}`"
                                         class="truncate text-sm text-foreground/90"
                                     >

--- a/resources/js/pages/Packages/Index.vue
+++ b/resources/js/pages/Packages/Index.vue
@@ -14,14 +14,6 @@ import { Switch } from '@/components/ui/switch'
 import { Badge } from '@/components/ui/badge'
 import { Select, SelectContent, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@/components/ui/table'
-import {
     AlertDialog,
     AlertDialogAction,
     AlertDialogCancel,
@@ -88,14 +80,16 @@ const orderedPackages = computed(() => {
     return [...(props.packages ?? [])].sort((a, b) => a.sort_order - b.sort_order)
 })
 
-function modifierNames(modifiers: PackageModifierVm[]): string {
+function menuNameForId(menuId: number): string {
+    const menu = (props.menuOptions ?? []).find((m) => m.id === menuId)
+    return menu?.name ?? `#${menuId}`
+}
+
+function modifierLabelList(modifiers: PackageModifierVm[]): string[] {
     const byId = new Map((props.menuOptions ?? []).map((m) => [m.id, m.name]))
-    const names = [...modifiers]
+    return [...modifiers]
         .sort((a, b) => a.sort_order - b.sort_order)
         .map((m) => byId.get(m.krypton_menu_id) ?? `#${m.krypton_menu_id}`)
-    if (names.length === 0) return '—'
-    const joined = names.join(', ')
-    return joined.length > 60 ? joined.slice(0, 57) + '…' : joined
 }
 
 const packageMenuOptions = computed(() => {
@@ -231,15 +225,25 @@ function executeDelete() {
         <Head :title="title" />
 
         <div class="space-y-5">
+            <!-- Two-tab pill nav -->
+            <nav class="inline-flex rounded-full border border-black/8 bg-muted/40 p-1 dark:border-white/10">
+                <a
+                    :href="route('package-configs.index')"
+                    class="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                    Dining Tiers
+                </a>
+                <span class="rounded-full bg-woosoo-accent/15 px-4 py-2 text-sm font-semibold text-foreground shadow-sm">
+                    Krypton Modifiers
+                </span>
+            </nav>
+
             <!-- Create / Edit form section -->
             <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
                 <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-[#f6b56d]/10 via-transparent to-transparent dark:from-[#f6b56d]/6" />
                 <div class="relative space-y-5">
                     <!-- Section header -->
                     <div>
-                        <a :href="route('package-configs.index')" class="mb-2 inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
-                            ← Dining Tiers
-                        </a>
                         <div class="mt-1">
                             <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">
                                 Krypton Modifiers
@@ -370,58 +374,66 @@ function executeDelete() {
                 </div>
             </section>
 
-            <!-- Package list section -->
+            <!-- Package card grid -->
             <section class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
                 <div class="flex items-center gap-2 border-b border-black/8 px-5 py-4 dark:border-white/10">
                     <Package class="h-4 w-4 text-muted-foreground" />
                     <div>
-                        <p class="text-sm font-semibold text-foreground">Configured Packages</p>
+                        <p class="text-sm font-semibold text-foreground">Krypton Modifier Packages</p>
                         <p class="text-xs text-muted-foreground">{{ orderedPackages.length }} package{{ orderedPackages.length === 1 ? '' : 's' }} configured.</p>
                     </div>
                 </div>
-                <div class="overflow-x-auto">
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Name</TableHead>
-                                <TableHead>Menu ID</TableHead>
-                                <TableHead>Modifiers</TableHead>
-                                <TableHead>Order</TableHead>
-                                <TableHead>Status</TableHead>
-                                <TableHead class="text-right">Actions</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            <TableRow v-for="item in orderedPackages" :key="item.id">
-                                <TableCell class="font-medium">{{ item.name }}</TableCell>
-                                <TableCell class="font-mono text-sm">{{ item.krypton_menu_id }}</TableCell>
-                                <TableCell class="text-sm text-muted-foreground">{{ modifierNames(item.modifiers ?? []) }}</TableCell>
-                                <TableCell>{{ item.sort_order }}</TableCell>
-                                <TableCell>
-                                    <Badge :variant="item.is_active ? 'default' : 'secondary'">
-                                        {{ item.is_active ? 'Active' : 'Inactive' }}
-                                    </Badge>
-                                </TableCell>
-                                <TableCell class="text-right">
-                                    <div class="flex justify-end gap-2">
-                                        <Button size="sm" variant="outline" @click="editPackage(item)">
-                                            <Pencil class="mr-1 h-3 w-3" />
-                                            Edit
-                                        </Button>
-                                        <Button size="sm" variant="destructive" @click="confirmDelete(item)">
-                                            <Trash2 class="mr-1 h-3 w-3" />
-                                            Delete
-                                        </Button>
-                                    </div>
-                                </TableCell>
-                            </TableRow>
-                            <TableRow v-if="orderedPackages.length === 0">
-                                <TableCell colspan="6" class="py-12 text-center text-sm text-muted-foreground">
-                                    No packages configured yet. Use the form above to add the first one.
-                                </TableCell>
-                            </TableRow>
-                        </TableBody>
-                    </Table>
+                <div class="p-4 sm:p-6">
+                    <div v-if="orderedPackages.length === 0" class="py-16 text-center text-sm text-muted-foreground">
+                        No packages configured yet. Use the form above to add the first one.
+                    </div>
+                    <div v-else class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        <div
+                            v-for="item in orderedPackages"
+                            :key="item.id"
+                            class="flex flex-col gap-3 rounded-[18px] border border-black/8 bg-white/60 p-5 dark:border-white/10 dark:bg-white/[0.04]"
+                        >
+                            <div class="flex items-start justify-between gap-2">
+                                <h3 class="text-lg font-bold text-foreground">{{ item.name }}</h3>
+                                <Badge :variant="item.is_active ? 'default' : 'secondary'" class="shrink-0 text-[10px]">
+                                    {{ item.is_active ? 'Active' : 'Inactive' }}
+                                </Badge>
+                            </div>
+
+                            <span class="inline-flex w-fit rounded-full border border-woosoo-accent/30 bg-woosoo-accent/10 px-2.5 py-1 text-[10px] font-semibold text-foreground">
+                                Linked Menu · {{ menuNameForId(item.krypton_menu_id) }}
+                            </span>
+
+                            <div v-if="modifierLabelList(item.modifiers ?? []).length > 0">
+                                <p class="mb-1.5 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+                                    Meats · {{ modifierLabelList(item.modifiers ?? []).length }} cuts
+                                </p>
+                                <ul class="space-y-0.5">
+                                    <li
+                                        v-for="(name, idx) in modifierLabelList(item.modifiers ?? [])"
+                                        :key="`${item.id}-mod-${idx}`"
+                                        class="truncate text-sm text-foreground/90"
+                                    >
+                                        {{ name }}
+                                    </li>
+                                </ul>
+                            </div>
+                            <p v-else class="text-xs text-muted-foreground">No modifiers linked</p>
+
+                            <div class="mt-auto flex items-center justify-between border-t border-black/5 pt-3 dark:border-white/8">
+                                <div class="flex gap-1">
+                                    <Button size="sm" variant="outline" @click="editPackage(item)">
+                                        <Pencil class="mr-1 h-3 w-3" />
+                                        Edit
+                                    </Button>
+                                    <Button size="sm" variant="ghost" class="text-destructive hover:text-destructive" @click="confirmDelete(item)">
+                                        <Trash2 class="h-3 w-3" />
+                                    </Button>
+                                </div>
+                                <span class="font-mono text-xs text-muted-foreground">Order #{{ item.sort_order }}</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </section>
         </div>

--- a/resources/js/pages/package-configs/IndexPackageConfigs.vue
+++ b/resources/js/pages/package-configs/IndexPackageConfigs.vue
@@ -59,6 +59,10 @@ function menusByType(pkg: PackageConfigVm, type: string) {
     return pkg.menus.filter((m) => (m.menu_type ?? 'meat') === type && m.is_active)
 }
 
+function addOnMenus(pkg: PackageConfigVm) {
+    return [...menusByType(pkg, 'side'), ...menusByType(pkg, 'dessert')]
+}
+
 function formatPrice(value: string): string {
     const n = parseFloat(String(value))
     if (!Number.isFinite(n)) return value
@@ -219,11 +223,11 @@ function confirmDelete() {
                             </div>
 
                             <!-- Add-ons/sides section -->
-                            <div v-if="menusByType(pkg, 'side').length > 0 || menusByType(pkg, 'dessert').length > 0">
+                            <div v-if="addOnMenus(pkg).length > 0">
                                 <p class="mb-2 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Add-ons Included</p>
                                 <ul class="space-y-1">
                                     <li
-                                        v-for="m in [...menusByType(pkg, 'side'), ...menusByType(pkg, 'dessert')]"
+                                        v-for="m in addOnMenus(pkg)"
                                         :key="m.id"
                                         class="flex items-center gap-2 text-sm text-foreground"
                                     >
@@ -320,10 +324,10 @@ function confirmDelete() {
                                 </li>
                             </ul>
                         </div>
-                        <div v-if="menusByType(manageMenusPkg, 'side').length > 0 || menusByType(manageMenusPkg, 'dessert').length > 0">
+                        <div v-if="addOnMenus(manageMenusPkg).length > 0">
                             <p class="mb-1 text-[10px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">Add-ons</p>
                             <ul class="space-y-1">
-                                <li v-for="m in [...menusByType(manageMenusPkg, 'side'), ...menusByType(manageMenusPkg, 'dessert')]" :key="m.id" class="flex items-center gap-2 text-sm">
+                                <li v-for="m in addOnMenus(manageMenusPkg)" :key="m.id" class="flex items-center gap-2 text-sm">
                                     <Check class="h-3 w-3 shrink-0 text-woosoo-green" />
                                     {{ m.name }}
                                     <Badge variant="secondary" class="ml-auto text-[9px]">{{ m.menu_type }}</Badge>

--- a/resources/js/pages/package-configs/IndexPackageConfigs.vue
+++ b/resources/js/pages/package-configs/IndexPackageConfigs.vue
@@ -134,6 +134,19 @@ function confirmDelete() {
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="space-y-5">
+            <!-- Two-tab pill nav -->
+            <nav class="inline-flex rounded-full border border-black/8 bg-muted/40 p-1 dark:border-white/10">
+                <span class="rounded-full bg-woosoo-accent/15 px-4 py-2 text-sm font-semibold text-foreground shadow-sm">
+                    Dining Tiers
+                </span>
+                <a
+                    :href="route('packages.index')"
+                    class="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                >
+                    Krypton Modifiers
+                </a>
+            </nav>
+
             <!-- Hero header -->
             <section class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
                 <div class="pointer-events-none absolute inset-0 bg-gradient-to-r from-woosoo-accent/10 via-transparent to-transparent dark:from-woosoo-accent/6" />
@@ -151,9 +164,6 @@ function confirmDelete() {
                         </p>
                     </div>
                     <div class="flex gap-2">
-                        <Button variant="outline" size="sm" as-child>
-                            <a :href="route('packages.index')">Krypton Modifiers</a>
-                        </Button>
                         <Button size="sm" @click="showCreate = true">
                             <Plus class="mr-1.5 h-3.5 w-3.5" />
                             New Package
@@ -174,7 +184,7 @@ function confirmDelete() {
                         <div
                             v-for="(pkg, index) in orderedPackages"
                             :key="pkg.id"
-                            class="relative flex flex-col gap-4 rounded-[18px] border border-black/8 bg-white/60 p-5 transition-all duration-150 dark:border-white/10 dark:bg-white/[0.04]"
+                            class="relative flex flex-col gap-4 rounded-[18px] border border-black/8 bg-white/72 p-5 shadow-sm transition-all duration-150 hover:border-woosoo-accent/25 dark:border-white/10 dark:bg-white/[0.05]"
                         >
                             <!-- Tier label + name -->
                             <div>

--- a/resources/js/pages/tablet-categories/IndexTabletCategories.vue
+++ b/resources/js/pages/tablet-categories/IndexTabletCategories.vue
@@ -56,6 +56,10 @@ const selectedCategory = computed(() =>
     props.categories.find((c) => c.id === selectedId.value) ?? null,
 )
 
+const sortedCategories = computed(() =>
+    [...props.categories].sort((a, b) => a.sort_order - b.sort_order),
+)
+
 // ─── Category Drag Reorder ─────────────────────────────────────────────────
 const dragOverId = ref<number | null>(null)
 const isReordering = ref(false)
@@ -73,7 +77,7 @@ function onDragOver(e: DragEvent, id: number) {
 
 function onDrop(targetId: number) {
     if (!draggingId || draggingId === targetId) return
-    const ordered = [...props.categories].sort((a, b) => a.sort_order - b.sort_order)
+    const ordered = [...sortedCategories.value]
     const fromIdx = ordered.findIndex((c) => c.id === draggingId)
     const toIdx   = ordered.findIndex((c) => c.id === targetId)
     if (fromIdx === -1 || toIdx === -1) return
@@ -263,7 +267,7 @@ function submitAttach() {
                         </div>
                         <div class="flex-1 overflow-y-auto py-1">
                             <div
-                                v-for="(cat, index) in [...categories].sort((a, b) => a.sort_order - b.sort_order)"
+                                v-for="(cat, index) in sortedCategories"
                                 :key="cat.id"
                                 class="flex cursor-pointer items-center gap-2 px-3 py-2.5 transition-colors"
                                 :class="{

--- a/resources/js/pages/tablet-categories/IndexTabletCategories.vue
+++ b/resources/js/pages/tablet-categories/IndexTabletCategories.vue
@@ -278,8 +278,10 @@ function submitAttach() {
                                 @dragover="onDragOver($event, cat.id)"
                                 @drop="onDrop(cat.id)"
                             >
-                                <GripVertical class="h-3.5 w-3.5 shrink-0 cursor-grab text-muted-foreground/40" />
-                                <span class="w-4 shrink-0 font-mono text-[10px] text-muted-foreground">#{{ index + 1 }}</span>
+                                <GripVertical class="h-4 w-4 shrink-0 cursor-grab rounded p-0.5 text-muted-foreground/50 hover:bg-black/5 dark:hover:bg-white/5" />
+                                <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-black/5 font-mono text-[10px] font-semibold text-muted-foreground dark:bg-white/8">
+                                    {{ index + 1 }}
+                                </span>
                                 <span class="min-w-0 flex-1 truncate text-sm font-medium">{{ cat.name }}</span>
                                 <span class="font-mono text-[10px] text-muted-foreground">{{ cat.menu_count }}</span>
                                 <button


### PR DESCRIPTION
## Summary

Presentational redesign of six admin pages aligned with nex-025 brand tokens. No controller, prop, migration, or test changes — all CRUD flows, Echo listeners, and drawers preserved.

**Commits (one per page + simplifier pass):**
1. Orders — Kitchen Dispatch kanban
2. POS — Live Table View
3. Packages — Krypton Modifier card grid
4. Dining Tiers — visual polish
5. Menu Sync — visual polish
6. Devices — Tablet Management cards
7. code-simplifier hygiene pass

## Screenshots

> Attach one screenshot per page after visual review at `/orders`, `/pos`, `/packages`, `/package-configs`, `/tablet-categories`, `/devices`.

| Page | Route | Screenshot |
|------|-------|------------|
| Kitchen Dispatch | `/orders` | _pending_ |
| Live Table View | `/pos` | _pending_ |
| Krypton Modifiers | `/packages` | _pending_ |
| Dining Tiers | `/package-configs` | _pending_ |
| Menu Sync | `/tablet-categories` | _pending_ |
| Tablet Management | `/devices` | _pending_ |

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `php artisan test --compact` (511 passed on page 1 gate)
- [ ] Manual smoke: open each page above; confirm drawers/dialogs still work
- [ ] Verifier: `scripts/pre-merge-check.ps1 -App woosoo-nexus`

## Contract impact

None — UI-only.
