### PR TITLE
feat(kds): action endpoints return full board payload for optimistic UI apply

### DIFF
--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Broadcasting\OrderBroadcaster;
 use App\Enums\OrderStatus;
+use App\Helpers\OrderBroadcastPayload;
 use App\Http\Controllers\Controller;
 use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
@@ -134,7 +135,12 @@ class KdsController extends Controller
         $order->loadMissing(['items', 'device', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
-        return response()->json(['status' => $next->value]);
+        // Return the full board payload so the client can apply optimistically and not
+        // wait for the Echo broadcast (broadcast-down resilience + faster perceived UI).
+        return response()->json([
+            'status' => $next->value,
+            'order' => OrderBroadcastPayload::make($order),
+        ]);
     }
 
     public function toggleItem(DeviceOrderItems $item): JsonResponse
@@ -164,7 +170,11 @@ class KdsController extends Controller
 
         app(OrderBroadcaster::class)->itemToggled($item);
 
+        // Echo the broadcast shape so the client can dispatch the same applyItemToggle path
+        // it uses for live events — keeps optimistic and Echo paths idempotent.
         return response()->json([
+            'item_id' => $item->id,
+            'order_id' => $item->order_id,
             'done' => (bool) $item->done,
             'done_at' => $item->done_at?->toIso8601String(),
         ]);
@@ -218,7 +228,11 @@ class KdsController extends Controller
         $order->loadMissing(['items', 'device', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
-        return response()->json(['status' => OrderStatus::IN_PROGRESS->value]);
+        // See advance(): full board payload for optimistic client apply.
+        return response()->json([
+            'status' => OrderStatus::IN_PROGRESS->value,
+            'order' => OrderBroadcastPayload::make($order),
+        ]);
     }
 
     private function toTicket(DeviceOrder $order): array

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -15,7 +15,19 @@ async function parseError(response: Response): Promise<string> {
   return 'Something went wrong. Please try again.'
 }
 
-export async function postKdsAdvance(orderId: string): Promise<{ status: string }> {
+export type KdsActionResponse = {
+  status: string
+  order: Record<string, unknown>
+}
+
+export type KdsToggleResponse = {
+  item_id: string | number
+  order_id: string | number
+  done: boolean
+  done_at: string | null
+}
+
+export async function postKdsAdvance(orderId: string): Promise<KdsActionResponse> {
   const response = await fetch(route('kds.advance', orderId), {
     method: 'POST',
     headers: {
@@ -33,7 +45,7 @@ export async function postKdsAdvance(orderId: string): Promise<{ status: string 
   return response.json()
 }
 
-export async function postKdsRecall(orderId: string): Promise<{ status: string }> {
+export async function postKdsRecall(orderId: string): Promise<KdsActionResponse> {
   const response = await fetch(route('kds.orders.recall', orderId), {
     method: 'POST',
     headers: {
@@ -51,7 +63,7 @@ export async function postKdsRecall(orderId: string): Promise<{ status: string }
   return response.json()
 }
 
-export async function postKdsToggleItem(itemId: string): Promise<{ done: boolean; done_at: string | null }> {
+export async function postKdsToggleItem(itemId: string): Promise<KdsToggleResponse> {
   const response = await fetch(route('kds.toggle-item', itemId), {
     method: 'POST',
     headers: {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -74,7 +74,15 @@ async function toggleItem(ticketId: string, itemId: string) {
   pendingToggle.value.add(itemId)
 
   try {
-    await postKdsToggleItem(itemId)
+    const response = await postKdsToggleItem(itemId)
+    // Optimistic apply — same shape as the Echo `item.toggled` payload, so the live broadcast
+    // landing milliseconds later is idempotent (applies the same state, no flicker).
+    board.applyItemToggle({
+      item_id: response.item_id,
+      order_id: response.order_id,
+      done: response.done,
+      done_at: response.done_at,
+    })
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to update item.')
   } finally {
@@ -103,7 +111,10 @@ async function advanceTicket(ticketId: string) {
   pendingAdvance.value.add(ticketId)
 
   try {
-    await postKdsAdvance(ticketId)
+    const response = await postKdsAdvance(ticketId)
+    // Optimistic apply — full payload matches Echo `order.updated` shape, so the live broadcast
+    // landing milliseconds later applies the same state idempotently (no flicker, no double-render).
+    board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to advance order.')
   } finally {
@@ -125,7 +136,9 @@ async function recallTicket(ticketId: string) {
   pendingRecall.value.add(ticketId)
 
   try {
-    await postKdsRecall(ticketId)
+    const response = await postKdsRecall(ticketId)
+    // Optimistic apply — see advanceTicket() for rationale.
+    board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to recall order.')
   } finally {

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -190,3 +190,45 @@ test('non-admin cannot access recall endpoint', function () {
         ->postJson("/kds/orders/{$order->id}/recall")
         ->assertForbidden();
 });
+
+test('advance response carries the full broadcast payload', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::CONFIRMED]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJsonStructure([
+            'status',
+            'order' => ['id', 'status', 'kds_state', 'kds_type', 'items', 'recalled', 'created_at', 'updated_at'],
+        ]);
+});
+
+test('recall response carries the full broadcast payload', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::SERVED, 'recalled' => 0]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/recall")
+        ->assertOk()
+        ->assertJsonStructure([
+            'status',
+            'order' => ['id', 'status', 'kds_state', 'kds_type', 'items', 'recalled'],
+        ])
+        ->assertJsonPath('order.recalled', 1)
+        ->assertJsonPath('order.kds_state', 'preparing');
+});
+
+test('toggle response carries item_id and order_id for optimistic apply', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertOk()
+        ->assertJsonStructure(['item_id', 'order_id', 'done', 'done_at'])
+        ->assertJsonPath('item_id', $item->id)
+        ->assertJsonPath('order_id', $order->id)
+        ->assertJsonPath('done', true);
+});


### PR DESCRIPTION
## Summary
- KDS `advance` / `recall` / `toggleItem` endpoints now return the **same payload shape they broadcast** over Echo.
- The client (`Display.vue`) applies that payload immediately via `useKdsBoard.applyOrderUpdate` / `applyItemToggle`, then the Echo event arriving ~ms later reconciles idempotently (replace-by-id).
- Result: kitchen sees its action take effect immediately, even if Reverb is briefly slow/down. No flicker, no double-render.

## Test plan
- [x] `php artisan test --compact tests/Feature/Admin/KdsControllerTest.php tests/Unit/OrderStatusRecallTest.php` — 34/34 passed (114 assertions, 8.11s)
- [x] `npm run test:unit` — 24/24 passed
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint:check` — exit 0
- [x] `npm run build` — built in 5.60s, no errors
- [x] `vendor/bin/pint --dirty --format agent` — passed
- [ ] **Manual on staging:** open `/kds` with two browser windows; click Mark Ready in window A — confirm the card transitions in window A *immediately* (not waiting for the Echo round-trip) and window B reconciles via Echo.

## Notes
- Additive change to the response shape; existing `assertJson(['status' => '...'])` and `assertJson(['done' => true])` matchers in tests remain valid.
- No state machine, route, or contract changes.
- Closes a gap from the kds-implementation-plan P4 resilience phase (broadcast-down responsiveness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)