### PR TITLE
fix(tablet-categories): add distinct validation to menu_ids

### DIFF
--- a/app/Http/Controllers/Admin/TabletCategoryController.php
+++ b/app/Http/Controllers/Admin/TabletCategoryController.php
@@ -128,7 +128,7 @@ class TabletCategoryController extends Controller
     {
         $validated = $request->validate([
             'menu_ids' => ['required', 'array'],
-            'menu_ids.*' => ['integer', 'min:1'],
+            'menu_ids.*' => ['integer', 'min:1', 'distinct'],
         ]);
 
         DB::transaction(function () use ($tabletCategory, $validated): void {
@@ -153,7 +153,7 @@ class TabletCategoryController extends Controller
     {
         $validated = $request->validate([
             'menu_ids' => ['required', 'array', 'min:1'],
-            'menu_ids.*' => ['integer', 'min:1'],
+            'menu_ids.*' => ['integer', 'min:1', 'distinct'],
         ]);
 
         $existingIds = $tabletCategory->menuPivots()->pluck('krypton_menu_id')->all();
@@ -202,7 +202,7 @@ class TabletCategoryController extends Controller
     {
         $validated = $request->validate([
             'menu_ids' => ['required', 'array'],
-            'menu_ids.*' => ['integer', 'min:1'],
+            'menu_ids.*' => ['integer', 'min:1', 'distinct'],
         ]);
 
         foreach ($validated['menu_ids'] as $index => $menuId) {


### PR DESCRIPTION
## Summary

- Adds `'distinct'` rule to `menu_ids.*` validation in `syncMenus()`, `attachMenus()`, and `updateMenuOrder()` in `TabletCategoryController`
- Prevents duplicate krypton_menu_id values from creating duplicate pivot rows or sort-order conflicts

## Context

This is the one unique fix extracted from the stale `kds-update-wsl` branch (PR #222, now closed). All other changes in that PR had already landed in `dev` via PRs #216, #218, and earlier KDS PRs.

## Test plan

- [ ] `php artisan test --compact --filter=TabletCategory` — 7 passing ✓
- [ ] Confirm a POST to `attach-menus` with duplicate IDs returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)