### PR TITLE
feat(frontend): global runtime error handler in app.ts

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -25,6 +25,14 @@ window.config = {
     baseUrl: document.querySelector('meta[name="asset-base-url"]')?.getAttribute('content') || '/',
 };
 
+window.addEventListener('error', (event) => {
+    console.error('[GLOBAL ERROR]', event.error ?? event.message, event);
+});
+
+window.addEventListener('unhandledrejection', (event) => {
+    console.error('[UNHANDLED REJECTION]', event.reason);
+});
+
 try {
     window.Echo = new Echo({
         broadcaster: import.meta.env.VITE_BROADCAST_DRIVER ?? 'reverb',


### PR DESCRIPTION
## Summary

- Add `window.addEventListener('error', ...)` and `window.addEventListener('unhandledrejection', ...)` to `resources/js/app.ts` immediately after the `window.config` block.
- Both handlers log with a `[GLOBAL ERROR]` / `[UNHANDLED REJECTION]` prefix to the browser console, making them readable via Boost `browser-logs` during the Verifier phase.
- No new dependencies. No toast integration (intentionally minimal).

## Test plan

- [ ] `npm run build` exits 0 (verified locally)
- [ ] In browser: trigger a JS error (e.g. `window.dispatchEvent(new ErrorEvent('error', {message: 'test'}))`) and confirm `[GLOBAL ERROR] test` appears in console
- [ ] Confirm no TypeScript errors — `ErrorEvent` and `PromiseRejectionEvent` are standard browser globals, no extra types needed
- [ ] Confirm no changes to other files

Generated with [Claude Code](https://claude.com/claude-code)