### PR TITLE
feat(admin): complete handoff UI alignment — remaining 15 pages + 2 components

### DIFF
--- a/resources/js/pages/Monitoring/Index.vue
+++ b/resources/js/pages/Monitoring/Index.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { Head } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { Button } from '@/components/ui/button';
+import { RefreshCw } from 'lucide-vue-next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { type BreadcrumbItem } from '@/types';
@@ -304,20 +305,11 @@ const breadcrumbs: BreadcrumbItem[] = [
                     <div class="flex flex-wrap items-center gap-3">
                         <Button variant="outline" size="sm" @click="toggleAutoRefresh"
                             :class="{ 'bg-woosoo-accent/10 text-woosoo-primary-dark': autoRefresh }">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2"
-                                :class="{ 'animate-spin': autoRefresh }" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
+                            <RefreshCw class="h-4 w-4 mr-2" :class="{ 'animate-spin': autoRefresh }" />
                             {{ autoRefresh ? 'Auto-refresh ON' : 'Auto-refresh OFF' }}
                         </Button>
                         <Button size="sm" @click="refreshMetrics" :disabled="loading">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2"
-                                :class="{ 'animate-spin': loading }" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
+                            <RefreshCw class="h-4 w-4 mr-2" :class="{ 'animate-spin': loading }" />
                             Refresh Now
                         </Button>
                     </div>
@@ -325,7 +317,7 @@ const breadcrumbs: BreadcrumbItem[] = [
             </div>
 
             <!-- Alert Banner -->
-            <div v-if="hasAlerts" class="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+            <div v-if="hasAlerts" class="bg-destructive/10 border border-destructive/20 rounded-[20px] p-4">
                 <div class="flex items-center gap-2">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-destructive" viewBox="0 0 20 20"
                         fill="currentColor">
@@ -506,7 +498,7 @@ const breadcrumbs: BreadcrumbItem[] = [
                         </div>
                     </div>
 
-                    <div v-if="metrics.printLatency.stuck > 0" class="mb-4 p-3 rounded bg-destructive/10 border border-destructive/20 text-sm">
+                    <div v-if="metrics.printLatency.stuck > 0" class="mb-4 p-3 rounded-[20px] bg-destructive/10 border border-destructive/20 text-sm">
                         <strong class="text-destructive">{{ metrics.printLatency.stuck }} stuck event(s)</strong>
                         — broadcast went out but never acknowledged (&gt;2 min).
                     </div>

--- a/resources/js/pages/ServiceRequests/Index.vue
+++ b/resources/js/pages/ServiceRequests/Index.vue
@@ -173,7 +173,18 @@ const openRequestDetail = (request: any) => {
 <template>
     <Head :title="props.title" :description="props.description" />
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="space-y-6 px-1 sm:px-2">
+        <div class="space-y-5">
+            <!-- Hero -->
+            <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-5 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                    <div class="space-y-1.5">
+                        <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Operations</span>
+                        <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">Service Requests</h1>
+                        <p class="max-w-xl text-sm leading-6 text-muted-foreground">Guest-initiated assistance requests from tablet devices. Pending items require attention from floor staff.</p>
+                    </div>
+                </div>
+            </div>
+
             <DataTableToolbar
                 v-model:search="search"
                 v-model:status="statusFilter"

--- a/resources/js/pages/branches/IndexBranches.vue
+++ b/resources/js/pages/branches/IndexBranches.vue
@@ -4,6 +4,8 @@ import { ref } from 'vue'
 import { Head } from '@inertiajs/vue3'
 import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-vue-next'
 import DataTable from '@/components/Branches/DataTable.vue'
 import BranchForm from '@/components/Branches/BranchForm.vue'
 
@@ -48,12 +50,32 @@ const handleEdit = (branch: Branch) => {
   <AppLayout :breadcrumbs="breadcrumbs">
     <Head title="Branches" />
 
-    <div class="p-6 space-y-6">
-      <DataTable 
-        :data="branches" 
-        @add="handleAdd"
-        @edit="handleEdit"
-      />
+    <div class="space-y-5">
+      <!-- Hero -->
+      <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-5 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div class="space-y-1.5">
+            <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Configuration</span>
+            <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">Branches</h1>
+            <p class="max-w-xl text-sm leading-6 text-muted-foreground">Manage branch locations, their device allocations, and associated users.</p>
+          </div>
+          <Button @click="handleAdd">
+            <Plus class="mr-2 h-4 w-4" />
+            Add Branch
+          </Button>
+        </div>
+      </div>
+
+      <!-- DataTable -->
+      <div class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
+        <div class="p-4 sm:p-6">
+          <DataTable
+            :data="branches"
+            @add="handleAdd"
+            @edit="handleEdit"
+          />
+        </div>
+      </div>
 
       <BranchForm
         v-model:open="showForm"

--- a/resources/js/pages/reports/DiscountTax.vue
+++ b/resources/js/pages/reports/DiscountTax.vue
@@ -61,13 +61,24 @@ const currencyFormatter = (value: unknown) => {
 
     <Head :title="props.title" />
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="p-6 space-y-6">
-            <!-- Header -->
-            <div class="flex items-center justify-between">
-                <div>
-                    <h1 class="text-3xl font-bold">{{ props.title }}</h1>
-                    <p class="text-sm text-muted-foreground mt-1">Track discount usage and tax collection</p>
+        <div class="space-y-5">
+            <!-- Hero -->
+            <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="relative space-y-3">
+                    <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Analytics · Discount & Tax</span>
+                    <div>
+                        <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">{{ props.title }}</h1>
+                        <p class="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">Track discount usage and tax collection across all orders.</p>
+                    </div>
                 </div>
+            </div>
+
+            <!-- Date range -->
+            <div class="flex flex-wrap items-center gap-3">
+                <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Date range:</span>
+                <span class="text-sm font-medium">{{ props.startDate ?? '—' }}</span>
+                <span class="text-muted-foreground">→</span>
+                <span class="text-sm font-medium">{{ props.endDate ?? 'today' }}</span>
             </div>
 
             <!-- Summary Cards -->
@@ -138,18 +149,18 @@ const currencyFormatter = (value: unknown) => {
                     <div class="overflow-x-auto">
                         <table class="w-full text-sm">
                             <thead>
-                                <tr class="border-b">
-                                    <th class="text-left py-3 px-4 font-semibold">Date</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Orders</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Sales</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Discount</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Discount %</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Tax</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Tax %</th>
+                                <tr class="border-b border-black/8 dark:border-white/10">
+                                    <th class="px-4 py-3 text-left text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Date</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Orders</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Sales</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Discount</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Discount %</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Tax</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Tax %</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr v-for="row in props.data" :key="row.date" class="border-b hover:bg-muted/50">
+                                <tr v-for="row in props.data" :key="row.date" class="border-b border-black/6 transition-colors hover:bg-black/[0.025] dark:border-white/8 dark:hover:bg-white/[0.03]">
                                     <td class="py-3 px-4 font-medium">{{ row.date }}</td>
                                     <td class="text-right py-3 px-4">{{ row.order_count }}</td>
                                     <td class="text-right py-3 px-4">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(row.total_sales) }}</td>
@@ -171,31 +182,31 @@ const currencyFormatter = (value: unknown) => {
                 </CardHeader>
                 <CardContent>
                     <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Total Orders</div>
-                            <div class="text-2xl font-bold">{{ totalOrders }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Total Orders</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ totalOrders }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Total Sales</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalSales) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Total Sales</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalSales) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Discount Expense</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalDiscount) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Discount Expense</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalDiscount) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Tax Collected</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalTax) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Tax Collected</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalTax) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Avg Discount %</div>
-                            <div class="text-2xl font-bold">{{ (props.data.length > 0
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Avg Discount %</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ (props.data.length > 0
                                 ? (props.data.reduce((sum, r) => sum + r.discount_percentage, 0) / props.data.length)
                                 : 0).toFixed(2) }}%</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Avg Tax %</div>
-                            <div class="text-2xl font-bold">{{ (props.data.length > 0
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Avg Tax %</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ (props.data.length > 0
                                 ? (props.data.reduce((sum, r) => sum + r.tax_percentage, 0) / props.data.length)
                                 : 0).toFixed(2) }}%</div>
                         </div>

--- a/resources/js/pages/reports/PrintAudit.vue
+++ b/resources/js/pages/reports/PrintAudit.vue
@@ -34,6 +34,15 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const totalPrints = props.data.length
 const totalPrintedValue = props.data.reduce((sum, row) => sum + row.total, 0)
+
+const getStatusColor = (status: string): 'success' | 'warning' | 'destructive' | 'secondary' | 'outline' => {
+    const s = status.toUpperCase()
+    if (s === 'COMPLETED') return 'success'
+    if (s === 'CONFIRMED' || s === 'SERVED' || s === 'READY') return 'secondary'
+    if (s === 'VOIDED' || s === 'CANCELLED') return 'destructive'
+    if (s === 'PENDING' || s === 'IN_PROGRESS') return 'warning'
+    return 'outline'
+}
 </script>
 
 <template>
@@ -122,11 +131,7 @@ const totalPrintedValue = props.data.reduce((sum, row) => sum + row.total, 0)
                                     <td class="py-3 px-4">{{ row.printed_by || '-' }}</td>
                                     <td class="py-3 px-4 text-xs">{{ new Date(row.printed_at).toLocaleString() }}</td>
                                     <td class="text-center py-3 px-4">
-                                        <Badge v-if="row.status === 'COMPLETED'" variant="default">{{ row.status }}
-                                        </Badge>
-                                        <Badge v-else-if="row.status === 'CONFIRMED'" variant="secondary">{{ row.status
-                                            }}</Badge>
-                                        <Badge v-else variant="outline">{{ row.status }}</Badge>
+                                        <Badge :variant="getStatusColor(row.status)">{{ row.status }}</Badge>
                                     </td>
                                     <td class="text-right py-3 px-4">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(row.total) }}</td>
                                     <td class="text-center py-3 px-4 text-xs">{{ row.device_id }}</td>


### PR DESCRIPTION
## Summary

- **DiscountTax.vue**: full brand alignment — hero card, `space-y-5` wrapper, brand table header/row classes, date range row, period summary items wrapped in mini stat cards (`rounded-[18px] border border-black/8`)
- **PrintAudit.vue**: replaces brittle `v-if/v-else-if/v-else` badge chains with a `getStatusColor` function matching the `success|warning|destructive|secondary|outline` variant set from Step 3
- **ServiceRequests/Index.vue**: removes stale `px-1 sm:px-2` from wrapper → `space-y-5`, adds Operations hero card before the toolbar
- **branches/IndexBranches.vue**: replaces `p-6 space-y-6` wrapper → `space-y-5`, adds Configuration hero card with Add Branch button CTA, wraps DataTable in table card pattern, imports `Plus` from lucide-vue-next
- **Monitoring/Index.vue**: alert banner `rounded-lg` → `rounded-[20px]`, stuck-events inline banner same fix, inline SVG refresh icons replaced with `<RefreshCw>` from lucide-vue-next

All other pages in the handoff scope were already aligned from prior work (nex-027 and step-1 through step-4) and required no changes.

## Test plan

- [x] `npm run build` — clean, no TS or Vite errors
- [x] `php artisan test --compact` — all tests pass, no regressions
- [x] Visual-only changes verified — no props, emits, routes, or backend contracts altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)