### PR TITLE
feat(kds): server-authoritative elapsed time via clock offset

### DIFF
--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -52,6 +52,7 @@ class KdsController extends Controller
         return Inertia::render('KDS/Display', [
             'title' => 'Kitchen Display',
             'initialTickets' => $orders->map(fn ($order) => $this->toTicket($order))->values(),
+            'serverNow' => (int) (microtime(true) * 1000),
         ]);
     }
 
@@ -140,6 +141,7 @@ class KdsController extends Controller
         return response()->json([
             'status' => $next->value,
             'order' => OrderBroadcastPayload::make($order),
+            'server_now' => (int) (microtime(true) * 1000),
         ]);
     }
 
@@ -177,6 +179,7 @@ class KdsController extends Controller
             'order_id' => $item->order_id,
             'done' => (bool) $item->done,
             'done_at' => $item->done_at?->toIso8601String(),
+            'server_now' => (int) (microtime(true) * 1000),
         ]);
     }
 
@@ -232,6 +235,7 @@ class KdsController extends Controller
         return response()->json([
             'status' => OrderStatus::IN_PROGRESS->value,
             'order' => OrderBroadcastPayload::make($order),
+            'server_now' => (int) (microtime(true) * 1000),
         ]);
     }
 

--- a/resources/js/components/KDS/KdsTicketCard.vue
+++ b/resources/js/components/KDS/KdsTicketCard.vue
@@ -10,6 +10,7 @@ import type { KdsDensity, KdsTicket } from './kdsTypes'
 const props = defineProps<{
   ticket: KdsTicket
   now: number
+  clockOffset: number
   density: KdsDensity
 }>()
 
@@ -22,8 +23,8 @@ const emit = defineEmits<{
 const doneCount = computed(() => props.ticket.items.filter((item) => item.done).length)
 const totalCount = computed(() => props.ticket.items.length)
 const terminal = computed(() => isTerminal(props.ticket.state))
-const elapsed = computed(() => elapsedFor(props.ticket, props.now))
-const urgency = computed(() => urgencyFor(props.ticket, props.now))
+const elapsed = computed(() => elapsedFor(props.ticket, props.now, props.clockOffset))
+const urgency = computed(() => urgencyFor(props.ticket, props.now, props.clockOffset))
 const nextState = computed(() => nextStateFor(props.ticket.state))
 const advanceBlocked = computed(() => isAdvanceBlocked(props.ticket))
 const recallable = computed(() => canRecallTicket(props.ticket))

--- a/resources/js/components/KDS/kdsApi.ts
+++ b/resources/js/components/KDS/kdsApi.ts
@@ -18,6 +18,7 @@ async function parseError(response: Response): Promise<string> {
 export type KdsActionResponse = {
   status: string
   order: Record<string, unknown>
+  server_now?: number
 }
 
 export type KdsToggleResponse = {
@@ -25,6 +26,7 @@ export type KdsToggleResponse = {
   order_id: string | number
   done: boolean
   done_at: string | null
+  server_now?: number
 }
 
 export async function postKdsAdvance(orderId: string): Promise<KdsActionResponse> {

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyAdvance, canAdvanceTicket, canRecallTicket, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
+import { applyAdvance, canAdvanceTicket, canRecallTicket, elapsedFor, filterTickets, isAdvanceBlocked, KDS_THRESHOLDS } from './kdsHelpers'
 import type { KdsTicket, KdsTicketState } from './kdsTypes'
 
 function preparingTicket(itemsDone: boolean[]): KdsTicket {
@@ -133,5 +133,39 @@ describe('filterTickets', () => {
     const tickets = ticketsWithStates('voided', 'new', 'served', 'preparing')
 
     expect(filterTickets(tickets, 'voided', now)).toEqual([tickets[0]])
+  })
+})
+
+describe('elapsedFor with clockOffset', () => {
+  it('adds positive offset to live ticket elapsed', () => {
+    const baseNow = 2_000_000_000_000
+    const ticket = makeTicket('new', baseNow - 60_000)
+
+    expect(elapsedFor(ticket, baseNow, 30_000)).toBe(90)
+  })
+
+  it('subtracts negative offset from live ticket elapsed, floored at 0', () => {
+    const baseNow = 2_000_000_000_000
+    const ticket = makeTicket('new', baseNow - 60_000)
+
+    expect(elapsedFor(ticket, baseNow, -30_000)).toBe(30)
+  })
+
+  it('clockOffset = 0 matches no-offset behavior', () => {
+    const baseNow = 2_000_000_000_000
+    const ticket = makeTicket('new', baseNow - 60_000)
+
+    expect(elapsedFor(ticket, baseNow, 0)).toBe(elapsedFor(ticket, baseNow))
+  })
+
+  it('terminal tickets ignore clockOffset', () => {
+    const ticket: KdsTicket = {
+      ...makeTicket('served'),
+      frozenElapsed: 45,
+    }
+    const baseNow = 2_000_000_000_000
+
+    expect(elapsedFor(ticket, baseNow, 99_999)).toBe(45)
+    expect(elapsedFor(ticket, baseNow, -99_999)).toBe(45)
   })
 })

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -29,12 +29,12 @@ export function isActive(state: KdsTicketState): boolean {
   return ACTIVE_STATES.includes(state)
 }
 
-export function elapsedFor(ticket: KdsTicket, now: number): number {
+export function elapsedFor(ticket: KdsTicket, now: number, clockOffset = 0): number {
   if (isTerminal(ticket.state)) {
     return ticket.frozenElapsed ?? ticket.elapsed
   }
 
-  return Math.max(0, Math.floor((now - ticket.issuedAt) / 1000))
+  return Math.max(0, Math.floor((now + clockOffset - ticket.issuedAt) / 1000))
 }
 
 export function formatElapsed(seconds: number): string {
@@ -44,12 +44,12 @@ export function formatElapsed(seconds: number): string {
   return `${mins}:${String(secs).padStart(2, '0')}`
 }
 
-export function urgencyFor(ticket: KdsTicket, now: number, thresholds: KdsThresholds = KDS_THRESHOLDS): KdsUrgency {
+export function urgencyFor(ticket: KdsTicket, now: number, clockOffset = 0, thresholds: KdsThresholds = KDS_THRESHOLDS): KdsUrgency {
   if (isTerminal(ticket.state)) {
     return 'ok'
   }
 
-  const elapsed = elapsedFor(ticket, now)
+  const elapsed = elapsedFor(ticket, now, clockOffset)
   const threshold = thresholds[ticket.type]
 
   if (elapsed >= threshold.over) {

--- a/resources/js/components/KDS/useKdsBoard.ts
+++ b/resources/js/components/KDS/useKdsBoard.ts
@@ -72,6 +72,11 @@ function payloadToTicket(payload: OrderPayload): KdsTicket {
 
 export function useKdsBoard(initialTickets: KdsTicket[]) {
   const tickets = ref<KdsTicket[]>(initialTickets.map((t) => ({ ...t, items: t.items.map((i) => ({ ...i })) })))
+  const clockOffset = ref(0)
+
+  function setClockOffset(serverNow: number): void {
+    clockOffset.value = serverNow - Date.now()
+  }
 
   function applyOrderUpdate(payload: OrderPayload): void {
     const id = String(payload.id)
@@ -109,5 +114,5 @@ export function useKdsBoard(initialTickets: KdsTicket[]) {
     })
   }
 
-  return { tickets, applyOrderUpdate, applyItemToggle }
+  return { tickets, applyOrderUpdate, applyItemToggle, clockOffset, setClockOffset }
 }

--- a/resources/js/pages/KDS/Display.vue
+++ b/resources/js/pages/KDS/Display.vue
@@ -17,6 +17,7 @@ import { useKdsEcho } from '@/components/KDS/useKdsEcho'
 const props = defineProps<{
   title: string
   initialTickets: KdsTicket[]
+  serverNow: number
 }>()
 
 function seedTickets(source: KdsTicket[]): KdsTicket[] {
@@ -31,6 +32,7 @@ const board = useKdsBoard(seedTickets(props.initialTickets))
 useKdsEcho(board)
 
 const tickets = board.tickets
+const { clockOffset, setClockOffset } = board
 const selectedFilter = ref<KdsFilter>('active')
 const density = ref<KdsDensity>('comfortable')
 const now = ref(Date.now())
@@ -39,8 +41,9 @@ const pendingRecall = ref<Set<string>>(new Set())
 const pendingToggle = ref<Set<string>>(new Set())
 let timer: ReturnType<typeof setInterval> | null = null
 
+const correctedNow = computed(() => now.value + clockOffset.value)
 const activeTickets = computed(() => tickets.value.filter((ticket) => ACTIVE_STATES.includes(ticket.state)))
-const visibleTickets = computed(() => sortTickets(filterTickets(tickets.value, selectedFilter.value, now.value), now.value))
+const visibleTickets = computed(() => sortTickets(filterTickets(tickets.value, selectedFilter.value, correctedNow.value), correctedNow.value))
 const clockLabel = computed(() => new Intl.DateTimeFormat('en-US', {
   hour: 'numeric',
   minute: '2-digit',
@@ -52,7 +55,7 @@ const dateLabel = computed(() => new Intl.DateTimeFormat('en-US', {
 }).format(now.value))
 const counts = computed<Record<KdsFilter, number>>(() => ({
   active: activeTickets.value.length,
-  overdue: filterTickets(tickets.value, 'overdue', now.value).length,
+  overdue: filterTickets(tickets.value, 'overdue', correctedNow.value).length,
   new: tickets.value.filter((ticket) => ticket.state === 'new').length,
   preparing: tickets.value.filter((ticket) => ticket.state === 'preparing' || ticket.state === 'ready').length,
   ready: 0,
@@ -75,6 +78,9 @@ async function toggleItem(ticketId: string, itemId: string) {
 
   try {
     const response = await postKdsToggleItem(itemId)
+    if (response.server_now != null) {
+      setClockOffset(response.server_now)
+    }
     // Optimistic apply — same shape as the Echo `item.toggled` payload, so the live broadcast
     // landing milliseconds later is idempotent (applies the same state, no flicker).
     board.applyItemToggle({
@@ -112,6 +118,9 @@ async function advanceTicket(ticketId: string) {
 
   try {
     const response = await postKdsAdvance(ticketId)
+    if (response.server_now != null) {
+      setClockOffset(response.server_now)
+    }
     // Optimistic apply — full payload matches Echo `order.updated` shape, so the live broadcast
     // landing milliseconds later applies the same state idempotently (no flicker, no double-render).
     board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
@@ -137,6 +146,9 @@ async function recallTicket(ticketId: string) {
 
   try {
     const response = await postKdsRecall(ticketId)
+    if (response.server_now != null) {
+      setClockOffset(response.server_now)
+    }
     // Optimistic apply — see advanceTicket() for rationale.
     board.applyOrderUpdate(response.order as Parameters<typeof board.applyOrderUpdate>[0])
   } catch (error) {
@@ -157,6 +169,7 @@ function toggleDensity() {
 
 onMounted(() => {
   document.body.classList.add('kds-active')
+  setClockOffset(props.serverNow)
 
   try {
     const storedDensity = window.localStorage.getItem('kds-density')
@@ -215,6 +228,7 @@ onBeforeUnmount(() => {
               :key="ticket.id"
               :ticket="ticket"
               :now="now"
+              :clock-offset="clockOffset"
               :density="density"
               @advance="advanceTicket"
               @recall="recallTicket"

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -4,6 +4,7 @@ use App\Enums\OrderStatus;
 use App\Models\DeviceOrder;
 use App\Models\DeviceOrderItems;
 use App\Models\User;
+use Illuminate\Testing\Fluent\AssertableJson;
 
 test('admins can advance a confirmed order to in_progress', function () {
     $admin = User::factory()->admin()->create();
@@ -231,4 +232,55 @@ test('toggle response carries item_id and order_id for optimistic apply', functi
         ->assertJsonPath('item_id', $item->id)
         ->assertJsonPath('order_id', $order->id)
         ->assertJsonPath('done', true);
+});
+
+// --- server_now clock offset ---
+
+test('advance response includes server_now as an integer', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::CONFIRMED]);
+
+    $before = (int) (microtime(true) * 1000);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJsonStructure(['server_now'])
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('server_now', fn ($value) => is_int($value) && $value >= $before)
+            ->etc()
+        );
+});
+
+test('recall response includes server_now as an integer', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::SERVED, 'recalled' => 0]);
+
+    $before = (int) (microtime(true) * 1000);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/recall")
+        ->assertOk()
+        ->assertJsonStructure(['server_now'])
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('server_now', fn ($value) => is_int($value) && $value >= $before)
+            ->etc()
+        );
+});
+
+test('toggle response includes server_now as an integer', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    $item = DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => false]);
+
+    $before = (int) (microtime(true) * 1000);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/items/{$item->id}/toggle")
+        ->assertOk()
+        ->assertJsonStructure(['server_now'])
+        ->assertJson(fn (AssertableJson $json) => $json
+            ->where('server_now', fn ($value) => is_int($value) && $value >= $before)
+            ->etc()
+        );
 });

--- a/tests/Feature/Admin/KdsDisplayTest.php
+++ b/tests/Feature/Admin/KdsDisplayTest.php
@@ -27,3 +27,18 @@ test('admins can open the KDS display with a tickets prop', function () {
             ->has('initialTickets')
         );
 });
+
+test('kds index response includes serverNow as an integer millisecond epoch', function () {
+    $admin = User::factory()->admin()->create();
+
+    $before = (int) (microtime(true) * 1000);
+
+    $this->actingAs($admin)
+        ->get('/kds')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('KDS/Display')
+            ->has('serverNow')
+            ->where('serverNow', fn ($value) => is_int($value) && $value >= $before)
+        );
+});


### PR DESCRIPTION
## Summary
- Backend includes `serverNow` (ms epoch) in the KDS `index()` Inertia props and `server_now` in `advance()`, `recall()`, and `toggleItem()` JSON responses
- Frontend computes `clockOffset = serverNow - Date.now()` on mount (from initial page load) and refreshes it after each action response, so any client/server clock drift is corrected continuously
- `elapsedFor` and `urgencyFor` in `kdsHelpers.ts` accept an optional `clockOffset = 0` parameter — all existing callers are unaffected
- `KdsTicketCard` receives `clockOffset` as a prop and passes it to the helpers; `Display.vue` uses `correctedNow` for `filterTickets`/`sortTickets` so overdue classification and sort order are also drift-corrected
- Freeze path (`frozenElapsed` = `updated_at - created_at`, server-computed) is untouched

## Test plan
- [ ] `php artisan test --compact tests/Feature/Admin/KdsControllerTest.php tests/Feature/Admin/KdsDisplayTest.php` — 26 tests pass
- [ ] `npm run test:unit` — 28 tests pass (4 new clockOffset cases in `kdsHelpers.test.ts`)
- [ ] `npm run typecheck` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)