### PR TITLE
fix(kds): close TOCTOU race in recall cap, gate canRecallTicket, eager-load device_order

### DIFF
--- a/app/Http/Controllers/Admin/KdsController.php
+++ b/app/Http/Controllers/Admin/KdsController.php
@@ -174,6 +174,7 @@ class KdsController extends Controller
 
         Log::info('[KDS] toggle item', ['item_id' => $item->id, 'done' => $item->done, 'admin_id' => auth()->id()]);
 
+        $item->loadMissing('device_order');
         app(OrderBroadcaster::class)->itemToggled($item);
 
         // Echo the broadcast shape so the client can dispatch the same applyItemToggle path
@@ -220,6 +221,13 @@ class KdsController extends Controller
             // Stale-state re-check: concurrent request already moved this order.
             if (! $fresh->status->canTransitionTo(OrderStatus::IN_PROGRESS)) {
                 $gateMessage = 'Order state changed concurrently; please retry.';
+
+                return;
+            }
+
+            // Re-check cap under lock: closes the TOCTOU window between the pre-check above and here.
+            if (($fresh->recalled ?? 0) >= self::MAX_RECALLS) {
+                $gateMessage = 'Maximum recalls reached for this order.';
 
                 return;
             }

--- a/resources/js/components/KDS/kdsHelpers.test.ts
+++ b/resources/js/components/KDS/kdsHelpers.test.ts
@@ -86,6 +86,18 @@ describe('Recall gating', () => {
   it.each<KdsTicketState>(['new', 'preparing', 'ready', 'voided'])('rejects recall from %s', (state) => {
     expect(canRecallTicket(makeTicket(state))).toBe(false)
   })
+
+  it('blocks recall when recalled count reaches MAX_RECALLS', () => {
+    const ticket = { ...makeTicket('served'), recalled: 5 }
+
+    expect(canRecallTicket(ticket)).toBe(false)
+  })
+
+  it('allows recall when recalled count is below MAX_RECALLS', () => {
+    const ticket = { ...makeTicket('served'), recalled: 4 }
+
+    expect(canRecallTicket(ticket)).toBe(true)
+  })
 })
 
 describe('filterTickets', () => {

--- a/resources/js/components/KDS/kdsHelpers.ts
+++ b/resources/js/components/KDS/kdsHelpers.ts
@@ -131,9 +131,11 @@ export function canAdvanceTicket(ticket: KdsTicket): boolean {
   return nextStateFor(ticket.state) !== null
 }
 
+const MAX_RECALLS = 5
+
 /** Recall is the served→in_progress edge only; voided orders need a new ticket (see order-state.contract.md). */
 export function canRecallTicket(ticket: KdsTicket): boolean {
-  return ticket.state === 'served'
+  return ticket.state === 'served' && (ticket.recalled ?? 0) < MAX_RECALLS
 }
 
 /** Primary action `:disabled` — Mark as Served gated until every checklist item is done. */

--- a/tests/Feature/Admin/KdsControllerTest.php
+++ b/tests/Feature/Admin/KdsControllerTest.php
@@ -296,3 +296,32 @@ test('toggle response includes server_now as an integer', function () {
             ->etc()
         );
 });
+
+// --- MAX_RECALLS atomicity ---
+
+test('recall is rejected when recalled count is already at the cap', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::SERVED, 'recalled' => 5]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/recall")
+        ->assertUnprocessable()
+        ->assertJsonFragment(['message' => 'Maximum recalls reached for this order.']);
+
+    expect($order->fresh()->recalled)->toBe(5);
+});
+
+// --- advance in_progress → served path ---
+
+test('advance from in_progress resolves directly to served — no intermediate ready status persists', function () {
+    $admin = User::factory()->admin()->create();
+    $order = DeviceOrder::factory()->create(['status' => OrderStatus::IN_PROGRESS]);
+    DeviceOrderItems::factory()->for($order, 'device_order')->create(['done' => true]);
+
+    $this->actingAs($admin)
+        ->postJson("/kds/orders/{$order->id}/advance")
+        ->assertOk()
+        ->assertJsonPath('status', 'served');
+
+    expect($order->fresh()->status)->toBe(OrderStatus::SERVED);
+});


### PR DESCRIPTION
## Summary

Post-review fixes for the KDS server-authoritative time work (follow-up to #199):

- **TOCTOU race in MAX_RECALLS cap** (`KdsController::recall`): the pre-check for `recalled >= 5` was outside the transaction, so two concurrent recall requests at `recalled=4` could both pass it, acquire `lockForUpdate` sequentially, and each increment — exceeding the cap. Re-check is now inside the transaction after `lockForUpdate`.
- **`canRecallTicket()` didn't mirror the server cap** (`kdsHelpers.ts`): the Recall button stayed enabled when `ticket.recalled >= 5`, showing a clickable button that would immediately 422. Now returns `false` when `recalled >= MAX_RECALLS`.
- **N+1 on item toggle** (`KdsController::toggleItem`): `ItemToggled::broadcastOn()` lazily loads `device_order` for the `device.{id}` channel. Route-model binding doesn't pre-load it, so every toggle fired an extra query inside the synchronous `ShouldBroadcastNow` path. Fixed with `$item->loadMissing('device_order')` before broadcast.

## Test plan

- [ ] `php artisan test --compact --filter="KdsController"` — 28 tests pass
- [ ] New PHP tests: recall cap at boundary (recalled=5 → 422, count unchanged); advance in_progress→served resolves directly to `served`
- [ ] New TS tests: `canRecallTicket` returns false at recalled=5, true at recalled=4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * KDS order recall functionality (served orders can be recalled to in-progress with per-order limits)
  * Kitchen Dispatch kanban board view for real-time order management and dispatch
  * Admin navigation badges displaying pending order counts and offline device status
  * Enhanced POS table view with dining duration tracking and new order creation

* **Bug Fixes**
  * Improved POS connection password fallback handling
  * Fixed device offline detection thresholds

* **Improvements**
  * Dark mode theme support with persistent user preferences
  * Redesigned admin shell with improved sidebar, topbar, and breadcrumb navigation
  * Updated design tokens and visual styling across dashboard, orders, and devices pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->