### PR TITLE
promote(staging): KDS optimistic UI apply + admin handoff completion

### DIFF
--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Broadcasting\OrderBroadcaster;
 use App\Enums\OrderStatus;
+use App\Helpers\OrderBroadcastPayload;
 use App\Http\Controllers\Controller;
 use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
@@ -134,7 +135,12 @@ class KdsController extends Controller
         $order->loadMissing(['items', 'device', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
-        return response()->json(['status' => $next->value]);
+        // Return the full board payload so the client can apply optimistically and not
+        // wait for the Echo broadcast (broadcast-down resilience + faster perceived UI).
+        return response()->json([
+            'status' => $next->value,
+            'order' => OrderBroadcastPayload::make($order),
+        ]);
     }
 
     public function toggleItem(DeviceOrderItems $item): JsonResponse
@@ -164,7 +170,11 @@ class KdsController extends Controller
 
         app(OrderBroadcaster::class)->itemToggled($item);
 
+        // Echo the broadcast shape so the client can dispatch the same applyItemToggle path
+        // it uses for live events — keeps optimistic and Echo paths idempotent.
         return response()->json([
+            'item_id' => $item->id,
+            'order_id' => $item->order_id,
             'done' => (bool) $item->done,
             'done_at' => $item->done_at?->toIso8601String(),
         ]);
@@ -218,7 +228,11 @@ class KdsController extends Controller
         $order->loadMissing(['items', 'device', 'serviceRequests']);
         app(OrderBroadcaster::class)->statusChanged($order);
 
-        return response()->json(['status' => OrderStatus::IN_PROGRESS->value]);
+        // See advance(): full board payload for optimistic client apply.
+        return response()->json([
+            'status' => OrderStatus::IN_PROGRESS->value,
+            'order' => OrderBroadcastPayload::make($order),
+        ]);
     }
 
     private function toTicket(DeviceOrder $order): array

--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ArrowRight, Check } from 'lucide-vue-next'
+import { ArrowRight, Check, RotateCcw } from 'lucide-vue-next'
 import { computed } from 'vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { elapsedFor, formatElapsed, isAdvanceBlocked, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
+import { canRecallTicket, elapsedFor, formatElapsed, isAdvanceBlocked, isTerminal, nextStateFor, stateLabel, ticketTypeLabel, urgencyFor } from './kdsHelpers'
 import type { KdsDensity, KdsTicket } from './kdsTypes'
 
 const props = defineProps<{
@@ -15,6 +15,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   advance: [ticketId: string]
+  recall: [ticketId: string]
   toggleItem: [ticketId: string, itemId: string]
 }>()
 
@@ -25,6 +26,7 @@ const elapsed = computed(() => elapsedFor(props.ticket, props.now))
 const urgency = computed(() => urgencyFor(props.ticket, props.now))
 const nextState = computed(() => nextStateFor(props.ticket.state))
 const advanceBlocked = computed(() => isAdvanceBlocked(props.ticket))
+const recallable = computed(() => canRecallTicket(props.ticket))
 const actionLabel = computed(() => {
   if (props.ticket.state === 'new') return 'Start Preparing'
   if (props.ticket.state === 'preparing' || props.ticket.state === 'ready') return 'Mark as Served'
@@ -146,6 +148,17 @@ function splitSafetyName(name: string) {
       >
         {{ actionLabel }}
         <ArrowRight data-icon="inline-end" aria-hidden="true" />
+      </Button>
+
+      <Button
+        v-else-if="recallable"
+        type="button"
+        variant="outline"
+        class="kds-card-action kds-recall-action"
+        @click="emit('recall', ticket.id)"
+      >
+        <RotateCcw data-icon="inline-start" aria-hidden="true" />
+        Recall
       </Button>
     </footer>
   </article>

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -15,7 +15,19 @@ async function parseError(response: Response): Promise<string> {
   return 'Something went wrong. Please try again.'
 }
 
-export async function postKdsAdvance(orderId: string): Promise<{ status: string }> {
+export type KdsActionResponse = {
+  status: string
+  order: Record<string, unknown>
+}
+
+export type KdsToggleResponse = {
+  item_id: string | number
+  order_id: string | number
+  done: boolean
+  done_at: string | null
+}
+
+export async function postKdsAdvance(orderId: string): Promise<KdsActionResponse> {
   const response = await fetch(route('kds.advance', orderId), {
     method: 'POST',
     headers: {
@@ -33,7 +45,7 @@ export async function postKdsAdvance(orderId: string): Promise<{ status: string 
   return response.json()
 }
 
-export async function postKdsRecall(orderId: string): Promise<{ status: string }> {
+export async function postKdsRecall(orderId: string): Promise<KdsActionResponse> {
   const response = await fetch(route('kds.orders.recall', orderId), {
     method: 'POST',
     headers: {
@@ -51,7 +63,7 @@ export async function postKdsRecall(orderId: string): Promise<{ status: string }
   return response.json()
 }
 
-export async function postKdsToggleItem(itemId: string): Promise<{ done: boolean; done_at: string | null }> {
+export async function postKdsToggleItem(itemId: string): Promise<KdsToggleResponse> {
   const response = await fetch(route('kds.toggle-item', itemId), {
     method: 'POST',
     headers: {

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -33,6 +33,24 @@ export async function postKdsAdvance(orderId: string): Promise<{ status: string 
   return response.json()
 }
 
+export async function postKdsRecall(orderId: string): Promise<{ status: string }> {
+  const response = await fetch(route('kds.orders.recall', orderId), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-TOKEN': csrfToken(),
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(await parseError(response))
+  }
+
+  return response.json()
+}
+
 export async function postKdsToggleItem(itemId: string): Promise<{ done: boolean; done_at: string | null }> {
   const response = await fetch(route('kds.toggle-item', itemId), {
     method: 'POST',

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyAdvance, canAdvanceTicket, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
+import { applyAdvance, canAdvanceTicket, canRecallTicket, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
 import type { KdsTicket, KdsTicketState } from './kdsTypes'
 
 function preparingTicket(itemsDone: boolean[]): KdsTicket {
@@ -75,6 +75,16 @@ describe('Mark as Served gating', () => {
     const ticket = preparingTicket([true, false])
 
     expect(applyAdvance(ticket, now).state).toBe('preparing')
+  })
+})
+
+describe('Recall gating', () => {
+  it('allows recall on served tickets only', () => {
+    expect(canRecallTicket(makeTicket('served'))).toBe(true)
+  })
+
+  it.each<KdsTicketState>(['new', 'preparing', 'ready', 'voided'])('rejects recall from %s', (state) => {
+    expect(canRecallTicket(makeTicket(state))).toBe(false)
   })
 })
 

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -131,6 +131,11 @@ export function canAdvanceTicket(ticket: KdsTicket): boolean {
   return nextStateFor(ticket.state) !== null
 }
 
+/** Recall is the served→in_progress edge only; voided orders need a new ticket (see order-state.contract.md). */
+export function canRecallTicket(ticket: KdsTicket): boolean {
+  return ticket.state === 'served'
+}
+
 /** Primary action `:disabled` — Mark as Served gated until every checklist item is done. */
 export function isAdvanceBlocked(ticket: KdsTicket): boolean {
   if (nextStateFor(ticket.state) === null) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -8,7 +8,7 @@ import KdsCommandBar from '@/components/KDS/KdsCommandBar.vue'
 import KdsEmptyState from '@/components/KDS/KdsEmptyState.vue'
 import KdsFilterChips from '@/components/KDS/KdsFilterChips.vue'
 import KdsTicketCard from '@/components/KDS/KdsTicketCard.vue'
-import { postKdsAdvance, postKdsToggleItem } from '@/components/KDS/kdsApi'
+import { postKdsAdvance, postKdsRecall, postKdsToggleItem } from '@/components/KDS/kdsApi'
 import { ACTIVE_STATES, canAdvanceTicket, filterTickets, sortTickets } from '@/components/KDS/kdsHelpers'
 import type { KdsDensity, KdsFilter, KdsTicket } from '@/components/KDS/kdsTypes'
 import { useKdsBoard } from '@/components/KDS/useKdsBoard'
@@ -35,6 +35,7 @@ const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
 const pendingAdvance = ref<Set<string>>(new Set())
+const pendingRecall = ref<Set<string>>(new Set())
 const pendingToggle = ref<Set<string>>(new Set())
 let timer: ReturnType<typeof setInterval> | null = null
 
@@ -110,6 +111,28 @@ async function advanceTicket(ticketId: string) {
   }
 }
 
+async function recallTicket(ticketId: string) {
+  const ticket = tickets.value.find((item) => item.id === ticketId)
+
+  if (!ticket || ticket.state !== 'served') {
+    return
+  }
+
+  if (pendingRecall.value.has(ticketId)) {
+    return
+  }
+
+  pendingRecall.value.add(ticketId)
+
+  try {
+    await postKdsRecall(ticketId)
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : 'Unable to recall order.')
+  } finally {
+    pendingRecall.value.delete(ticketId)
+  }
+}
+
 function toggleDensity() {
   density.value = density.value === 'comfortable' ? 'compact' : 'comfortable'
   try {
@@ -181,6 +204,7 @@ onBeforeUnmount(() => {
               :now="now"
               :density="density"
               @advance="advanceTicket"
+              @recall="recallTicket"
               @toggle-item="toggleItem"
             />
           </div>
@@ -862,6 +886,17 @@ body.kds-active {
 :deep(.kds-card-action:focus-visible) {
   outline: 3px solid rgb(246 181 109 / 0.45);
   outline-offset: 2px;
+}
+
+:deep(.kds-recall-action) {
+  border-color: rgb(246 181 109 / 0.35);
+  background: rgb(246 181 109 / 0.08);
+  color: var(--kds-accent);
+}
+
+:deep(.kds-recall-action:hover) {
+  background: rgb(246 181 109 / 0.16);
+  color: var(--kds-accent);
 }
 
 :deep(.kds-empty) {

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -74,7 +74,15 @@ async function toggleItem(ticketId: string, itemId: string) {
   pendingToggle.value.add(itemId)
 
   try {
-    await postKdsToggleItem(itemId)
+    const response = await postKdsToggleItem(itemId)
+    // Optimistic apply — same shape as the Echo `item.toggled` payload, so the live broadcast
+    // landing milliseconds later is idempotent (applies the same state, no flicker).
+    board.applyItemToggle({
+      item_id: response.item_id,
+      order_id: response.order_id,
+      done: response.done,
+      done_at: response.done_at,
+    })
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to update item.')
   } finally {
@@ -103,7 +111,10 @@ async function advanceTicket(ticketId: string) {
   pendingAdvance.value.add(ticketId)
 
   try {
-    await postKdsAdvance(ticketId)
+    const response = await postKdsAdvance(ticketId)
+    // Optimistic apply — full payload matches Echo `order.updated` shape, so the live broadcast
+    // landing milliseconds later applies the same state idempotently (no flicker, no double-render).
+    board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to advance order.')
   } finally {
@@ -125,7 +136,9 @@ async function recallTicket(ticketId: string) {
   pendingRecall.value.add(ticketId)
 
   try {
-    await postKdsRecall(ticketId)
+    const response = await postKdsRecall(ticketId)
+    // Optimistic apply — see advanceTicket() for rationale.
+    board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
   } catch (error) {
     toast.error(error instanceof Error ? error.message : 'Unable to recall order.')
   } finally {

--- a/resources/js/pages/Monitoring/Index.vue
+++ b/resources/js/pages/Monitoring/Index.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, computed } from 'vue';
 import { Head } from '@inertiajs/vue3';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { Button } from '@/components/ui/button';
+import { RefreshCw } from 'lucide-vue-next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { type BreadcrumbItem } from '@/types';
@@ -304,20 +305,11 @@ const breadcrumbs: BreadcrumbItem[] = [
                     <div class="flex flex-wrap items-center gap-3">
                         <Button variant="outline" size="sm" @click="toggleAutoRefresh"
                             :class="{ 'bg-woosoo-accent/10 text-woosoo-primary-dark': autoRefresh }">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2"
-                                :class="{ 'animate-spin': autoRefresh }" fill="none" viewBox="0 0 24 24"
-                                stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
+                            <RefreshCw class="h-4 w-4 mr-2" :class="{ 'animate-spin': autoRefresh }" />
                             {{ autoRefresh ? 'Auto-refresh ON' : 'Auto-refresh OFF' }}
                         </Button>
                         <Button size="sm" @click="refreshMetrics" :disabled="loading">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2"
-                                :class="{ 'animate-spin': loading }" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                            </svg>
+                            <RefreshCw class="h-4 w-4 mr-2" :class="{ 'animate-spin': loading }" />
                             Refresh Now
                         </Button>
                     </div>
@@ -325,7 +317,7 @@ const breadcrumbs: BreadcrumbItem[] = [
             </div>
 
             <!-- Alert Banner -->
-            <div v-if="hasAlerts" class="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+            <div v-if="hasAlerts" class="bg-destructive/10 border border-destructive/20 rounded-[20px] p-4">
                 <div class="flex items-center gap-2">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-destructive" viewBox="0 0 20 20"
                         fill="currentColor">
@@ -506,7 +498,7 @@ const breadcrumbs: BreadcrumbItem[] = [
                         </div>
                     </div>
 
-                    <div v-if="metrics.printLatency.stuck > 0" class="mb-4 p-3 rounded bg-destructive/10 border border-destructive/20 text-sm">
+                    <div v-if="metrics.printLatency.stuck > 0" class="mb-4 p-3 rounded-[20px] bg-destructive/10 border border-destructive/20 text-sm">
                         <strong class="text-destructive">{{ metrics.printLatency.stuck }} stuck event(s)</strong>
                         — broadcast went out but never acknowledged (&gt;2 min).
                     </div>

--- a/resources/js/pages/ServiceRequests/Index.vue
+++ b/resources/js/pages/ServiceRequests/Index.vue
@@ -173,7 +173,18 @@ const openRequestDetail = (request: any) => {
 <template>
     <Head :title="props.title" :description="props.description" />
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="space-y-6 px-1 sm:px-2">
+        <div class="space-y-5">
+            <!-- Hero -->
+            <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-5 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                    <div class="space-y-1.5">
+                        <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Operations</span>
+                        <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">Service Requests</h1>
+                        <p class="max-w-xl text-sm leading-6 text-muted-foreground">Guest-initiated assistance requests from tablet devices. Pending items require attention from floor staff.</p>
+                    </div>
+                </div>
+            </div>
+
             <DataTableToolbar
                 v-model:search="search"
                 v-model:status="statusFilter"

--- a/resources/js/pages/branches/IndexBranches.vue
+++ b/resources/js/pages/branches/IndexBranches.vue
@@ -4,6 +4,8 @@ import { ref } from 'vue'
 import { Head } from '@inertiajs/vue3'
 import AppLayout from '@/layouts/AppLayout.vue'
 import { type BreadcrumbItem } from '@/types'
+import { Button } from '@/components/ui/button'
+import { Plus } from 'lucide-vue-next'
 import DataTable from '@/components/Branches/DataTable.vue'
 import BranchForm from '@/components/Branches/BranchForm.vue'
 
@@ -48,12 +50,32 @@ const handleEdit = (branch: Branch) => {
   <AppLayout :breadcrumbs="breadcrumbs">
     <Head title="Branches" />
 
-    <div class="p-6 space-y-6">
-      <DataTable 
-        :data="branches" 
-        @add="handleAdd"
-        @edit="handleEdit"
-      />
+    <div class="space-y-5">
+      <!-- Hero -->
+      <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-5 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div class="space-y-1.5">
+            <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Configuration</span>
+            <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">Branches</h1>
+            <p class="max-w-xl text-sm leading-6 text-muted-foreground">Manage branch locations, their device allocations, and associated users.</p>
+          </div>
+          <Button @click="handleAdd">
+            <Plus class="mr-2 h-4 w-4" />
+            Add Branch
+          </Button>
+        </div>
+      </div>
+
+      <!-- DataTable -->
+      <div class="overflow-hidden rounded-[26px] border border-black/8 bg-card/92 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10">
+        <div class="p-4 sm:p-6">
+          <DataTable
+            :data="branches"
+            @add="handleAdd"
+            @edit="handleEdit"
+          />
+        </div>
+      </div>
 
       <BranchForm
         v-model:open="showForm"

--- a/resources/js/pages/reports/DiscountTax.vue
+++ b/resources/js/pages/reports/DiscountTax.vue
@@ -61,13 +61,24 @@ const currencyFormatter = (value: unknown) => {
 
     <Head :title="props.title" />
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="p-6 space-y-6">
-            <!-- Header -->
-            <div class="flex items-center justify-between">
-                <div>
-                    <h1 class="text-3xl font-bold">{{ props.title }}</h1>
-                    <p class="text-sm text-muted-foreground mt-1">Track discount usage and tax collection</p>
+        <div class="space-y-5">
+            <!-- Hero -->
+            <div class="relative overflow-hidden rounded-[26px] border border-black/8 bg-card/92 px-5 py-6 shadow-sm shadow-black/5 backdrop-blur-sm dark:border-white/10 md:px-6">
+                <div class="relative space-y-3">
+                    <span class="inline-flex rounded-full border border-border/70 bg-accent/12 px-3 py-1 text-[11px] font-semibold tracking-[0.22em] text-muted-foreground uppercase">Analytics · Discount & Tax</span>
+                    <div>
+                        <h1 class="font-header text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">{{ props.title }}</h1>
+                        <p class="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">Track discount usage and tax collection across all orders.</p>
+                    </div>
                 </div>
+            </div>
+
+            <!-- Date range -->
+            <div class="flex flex-wrap items-center gap-3">
+                <span class="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Date range:</span>
+                <span class="text-sm font-medium">{{ props.startDate ?? '—' }}</span>
+                <span class="text-muted-foreground">→</span>
+                <span class="text-sm font-medium">{{ props.endDate ?? 'today' }}</span>
             </div>
 
             <!-- Summary Cards -->
@@ -138,18 +149,18 @@ const currencyFormatter = (value: unknown) => {
                     <div class="overflow-x-auto">
                         <table class="w-full text-sm">
                             <thead>
-                                <tr class="border-b">
-                                    <th class="text-left py-3 px-4 font-semibold">Date</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Orders</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Sales</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Discount</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Discount %</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Tax</th>
-                                    <th class="text-right py-3 px-4 font-semibold">Tax %</th>
+                                <tr class="border-b border-black/8 dark:border-white/10">
+                                    <th class="px-4 py-3 text-left text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Date</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Orders</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Sales</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Discount</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Discount %</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Tax</th>
+                                    <th class="px-4 py-3 text-right text-xs font-semibold tracking-[0.1em] text-muted-foreground uppercase">Tax %</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr v-for="row in props.data" :key="row.date" class="border-b hover:bg-muted/50">
+                                <tr v-for="row in props.data" :key="row.date" class="border-b border-black/6 transition-colors hover:bg-black/[0.025] dark:border-white/8 dark:hover:bg-white/[0.03]">
                                     <td class="py-3 px-4 font-medium">{{ row.date }}</td>
                                     <td class="text-right py-3 px-4">{{ row.order_count }}</td>
                                     <td class="text-right py-3 px-4">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(row.total_sales) }}</td>
@@ -171,31 +182,31 @@ const currencyFormatter = (value: unknown) => {
                 </CardHeader>
                 <CardContent>
                     <div class="grid grid-cols-2 md:grid-cols-3 gap-4">
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Total Orders</div>
-                            <div class="text-2xl font-bold">{{ totalOrders }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Total Orders</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ totalOrders }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Total Sales</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalSales) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Total Sales</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalSales) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Discount Expense</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalDiscount) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Discount Expense</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalDiscount) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Tax Collected</div>
-                            <div class="text-2xl font-bold">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalTax) }}</div>
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Tax Collected</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(totalTax) }}</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Avg Discount %</div>
-                            <div class="text-2xl font-bold">{{ (props.data.length > 0
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Avg Discount %</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ (props.data.length > 0
                                 ? (props.data.reduce((sum, r) => sum + r.discount_percentage, 0) / props.data.length)
                                 : 0).toFixed(2) }}%</div>
                         </div>
-                        <div>
-                            <div class="text-sm font-medium text-muted-foreground">Avg Tax %</div>
-                            <div class="text-2xl font-bold">{{ (props.data.length > 0
+                        <div class="rounded-[18px] border border-black/8 bg-white/60 px-4 py-3 dark:border-white/10 dark:bg-white/[0.04]">
+                            <div class="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Avg Tax %</div>
+                            <div class="mt-1 text-2xl font-semibold tabular-nums">{{ (props.data.length > 0
                                 ? (props.data.reduce((sum, r) => sum + r.tax_percentage, 0) / props.data.length)
                                 : 0).toFixed(2) }}%</div>
                         </div>

--- a/resources/js/pages/reports/PrintAudit.vue
+++ b/resources/js/pages/reports/PrintAudit.vue
@@ -34,6 +34,15 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const totalPrints = props.data.length
 const totalPrintedValue = props.data.reduce((sum, row) => sum + row.total, 0)
+
+const getStatusColor = (status: string): 'success' | 'warning' | 'destructive' | 'secondary' | 'outline' => {
+    const s = status.toUpperCase()
+    if (s === 'COMPLETED') return 'success'
+    if (s === 'CONFIRMED' || s === 'SERVED' || s === 'READY') return 'secondary'
+    if (s === 'VOIDED' || s === 'CANCELLED') return 'destructive'
+    if (s === 'PENDING' || s === 'IN_PROGRESS') return 'warning'
+    return 'outline'
+}
 </script>
 
 <template>
@@ -122,11 +131,7 @@ const totalPrintedValue = props.data.reduce((sum, row) => sum + row.total, 0)
                                     <td class="py-3 px-4">{{ row.printed_by || '-' }}</td>
                                     <td class="py-3 px-4 text-xs">{{ new Date(row.printed_at).toLocaleString() }}</td>
                                     <td class="text-center py-3 px-4">
-                                        <Badge v-if="row.status === 'COMPLETED'" variant="default">{{ row.status }}
-                                        </Badge>
-                                        <Badge v-else-if="row.status === 'CONFIRMED'" variant="secondary">{{ row.status
-                                            }}</Badge>
-                                        <Badge v-else variant="outline">{{ row.status }}</Badge>
+                                        <Badge :variant="getStatusColor(row.status)">{{ row.status }}</Badge>
                                     </td>
                                     <td class="text-right py-3 px-4">{{ "₱" + new Intl.NumberFormat("en-PH",{minimumFractionDigits:2,maximumFractionDigits:2}).format(row.total) }}</td>
                                     <td class="text-center py-3 px-4 text-xs">{{ row.device_id }}</td>

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -190,3 +190,45 @@ test('non-admin cannot access recall endpoint', function () {
         ->postJson("/kds/orders/{$order->id}/recall")
         ->assertForbidden();
 });
+
+test('advance response carries the full broadcast payload', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::CONFIRMED]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJsonStructure([
+            'status',
+            'order' => ['id', 'status', 'kds_state', 'kds_type', 'items', 'recalled', 'created_at', 'updated_at'],
+        ]);
+});
+
+test('recall response carries the full broadcast payload', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::SERVED, 'recalled' => 0]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/recall")
+        ->assertOk()
+        ->assertJsonStructure([
+            'status',
+            'order' => ['id', 'status', 'kds_state', 'kds_type', 'items', 'recalled'],
+        ])
+        ->assertJsonPath('order.recalled', 1)
+        ->assertJsonPath('order.kds_state', 'preparing');
+});
+
+test('toggle response carries item_id and order_id for optimistic apply', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertOk()
+        ->assertJsonStructure(['item_id', 'order_id', 'done', 'done_at'])
+        ->assertJsonPath('item_id', $item->id)
+        ->assertJsonPath('order_id', $order->id)
+        ->assertJsonPath('done', true);
+});


### PR DESCRIPTION
## Summary
- Promote nexus `dev` (tip `529fa93`) to `staging`.
- Carries PR #197 (`ac32325` — KDS action endpoints return full board payload; optimistic UI apply with idempotent Echo reconcile) and PR #196 (`803f268` — admin handoff UI alignment, 15 pages + 2 components).
- Platform case `nex-case-029` already closed COMPLETE (chain verified through executioner).

## Test plan
- [ ] Confirm `MERGEABLE / CLEAN` (divergence is merge-commit topology only).
- [ ] After merge: rebuild staging assets on the WSL stack (`pld rebuild`).
- [ ] Smoke `/kds`: open two browser windows, click Mark Ready in window A — verify the card transitions immediately in A (no Echo wait) and window B reconciles via Echo.
- [ ] Smoke the redesigned admin pages: Monitoring, ServiceRequests, Branches, DiscountTax, PrintAudit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)